### PR TITLE
Add subtitle offset control

### DIFF
--- a/api.go
+++ b/api.go
@@ -50,11 +50,12 @@ const (
 )
 
 type API struct {
-	config        Config
-	app           *Application
-	http          *fiber.App
-	validateUser  func(context.Context) (*User, error)
-	previewRunner func(context.Context, string, string, string, string, int, Codec, io.Writer, AudioMode) error
+	config                          Config
+	app                             *Application
+	http                            *fiber.App
+	validateUser                    func(context.Context) (*User, error)
+	previewRunner                   func(context.Context, string, string, string, string, int, Codec, io.Writer, AudioMode) error
+	previewRunnerWithSubtitleOffset func(context.Context, string, string, string, string, int, Codec, io.Writer, AudioMode, int64) error
 }
 
 func NewAPI(config Config, app *Application) (*API, error) {
@@ -673,6 +674,10 @@ func (a *API) previewStream(ctx fiber.Ctx) error {
 	if subtitleIndex < -1 {
 		return errors.New("subtitle not available")
 	}
+	subtitleOffsetMs, err := parseSubtitleOffsetMs(ctx.Query("subtitleOffsetMs", "0"))
+	if err != nil {
+		return errors.New("subtitleOffsetMs is invalid")
+	}
 
 	// Validate the caller-visible source before asking the configured Plex
 	// administrator token for metadata. This prevents a valid session from
@@ -747,7 +752,7 @@ func (a *API) previewStream(ctx fiber.Ctx) error {
 		} else {
 			cacheMediaID := strconv.FormatInt(visibleMediaID, 10)
 			if entries, ok := a.app.GetCachedSubtitleEntries(ratingKeyStr, cacheMediaID, subtitleIndex); ok {
-				subtitleFile, err = WriteClipSRT(entries, fromMs, toMs)
+				subtitleFile, err = WriteClipSRT(entries, fromMs, toMs, subtitleOffsetMs)
 				if err != nil {
 					return fmt.Errorf("could not write clip subtitle: %w", err)
 				}
@@ -755,7 +760,7 @@ func (a *API) previewStream(ctx fiber.Ctx) error {
 				if !isSupportedTextSubtitle(source) {
 					return errors.New("subtitle codec is not supported")
 				}
-				subtitleFile, err = a.app.prepareExternalSubtitle(operationCtx, source, fromMs, toMs)
+				subtitleFile, err = a.app.prepareExternalSubtitle(operationCtx, source, fromMs, toMs, subtitleOffsetMs)
 				if err != nil {
 					return newPreviewUpstreamFailure("preview subtitle source unavailable", err)
 				}
@@ -769,7 +774,7 @@ func (a *API) previewStream(ctx fiber.Ctx) error {
 				subtitleCtx, cancelSubtitle := context.WithTimeout(operationCtx, renderPreviewTimeout)
 				subtitleFile, err = func() (string, error) {
 					defer release()
-					return ExtractSubtitleContext(subtitleCtx, fileURL, from, to, source.EmbeddedIndex)
+					return ExtractSubtitleContext(subtitleCtx, fileURL, from, to, source.EmbeddedIndex, subtitleOffsetMs)
 				}()
 				cancelSubtitle()
 				if err != nil {
@@ -805,9 +810,15 @@ func (a *API) previewStream(ctx fiber.Ctx) error {
 		}
 	}()
 	previewRunner := a.previewRunner
+	previewRunnerWithOffset := a.previewRunnerWithSubtitleOffset
+	if previewRunner == nil && previewRunnerWithOffset == nil {
+		previewRunnerWithOffset = func(ctx context.Context, fileURL, from, to, subtitleFile string, subtitleIndex int, codec Codec, writer io.Writer, audioMode AudioMode, offsetMs int64) error {
+			return DoFfmpegPreviewContextWithSubtitleOffset(ctx, fileURL, from, to, subtitleFile, subtitleIndex, codec, writer, audioMode, offsetMs)
+		}
+	}
 	if previewRunner == nil {
 		previewRunner = func(ctx context.Context, fileURL, from, to, subtitleFile string, subtitleIndex int, codec Codec, writer io.Writer, audioMode AudioMode) error {
-			return DoFfmpegPreviewContext(ctx, fileURL, from, to, subtitleFile, subtitleIndex, codec, writer, audioMode)
+			return previewRunnerWithOffset(ctx, fileURL, from, to, subtitleFile, subtitleIndex, codec, writer, audioMode, subtitleOffsetMs)
 		}
 	}
 	ctx.Response().SetBodyStreamWriter(func(w *bufio.Writer) {

--- a/api_render_jobs_test.go
+++ b/api_render_jobs_test.go
@@ -508,7 +508,7 @@ func TestPreviewColdCacheUsesExternalSubtitleStream(t *testing.T) {
 		},
 	}
 	httpApp := testAuthenticatedParamRoute(http.MethodGet, "/preview/:ratingKey/:from/:to", api.preview)
-	response, err := httpApp.Test(httptest.NewRequest(http.MethodGet, "/preview/movie-1/00:00:00/00:00:02?mediaId=200&subtitle=0", nil))
+	response, err := httpApp.Test(httptest.NewRequest(http.MethodGet, "/preview/movie-1/00:00:00/00:00:02?mediaId=200&subtitle=0&subtitleOffsetMs=-500", nil))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -517,7 +517,7 @@ func TestPreviewColdCacheUsesExternalSubtitleStream(t *testing.T) {
 		body, _ := io.ReadAll(response.Body)
 		t.Fatalf("status = %d body=%s", response.StatusCode, body)
 	}
-	if subtitleContent == "" || !strings.Contains(subtitleContent, "00:00:01,000 --> 00:00:02,000") {
+	if subtitleContent == "" || !strings.Contains(subtitleContent, "00:00:00,500 --> 00:00:02,000") {
 		t.Fatalf("cold-cache preview did not receive clip-relative external subtitle: %q", subtitleContent)
 	}
 }
@@ -617,6 +617,19 @@ func TestPreviewRejectsOutOfBoundsRangeBeforeUpstreamCalls(t *testing.T) {
 	defer response.Body.Close()
 	if response.StatusCode != http.StatusUnprocessableEntity {
 		t.Fatalf("preview range status = %d, want 422", response.StatusCode)
+	}
+}
+
+func TestPreviewRejectsInvalidSubtitleOffsetBeforeUpstreamCalls(t *testing.T) {
+	api := &API{app: &Application{}}
+	app := testAuthenticatedParamRoute(http.MethodGet, "/preview/:ratingKey/:from/:to", api.preview)
+	response, err := app.Test(httptest.NewRequest(http.MethodGet, "/preview/movie/00:00:00/00:00:01?subtitleOffsetMs=not-a-number", nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusUnprocessableEntity {
+		t.Fatalf("preview offset status = %d, want 422", response.StatusCode)
 	}
 }
 

--- a/application.go
+++ b/application.go
@@ -740,7 +740,7 @@ func (a *Application) downloadSubtitle(ctx context.Context, streamKey, codec str
 	}
 }
 
-func (a *Application) prepareExternalSubtitle(ctx context.Context, source subtitleSource, fromMs, toMs int64) (string, error) {
+func (a *Application) prepareExternalSubtitle(ctx context.Context, source subtitleSource, fromMs, toMs int64, subtitleOffsets ...int64) (string, error) {
 	if !source.External || source.StreamKey == "" {
 		return "", fmt.Errorf("external subtitle stream key is missing")
 	}
@@ -751,7 +751,7 @@ func (a *Application) prepareExternalSubtitle(ctx context.Context, source subtit
 	if err != nil {
 		return "", fmt.Errorf("could not download external subtitle: %w", err)
 	}
-	subtitleFile, err := WriteClipSRT(entries, fromMs, toMs)
+	subtitleFile, err := WriteClipSRT(entries, fromMs, toMs, subtitleOffsets...)
 	if err != nil {
 		return "", fmt.Errorf("could not write external subtitle: %w", err)
 	}

--- a/application_test.go
+++ b/application_test.go
@@ -386,6 +386,70 @@ func TestWriteClipSRT(t *testing.T) {
 	}
 }
 
+func TestWriteClipSRTSubtitleOffsetShiftsWithoutMutatingEntries(t *testing.T) {
+	entries := []SubtitleEntry{{Start: 1000, End: 3000, Text: "shift me"}}
+
+	positive, err := WriteClipSRT(entries, 0, 2500, 500)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(positive)
+	positiveEntries, err := ParseSRT(positive)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(positiveEntries) != 1 || positiveEntries[0].Start != 1500 || positiveEntries[0].End != 2500 {
+		t.Fatalf("positive offset entries = %+v", positiveEntries)
+	}
+
+	negative, err := WriteClipSRT(entries, 0, 2500, -500)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(negative)
+	negativeEntries, err := ParseSRT(negative)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(negativeEntries) != 1 || negativeEntries[0].Start != 500 || negativeEntries[0].End != 2500 {
+		t.Fatalf("negative offset entries = %+v", negativeEntries)
+	}
+	if entries[0].Start != 1000 || entries[0].End != 3000 {
+		t.Fatalf("source entries were mutated: %+v", entries)
+	}
+}
+
+func TestSubtitleOffsetParsingAndRange(t *testing.T) {
+	for _, test := range []struct {
+		value string
+		want  int64
+		valid bool
+	}{
+		{value: "250", want: 250, valid: true},
+		{value: "-250", want: -250, valid: true},
+		{value: "", want: 0, valid: true},
+		{value: "not-a-number", valid: false},
+		{value: "900001", valid: false},
+	} {
+		got, err := parseSubtitleOffsetMs(test.value)
+		if test.valid && (err != nil || got != test.want) {
+			t.Errorf("parseSubtitleOffsetMs(%q) = %d, %v; want %d", test.value, got, err, test.want)
+		}
+		if !test.valid && err == nil {
+			t.Errorf("parseSubtitleOffsetMs(%q) unexpectedly succeeded", test.value)
+		}
+	}
+}
+
+func TestSubtitleOverlayFilterAppliesSignedOffset(t *testing.T) {
+	if got := subtitleOverlayFilter(2, 500, ",scale[out]"); !strings.Contains(got, "setpts=PTS+500/1000/TB") {
+		t.Fatalf("positive overlay offset filter = %q", got)
+	}
+	if got := subtitleOverlayFilter(2, -500, ",scale[out]"); !strings.Contains(got, "setpts=PTS-500/1000/TB") {
+		t.Fatalf("negative overlay offset filter = %q", got)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Subtitle cache tests
 // ---------------------------------------------------------------------------

--- a/ffmpeg.go
+++ b/ffmpeg.go
@@ -36,6 +36,41 @@ const (
 
 const dialogueAudioFilter = "pan=stereo|FL<FL+0.85*FC+0.50*BL+0.50*SL|FR<FR+0.85*FC+0.50*BR+0.50*SR,alimiter=limit=0.95:attack=5:release=50:latency=1:level=0"
 
+// Subtitle offsets are deliberately bounded to keep timestamp arithmetic
+// predictable and to match the maximum supported clip duration.
+const maxSubtitleOffsetMs int64 = 15 * 60 * 1000
+
+func validateSubtitleOffsetMs(offset int64) error {
+	if offset < -maxSubtitleOffsetMs || offset > maxSubtitleOffsetMs {
+		return fmt.Errorf("subtitleOffsetMs must be between -%d and %d", maxSubtitleOffsetMs, maxSubtitleOffsetMs)
+	}
+	return nil
+}
+
+func parseSubtitleOffsetMs(value string) (int64, error) {
+	if value == "" {
+		return 0, nil
+	}
+	offset, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid subtitleOffsetMs: %w", err)
+	}
+	if err := validateSubtitleOffsetMs(offset); err != nil {
+		return 0, err
+	}
+	return offset, nil
+}
+
+func saturatingAddInt64(a, b int64) int64 {
+	if b > 0 && a > math.MaxInt64-b {
+		return math.MaxInt64
+	}
+	if b < 0 && a < math.MinInt64-b {
+		return math.MinInt64
+	}
+	return a + b
+}
+
 func parseAudioMode(value string) (AudioMode, error) {
 	if value == "" {
 		return AudioModeStandard, nil
@@ -101,19 +136,27 @@ func init() {
 }
 
 type FfmpegParams struct {
-	URL           string
-	From          string
-	To            string
-	Filename      string
-	Height        int
-	QP            int
-	Codec         Codec
-	AudioMode     AudioMode
-	SubtitleFile  string
-	SubtitleIndex int // >= 0 for PGS overlay via overlay filter
-	OutputPath    string
-	Context       context.Context
-	Metadata      FfmpegParamsMetadata
+	URL              string
+	From             string
+	To               string
+	Filename         string
+	Height           int
+	QP               int
+	Codec            Codec
+	AudioMode        AudioMode
+	SubtitleFile     string
+	SubtitleIndex    int // >= 0 for PGS overlay via overlay filter
+	SubtitleOffsetMs int64
+	OutputPath       string
+	Context          context.Context
+	Metadata         FfmpegParamsMetadata
+}
+
+func subtitleOverlayFilter(index int, offsetMs int64, suffix string) string {
+	if offsetMs == 0 {
+		return fmt.Sprintf("[0:v][0:s:%d]overlay%s", index, suffix)
+	}
+	return fmt.Sprintf("[0:s:%d]setpts=PTS%+d/1000/TB[sub];[0:v][sub]overlay%s", index, offsetMs, suffix)
 }
 
 type FfmpegParamsMetadata struct {
@@ -144,6 +187,9 @@ func configureMP4Output(outputArgs ffmpeg.KwArgs) {
 }
 
 func DoFfmpeg(params FfmpegParams) (string, error) {
+	if err := validateSubtitleOffsetMs(params.SubtitleOffsetMs); err != nil {
+		return params.OutputPath, err
+	}
 	outputMetadata := map[string]string{
 		"title":   params.Metadata.Title,
 		"comment": params.From,
@@ -215,7 +261,7 @@ func DoFfmpeg(params FfmpegParams) (string, error) {
 	switch params.Codec {
 	case CodecH264VAAPI:
 		if params.SubtitleIndex >= 0 {
-			outputArgs["filter_complex"] = fmt.Sprintf("[0:v][0:s:%d]overlay,format=nv12,hwupload,scale_vaapi=format=nv12,scale_vaapi=-2:%d[out]", params.SubtitleIndex, params.Height)
+			outputArgs["filter_complex"] = subtitleOverlayFilter(params.SubtitleIndex, params.SubtitleOffsetMs, fmt.Sprintf(",format=nv12,hwupload,scale_vaapi=format=nv12,scale_vaapi=-2:%d[out]", params.Height))
 			outputArgs["map"] = []string{"[out]", "0:a:0?"}
 			delete(inputArgs, "hwaccel_output_format")
 		} else if params.SubtitleFile != "" {
@@ -229,9 +275,9 @@ func DoFfmpeg(params FfmpegParams) (string, error) {
 	case CodecH264NVENC:
 		if params.SubtitleIndex >= 0 {
 			if params.Height > 0 {
-				outputArgs["filter_complex"] = fmt.Sprintf("[0:v][0:s:%d]overlay,hwupload_cuda,scale_cuda=-2:%d[out]", params.SubtitleIndex, params.Height)
+				outputArgs["filter_complex"] = subtitleOverlayFilter(params.SubtitleIndex, params.SubtitleOffsetMs, fmt.Sprintf(",hwupload_cuda,scale_cuda=-2:%d[out]", params.Height))
 			} else {
-				outputArgs["filter_complex"] = fmt.Sprintf("[0:v][0:s:%d]overlay,hwupload_cuda[out]", params.SubtitleIndex)
+				outputArgs["filter_complex"] = subtitleOverlayFilter(params.SubtitleIndex, params.SubtitleOffsetMs, ",hwupload_cuda[out]")
 			}
 			outputArgs["map"] = []string{"[out]", "0:a:0?"}
 		} else if params.SubtitleFile != "" {
@@ -251,7 +297,7 @@ func DoFfmpeg(params FfmpegParams) (string, error) {
 		fallthrough
 	default:
 		if params.SubtitleIndex >= 0 {
-			outputArgs["filter_complex"] = fmt.Sprintf("[0:v][0:s:%d]overlay,scale=-2:%d[out]", params.SubtitleIndex, params.Height)
+			outputArgs["filter_complex"] = subtitleOverlayFilter(params.SubtitleIndex, params.SubtitleOffsetMs, fmt.Sprintf(",scale=-2:%d[out]", params.Height))
 			outputArgs["map"] = []string{"[out]", "0:a:0?"}
 		} else {
 			vf := "scale=-2:" + strconv.Itoa(params.Height)
@@ -356,6 +402,17 @@ func isExpectedPreviewTermination(err error, writer io.Writer) bool {
 }
 
 func DoFfmpegPreviewContext(ctx context.Context, fileURL, from, to string, subtitleFile string, subtitleIndex int, codec Codec, writer io.Writer, audioModes ...AudioMode) error {
+	return doFfmpegPreviewContext(ctx, fileURL, from, to, subtitleFile, subtitleIndex, codec, writer, 0, audioModes...)
+}
+
+func DoFfmpegPreviewContextWithSubtitleOffset(ctx context.Context, fileURL, from, to string, subtitleFile string, subtitleIndex int, codec Codec, writer io.Writer, audioMode AudioMode, subtitleOffsetMs int64) error {
+	return doFfmpegPreviewContext(ctx, fileURL, from, to, subtitleFile, subtitleIndex, codec, writer, subtitleOffsetMs, audioMode)
+}
+
+func doFfmpegPreviewContext(ctx context.Context, fileURL, from, to string, subtitleFile string, subtitleIndex int, codec Codec, writer io.Writer, subtitleOffsetMs int64, audioModes ...AudioMode) error {
+	if err := validateSubtitleOffsetMs(subtitleOffsetMs); err != nil {
+		return err
+	}
 	inputArgs := ffmpeg.KwArgs{
 		"ss":          from,
 		"to":          to,
@@ -400,7 +457,7 @@ func DoFfmpegPreviewContext(ctx context.Context, fileURL, from, to string, subti
 	switch codec {
 	case CodecH264VAAPI:
 		if subtitleIndex >= 0 {
-			outputArgs["filter_complex"] = fmt.Sprintf("[0:v][0:s:%d]overlay,format=nv12,hwupload,scale_vaapi=format=nv12,scale_vaapi=-2:%d[out]", subtitleIndex, height)
+			outputArgs["filter_complex"] = subtitleOverlayFilter(subtitleIndex, subtitleOffsetMs, fmt.Sprintf(",format=nv12,hwupload,scale_vaapi=format=nv12,scale_vaapi=-2:%d[out]", height))
 			outputArgs["map"] = []string{"[out]", "0:a:0?"}
 			delete(inputArgs, "hwaccel_output_format")
 		} else if subtitleFile != "" {
@@ -413,7 +470,7 @@ func DoFfmpegPreviewContext(ctx context.Context, fileURL, from, to string, subti
 		outputArgs["compression_level"] = "0"
 	case CodecH264NVENC:
 		if subtitleIndex >= 0 {
-			outputArgs["filter_complex"] = fmt.Sprintf("[0:v][0:s:%d]overlay,hwupload_cuda,scale_cuda=-2:%d[out]", subtitleIndex, height)
+			outputArgs["filter_complex"] = subtitleOverlayFilter(subtitleIndex, subtitleOffsetMs, fmt.Sprintf(",hwupload_cuda,scale_cuda=-2:%d[out]", height))
 			outputArgs["map"] = []string{"[out]", "0:a:0?"}
 		} else if subtitleFile != "" {
 			configureNVENCTextSubtitle(inputArgs, outputArgs, subtitleFile, height)
@@ -425,7 +482,7 @@ func DoFfmpegPreviewContext(ctx context.Context, fileURL, from, to string, subti
 		fallthrough
 	default:
 		if subtitleIndex >= 0 {
-			outputArgs["filter_complex"] = fmt.Sprintf("[0:v][0:s:%d]overlay,scale=-2:%d[out]", subtitleIndex, height)
+			outputArgs["filter_complex"] = subtitleOverlayFilter(subtitleIndex, subtitleOffsetMs, fmt.Sprintf(",scale=-2:%d[out]", height))
 			outputArgs["map"] = []string{"[out]", "0:a:0?"}
 		} else {
 			vf := "scale=-2:" + strconv.Itoa(height)
@@ -601,11 +658,72 @@ func parseSRTTimestamp(s string) (int64, error) {
 // subtitle streams) for the given time range and writes it to a temp SRT file.
 // The timestamps in the output file are relative to from, so they align with
 // the clip produced by DoFfmpeg for the same range.
-func ExtractSubtitle(url, from, to string, subtitleIndex int) (string, error) {
-	return ExtractSubtitleContext(context.Background(), url, from, to, subtitleIndex)
+func ExtractSubtitle(url, from, to string, subtitleIndex int, subtitleOffsets ...int64) (string, error) {
+	return ExtractSubtitleContext(context.Background(), url, from, to, subtitleIndex, subtitleOffsets...)
 }
 
-func ExtractSubtitleContext(ctx context.Context, url, from, to string, subtitleIndex int) (string, error) {
+func ExtractSubtitleContext(ctx context.Context, url, from, to string, subtitleIndex int, subtitleOffsets ...int64) (string, error) {
+	offset, err := subtitleOffsetArgument(subtitleOffsets)
+	if err != nil {
+		return "", err
+	}
+	if offset == 0 {
+		return extractSubtitleContextRaw(ctx, url, from, to, subtitleIndex)
+	}
+
+	fromMs, err := ParseTimestampToMs(from)
+	if err != nil {
+		return "", fmt.Errorf("invalid subtitle extraction start: %w", err)
+	}
+	toMs, err := ParseTimestampToMs(to)
+	if err != nil || toMs <= fromMs {
+		return "", fmt.Errorf("invalid subtitle extraction range")
+	}
+	// A shifted subtitle in the requested clip comes from this source range.
+	// Avoid passing negative seek times to FFmpeg; entries before source zero
+	// cannot exist and are consequently absent from the result.
+	extractFrom := saturatingAddInt64(fromMs, -offset)
+	extractTo := saturatingAddInt64(toMs, -offset)
+	if extractFrom < 0 {
+		extractFrom = 0
+	}
+	if extractTo <= extractFrom {
+		return WriteClipSRT(nil, fromMs, toMs, offset)
+	}
+
+	rawFile, err := extractSubtitleContextRaw(ctx, url, formatRenderTimestamp(extractFrom), formatRenderTimestamp(extractTo), subtitleIndex)
+	if err != nil {
+		return "", err
+	}
+	defer os.Remove(rawFile)
+	entries, err := ParseSRT(rawFile)
+	if err != nil {
+		return "", fmt.Errorf("could not parse extracted subtitle: %w", err)
+	}
+	// Raw extraction timestamps are relative to extractFrom. Convert them back
+	// to source time, then apply the same clipping path used by external and
+	// cached subtitles. This keeps all subtitle types semantically identical.
+	for i := range entries {
+		entries[i].Start = saturatingAddInt64(entries[i].Start, extractFrom)
+		entries[i].End = saturatingAddInt64(entries[i].End, extractFrom)
+	}
+	return WriteClipSRT(entries, fromMs, toMs, offset)
+}
+
+func subtitleOffsetArgument(offsets []int64) (int64, error) {
+	if len(offsets) > 1 {
+		return 0, errors.New("multiple subtitle offsets specified")
+	}
+	if len(offsets) == 0 {
+		return 0, nil
+	}
+	if err := validateSubtitleOffsetMs(offsets[0]); err != nil {
+		return 0, err
+	}
+	return offsets[0], nil
+}
+
+func extractSubtitleContextRaw(ctx context.Context, url, from, to string, subtitleIndex int) (string, error) {
 	tmpFile := fmt.Sprintf("/tmp/cutscene_sub_%d.srt", time.Now().UnixNano())
 
 	inputArgs := ffmpeg.KwArgs{
@@ -711,7 +829,14 @@ func formatSRTTimestamp(ms int64) string {
 	return fmt.Sprintf("%02d:%02d:%02d,%03d", h, m, s, ms)
 }
 
-func WriteClipSRT(entries []SubtitleEntry, fromMs, toMs int64) (string, error) {
+func WriteClipSRT(entries []SubtitleEntry, fromMs, toMs int64, subtitleOffsets ...int64) (string, error) {
+	offset, err := subtitleOffsetArgument(subtitleOffsets)
+	if err != nil {
+		return "", err
+	}
+	if fromMs < 0 || toMs <= fromMs {
+		return "", errors.New("invalid subtitle clip range")
+	}
 	tmpFile, err := os.CreateTemp("", "cutscene_clip_*.srt")
 	if err != nil {
 		return "", err
@@ -721,15 +846,19 @@ func WriteClipSRT(entries []SubtitleEntry, fromMs, toMs int64) (string, error) {
 
 	seq := 1
 	for _, entry := range entries {
-		if entry.End <= fromMs || entry.Start >= toMs {
+		// Work on local values only. Cached entries are source data and must not
+		// be changed when one preview/render requests an offset.
+		startMs := saturatingAddInt64(entry.Start, offset)
+		endMs := saturatingAddInt64(entry.End, offset)
+		if endMs <= fromMs || startMs >= toMs {
 			continue
 		}
 
-		start := entry.Start - fromMs
+		start := startMs - fromMs
 		if start < 0 {
 			start = 0
 		}
-		end := entry.End - fromMs
+		end := endMs - fromMs
 		if end > toMs-fromMs {
 			end = toMs - fromMs
 		}

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -285,20 +285,6 @@ function App() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [audioMode])
 
-  // ---------------------------------------------------------------- subtitle offset auto-preview
-  // Changing the subtitle offset is a discrete, intentional action — the
-  // preview refreshes so the user sees the shifted subtitles immediately,
-  // just like changing the audio mode or subtitle track.
-  useEffect(() => {
-    if (!selectedSession) return
-    if (startPosition == null || endPosition == null) return
-    if (!playerReadyRef.current) return
-    setPlayerPosition(startPosition, endPosition)
-    setPreviewStale(false)
-    setControlsChangedSinceJob(true)
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [subtitleOffsetMs])
-
   // ---------------------------------------------------------------- derived subtitle state
   const filteredSubtitleEntries = useMemo(() => {
     if (!subtitleSearch.trim()) return []
@@ -337,6 +323,55 @@ function App() {
   const flashTrim = useCallback(() => {
     setTrimFlashKey(k => k + 1)
   }, [])
+
+  // ---------------------------------------------------------------- subtitle selection refit
+  // Recompute the clip start/end around the active subtitle selection using
+  // shifted timings (entry.start/end + offset) and the same 500ms padding +
+  // duration clamping as a fresh pick. Returns null when no selection is
+  // active (anchor < 0) or the entries are missing — callers must not alter a
+  // manually-set range in that case.
+  const refitSelectionRange = useCallback((offset) => {
+    if (subtitleAnchor < 0) return null
+    const duration = selectedSession?.duration ?? Infinity
+    const end = subtitleSelectionEnd >= 0 ? subtitleSelectionEnd : subtitleAnchor
+    const from = Math.min(subtitleAnchor, end)
+    const to = Math.max(subtitleAnchor, end)
+    const firstEntry = subtitleEntries[from]
+    const lastEntry = subtitleEntries[to]
+    if (!firstEntry || !lastEntry) return null
+    const shiftedStart = firstEntry.start + offset
+    const shiftedEnd = lastEntry.end + offset
+    const newStart = Math.max(0, Math.min(shiftedStart - 500, duration))
+    const newEnd = Math.max(0, Math.min(shiftedEnd + 500, duration))
+    return [newStart, newEnd]
+  }, [subtitleAnchor, subtitleSelectionEnd, subtitleEntries, selectedSession])
+
+  // ---------------------------------------------------------------- subtitle offset auto-preview
+  // Changing the subtitle offset is a discrete, intentional action. When a
+  // subtitle entry or contiguous multi-selection is active, the clip range is
+  // refit around the shifted selection (same 500ms padding/clamping as a pick)
+  // before refreshing the preview. When no selection is active, a manually-set
+  // range is left untouched and only the preview URL updates.
+  useEffect(() => {
+    if (!selectedSession) return
+    if (startPosition == null || endPosition == null) return
+    if (!playerReadyRef.current) return
+    const refit = refitSelectionRange(subtitleOffsetMs)
+    if (refit) {
+      const [newStart, newEnd] = refit
+      setStartPosition(newStart)
+      setEndPosition(newEnd)
+      setPlayerPosition(newStart, newEnd)
+      flashTrim()
+      setPreviewStale(false)
+      setControlsChangedSinceJob(true)
+      return
+    }
+    setPlayerPosition(startPosition, endPosition)
+    setPreviewStale(false)
+    setControlsChangedSinceJob(true)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [subtitleOffsetMs])
 
   // ---------------------------------------------------------------- bound setters (clamp to duration only)
   // A typed timestamp commit is a single discrete, intentional action — like

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -32,6 +32,14 @@ function App() {
   const [previewStale, setPreviewStale] = useState(false)
   const [audioMode, setAudioMode] = useState(AUDIO_MODES.STANDARD)
 
+  // --- Subtitle offset ---
+  // Positive = subtitles appear later, negative = earlier. Retained across
+  // subtitle track switches and entry picks (not reset by selection); reset
+  // only on session change, mirroring audioMode. Applied to the preview URL,
+  // the render-job payload (as `subtitleOffsetMs`), and subtitle-derived clip
+  // range math.
+  const [subtitleOffsetMs, setSubtitleOffsetMs] = useState(0)
+
   // --- Subtitle streams ---
   const [subtitleStreams, setSubtitleStreams] = useState([])
   const [selectedSubtitle, setSelectedSubtitle] = useState(-1)
@@ -124,18 +132,21 @@ function App() {
   }, [])
 
   // ---------------------------------------------------------------- player URL builder
-  const setPlayerPosition = useCallback((start, end, subtitleOverride = selectedSubtitle, audioModeOverride = audioMode) => {
+  const setPlayerPosition = useCallback((start, end, subtitleOverride = selectedSubtitle, audioModeOverride = audioMode, offsetOverride = subtitleOffsetMs) => {
     const subtitleIndex = subtitleOverride
     const subtitleParam = subtitleIndex >= 0 ? `&subtitle=${subtitleIndex}` : ''
     const audioModeParam = audioModeOverride && audioModeOverride !== AUDIO_MODES.STANDARD
       ? `&audioMode=${audioModeOverride}`
       : ''
+    // Only emit the offset param when a subtitle track is selected and the
+    // offset is non-zero — keeps the default preview URL stable.
+    const offsetParam = (subtitleIndex >= 0 && offsetOverride) ? `&subtitleOffsetMs=${offsetOverride}` : ''
     setPlayerError(false)
     setPlayerUrl(
       `/preview/${selectedSession.ratingKey}/${millisToDuration(start)}/${millisToDuration(end)}` +
-      `?mediaId=${selectedSession.Media[0].Part[0].id}${subtitleParam}${audioModeParam}`
+      `?mediaId=${selectedSession.Media[0].Part[0].id}${subtitleParam}${audioModeParam}${offsetParam}`
     )
-  }, [selectedSession, selectedSubtitle, audioMode])
+  }, [selectedSession, selectedSubtitle, audioMode, subtitleOffsetMs])
 
   // ---------------------------------------------------------------- session change → streams + prewarm
   useEffect(() => {
@@ -156,6 +167,7 @@ function App() {
       setStartPosition(initStart)
       setEndPosition(initEnd)
       setAudioMode(AUDIO_MODES.STANDARD)
+      setSubtitleOffsetMs(0)
       setSubtitleStreams([])
       setSelectedSubtitle(-1)
       setStreamsError(null)
@@ -273,6 +285,20 @@ function App() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [audioMode])
 
+  // ---------------------------------------------------------------- subtitle offset auto-preview
+  // Changing the subtitle offset is a discrete, intentional action — the
+  // preview refreshes so the user sees the shifted subtitles immediately,
+  // just like changing the audio mode or subtitle track.
+  useEffect(() => {
+    if (!selectedSession) return
+    if (startPosition == null || endPosition == null) return
+    if (!playerReadyRef.current) return
+    setPlayerPosition(startPosition, endPosition)
+    setPreviewStale(false)
+    setControlsChangedSinceJob(true)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [subtitleOffsetMs])
+
   // ---------------------------------------------------------------- derived subtitle state
   const filteredSubtitleEntries = useMemo(() => {
     if (!subtitleSearch.trim()) return []
@@ -351,13 +377,19 @@ function App() {
   }, [selectedSession])
 
   // ---------------------------------------------------------------- subtitle pick (clamp to duration)
+  // Subtitle timings are shifted by `subtitleOffsetMs` before deriving the clip
+  // range: a positive offset makes the subtitle appear later in the output, so
+  // the clip should cover the shifted window (with the usual 500ms padding).
   const handleSubtitlePick = useCallback((fullIdx, shiftKey) => {
     const duration = selectedSession?.duration ?? Infinity
+    const offset = subtitleOffsetMs
     if (subtitleSearch.trim()) {
       const entry = subtitleEntries[fullIdx]
       if (!entry) return
-      const newStart = Math.max(0, Math.min(entry.start - 500, duration))
-      const newEnd = Math.max(0, Math.min(entry.end + 500, duration))
+      const shiftedStart = entry.start + offset
+      const shiftedEnd = entry.end + offset
+      const newStart = Math.max(0, Math.min(shiftedStart - 500, duration))
+      const newEnd = Math.max(0, Math.min(shiftedEnd + 500, duration))
       setSubtitleAnchor(fullIdx)
       setSubtitleSelectionEnd(fullIdx)
       setStartPosition(newStart)
@@ -383,15 +415,17 @@ function App() {
     const firstEntry = subtitleEntries[from]
     const lastEntry = subtitleEntries[to]
     if (!firstEntry || !lastEntry) return
-    const newStart = Math.max(0, Math.min(firstEntry.start - 500, duration))
-    const newEnd = Math.max(0, Math.min(lastEntry.end + 500, duration))
+    const shiftedStart = firstEntry.start + offset
+    const shiftedEnd = lastEntry.end + offset
+    const newStart = Math.max(0, Math.min(shiftedStart - 500, duration))
+    const newEnd = Math.max(0, Math.min(shiftedEnd + 500, duration))
     setStartPosition(newStart)
     setEndPosition(newEnd)
     setPreviewStale(false)
     setPlayerPosition(newStart, newEnd)
     flashTrim()
     setControlsChangedSinceJob(true)
-  }, [subtitleSearch, subtitleAnchor, subtitleEntries, setPlayerPosition, flashTrim, selectedSession])
+  }, [subtitleSearch, subtitleAnchor, subtitleEntries, setPlayerPosition, flashTrim, selectedSession, subtitleOffsetMs])
 
   // ---------------------------------------------------------------- render-job create
   const createRenderJob = useCallback((retrySpec = null) => {
@@ -400,12 +434,12 @@ function App() {
     setDownloadCompleted(false)
     networkRetryCountRef.current = 0
 
-    const spec = retrySpec || snapshotJobSpec(selectedSession, startPosition, endPosition, selectedSubtitle, subtitleStreams, audioMode)
+    const spec = retrySpec || snapshotJobSpec(selectedSession, startPosition, endPosition, selectedSubtitle, subtitleStreams, audioMode, subtitleOffsetMs)
     let body
     try {
       body = JSON.stringify(retrySpec
         ? buildRenderJobRequestFromSpec(retrySpec)
-        : buildRenderJobRequest(selectedSession, startPosition, endPosition, selectedSubtitle, audioMode))
+        : buildRenderJobRequest(selectedSession, startPosition, endPosition, selectedSubtitle, audioMode, subtitleOffsetMs))
     } catch (error) {
       setRenderState({
         status: JOB_STATES.FAILED,
@@ -462,7 +496,7 @@ function App() {
           downloadUrl: null, expiresAt: null, retryAfter: err?.retryAfter || null,
         })
       })
-  }, [selectedSession, startPosition, endPosition, selectedSubtitle, subtitleStreams, audioMode, stopPolling])
+  }, [selectedSession, startPosition, endPosition, selectedSubtitle, subtitleStreams, audioMode, subtitleOffsetMs, stopPolling])
 
   // ---------------------------------------------------------------- render-job polling (ref-bound)
   const pollForJobRef = useRef(null)
@@ -642,6 +676,7 @@ function App() {
     setStartPosition(null)
     setEndPosition(null)
     setAudioMode(AUDIO_MODES.STANDARD)
+    setSubtitleOffsetMs(0)
     setTrimFlashKey(0)
   }, [jobIsActive, stopPolling])
 
@@ -745,6 +780,8 @@ function App() {
               onCreateNewJob={() => createRenderJob()}
               audioMode={audioMode}
               onAudioModeChange={setAudioMode}
+              subtitleOffsetMs={subtitleOffsetMs}
+              onSubtitleOffsetChange={setSubtitleOffsetMs}
               subtitle={selectedSubtitle}
               streams={subtitleStreams}
               selectedSubtitle={selectedSubtitle}

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -147,6 +147,18 @@ async function selectAudioMode(label) {
   await flush();
 }
 
+async function clickSubtitleOffset(direction) {
+  // direction is 'later' (+) or 'earlier' (−); each click steps by 100ms.
+  const label = direction === 'later' ? 'Subtitles later' : 'Subtitles earlier';
+  fireEvent.click(screen.getByRole('button', {name: label}));
+  await flush();
+}
+
+async function resetSubtitleOffset() {
+  fireEvent.click(screen.getByRole('button', {name: 'Reset subtitle offset'}));
+  await flush();
+}
+
 function textStreams() {
   return [
     {index: 0, type: 'text', codec: 'srt', displayTitle: 'X track'},
@@ -420,6 +432,148 @@ test('changing sessions resets audio mode to standard', async () => {
   );
 });
 
+test('positive subtitle offset delays subtitles: preview URL and render payload carry subtitleOffsetMs', async () => {
+  const pending = installFetch();
+  render(<App/>);
+  await flush();
+  await selectSession('Alpha');
+  await resolveRequest(requestFor(pending, url => url === '/streams/A?mediaId=101'), textStreams());
+
+  // Default offset is 0 — the preview URL omits the param entirely.
+  expect(screen.getByTestId('react-player').getAttribute('data-url'))
+    .toBe('/preview/A/00:00:00/00:01:00?mediaId=101&subtitle=0');
+  expect(screen.getByRole('button', {name: 'Reset subtitle offset'})).toBeDisabled();
+
+  // Two +100ms steps → +200ms. The preview URL gains subtitleOffsetMs=200.
+  await clickSubtitleOffset('later');
+  await clickSubtitleOffset('later');
+  expect(screen.getByRole('button', {name: 'Reset subtitle offset'})).toHaveTextContent('+200 ms');
+  expect(screen.getByTestId('react-player').getAttribute('data-url'))
+    .toBe('/preview/A/00:00:00/00:01:00?mediaId=101&subtitle=0&subtitleOffsetMs=200');
+  expect(screen.queryByRole('button', {name: 'Preview selection'})).not.toBeInTheDocument();
+
+  // The render-job payload carries subtitleOffsetMs alongside the other fields.
+  fireEvent.click(screen.getByRole('button', {name: 'Render clip'}));
+  const createRequest = requestFor(pending, url => url === '/render-jobs');
+  expect(JSON.parse(createRequest.options.body)).toMatchObject({
+    ratingKey: 'A', mediaId: 101, subtitleIndex: 0, audioMode: 'standard', subtitleOffsetMs: 200,
+  });
+});
+
+test('negative subtitle offset advances subtitles and renders an earlier preview param', async () => {
+  const pending = installFetch();
+  render(<App/>);
+  await flush();
+  await selectSession('Alpha');
+  await resolveRequest(requestFor(pending, url => url === '/streams/A?mediaId=101'), textStreams());
+
+  await clickSubtitleOffset('earlier');
+  expect(screen.getByRole('button', {name: 'Reset subtitle offset'})).toHaveTextContent('−100 ms');
+  expect(screen.getByTestId('react-player').getAttribute('data-url'))
+    .toBe('/preview/A/00:00:00/00:01:00?mediaId=101&subtitle=0&subtitleOffsetMs=-100');
+
+  fireEvent.click(screen.getByRole('button', {name: 'Render clip'}));
+  const createRequest = requestFor(pending, url => url === '/render-jobs');
+  expect(JSON.parse(createRequest.options.body)).toMatchObject({subtitleOffsetMs: -100});
+});
+
+test('subtitle offset is retained while selecting subtitle tracks and entries', async () => {
+  const pending = installFetch();
+  render(<App/>);
+  await flush();
+  await selectSession('Alpha');
+  await resolveRequest(requestFor(pending, url => url === '/streams/A?mediaId=101'), textStreams());
+
+  await clickSubtitleOffset('later');
+  await clickSubtitleOffset('later');
+  await clickSubtitleOffset('later'); // +300ms
+  expect(screen.getByRole('button', {name: 'Reset subtitle offset'})).toHaveTextContent('+300 ms');
+
+  // Switching the subtitle track keeps the offset.
+  await selectSubtitle('Y track');
+  expect(screen.getByRole('button', {name: 'Reset subtitle offset'})).toHaveTextContent('+300 ms');
+  const yRequest = pending.filter(r => r.url.includes('/subtitles/A?subtitle=1')).slice(-1)[0];
+  await resolveRequest(yRequest, [{start: 1000, end: 2000, text: 'Y one'}]);
+
+  // Picking a subtitle entry keeps the offset too — it must not reset.
+  fireEvent.click(screen.getByRole('button', {name: /Subtitle at 00:00:01/}));
+  await flush();
+  expect(screen.getByRole('button', {name: 'Reset subtitle offset'})).toHaveTextContent('+300 ms');
+});
+
+test('subtitle offset shifts the clip range derived from a subtitle pick', async () => {
+  const pending = installFetch();
+  render(<App/>);
+  await flush();
+  await selectSession('Alpha');
+  await resolveRequest(requestFor(pending, url => url === '/streams/A?mediaId=101'), textStreams());
+  const subtitleRequest = requestFor(pending, url => url.includes('/subtitles/A?subtitle=0'));
+  await resolveRequest(subtitleRequest, [
+    {start: 5000, end: 6000, text: 'Range set'},
+  ]);
+
+  // +500ms offset: the subtitle displays at 5500–6500 in the output, so the
+  // clip range (with 500ms padding) becomes 5000–7000 instead of 4500–6500.
+  for (let i = 0; i < 5; i++) await clickSubtitleOffset('later');
+  expect(screen.getByRole('button', {name: 'Reset subtitle offset'})).toHaveTextContent('+500 ms');
+
+  fireEvent.click(screen.getByRole('button', {name: /Subtitle at 00:00:05/}));
+  await flush();
+  expect(screen.getByTestId('react-player').getAttribute('data-url'))
+    .toContain('/preview/A/00:00:05/00:00:07');
+  expect(screen.getByTestId('react-player').getAttribute('data-url'))
+    .toContain('subtitleOffsetMs=500');
+});
+
+test('clicking the offset value resets to 0 and drops the preview param', async () => {
+  const pending = installFetch();
+  render(<App/>);
+  await flush();
+  await selectSession('Alpha');
+  await resolveRequest(requestFor(pending, url => url === '/streams/A?mediaId=101'), textStreams());
+
+  await clickSubtitleOffset('later');
+  await clickSubtitleOffset('later');
+  expect(screen.getByTestId('react-player').getAttribute('data-url'))
+    .toContain('subtitleOffsetMs=200');
+
+  await resetSubtitleOffset();
+  expect(screen.getByRole('button', {name: 'Reset subtitle offset'})).toHaveTextContent('0 ms');
+  expect(screen.getByRole('button', {name: 'Reset subtitle offset'})).toBeDisabled();
+  expect(screen.getByTestId('react-player').getAttribute('data-url'))
+    .toBe('/preview/A/00:00:00/00:01:00?mediaId=101&subtitle=0');
+});
+
+test('changing sessions resets the subtitle offset to 0', async () => {
+  const pending = installFetch();
+  render(<App/>);
+  await flush();
+  await selectSession('Alpha');
+  await resolveRequest(requestFor(pending, url => url === '/streams/A?mediaId=101'), textStreams());
+  await clickSubtitleOffset('later');
+  expect(screen.getByRole('button', {name: 'Reset subtitle offset'})).toHaveTextContent('+100 ms');
+
+  await changeSession();
+  await selectSession('Beta');
+  await resolveRequest(requestFor(pending, url => url === '/streams/B?mediaId=202'), textStreams());
+  expect(screen.getByRole('button', {name: 'Reset subtitle offset'})).toHaveTextContent('0 ms');
+  expect(screen.getByTestId('react-player').getAttribute('data-url'))
+    .toBe('/preview/B/00:00:05/00:01:05?mediaId=202&subtitle=0');
+});
+
+test('subtitle offset control is disabled when no subtitle track is selected', async () => {
+  const pending = installFetch();
+  render(<App/>);
+  await flush();
+  await selectSession('Alpha');
+  await resolveRequest(requestFor(pending, url => url === '/streams/A?mediaId=101'), []);
+
+  expect(screen.getByRole('button', {name: 'Subtitles later'})).toBeDisabled();
+  expect(screen.getByRole('button', {name: 'Subtitles earlier'})).toBeDisabled();
+  // No subtitle param in the preview URL when offset is irrelevant.
+  expect(screen.getByTestId('react-player').getAttribute('data-url')).not.toContain('subtitleOffsetMs');
+});
+
 test('subtitle entry click sets clip range and auto-applies preview', async () => {
   const pending = installFetch();
   render(<App/>);
@@ -541,6 +695,7 @@ test('render-job POST body and queued/running/succeeded polling produce a saniti
   expect(createRequest.options.headers['Content-Type']).toBe('application/json');
   expect(JSON.parse(createRequest.options.body)).toEqual({
     ratingKey: 'A', mediaId: 101, fromMs: 0, toMs: 60000, subtitleIndex: -1, audioMode: 'standard',
+    subtitleOffsetMs: 0,
   });
 
   await resolveRequestWith(createRequest, {id: 'job-1', status: 'queued'}, {status: 202});
@@ -634,6 +789,7 @@ test('retryable render failures resubmit the immutable full submitted payload', 
   const submittedBody = JSON.parse(firstCreate.options.body);
   expect(submittedBody).toEqual({
     ratingKey: 'A', mediaId: 101, fromMs: 0, toMs: 60000, subtitleIndex: 0, audioMode: 'dialogue',
+    subtitleOffsetMs: 0,
   });
 
   await resolveRequestWith(firstCreate, {id: 'job-retry', status: 'queued'}, {status: 202});

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -574,6 +574,91 @@ test('subtitle offset control is disabled when no subtitle track is selected', a
   expect(screen.getByTestId('react-player').getAttribute('data-url')).not.toContain('subtitleOffsetMs');
 });
 
+test('changing offset refits an active single subtitle selection around shifted timings', async () => {
+  const pending = installFetch();
+  render(<App/>);
+  await flush();
+  await selectSession('Alpha');
+  await resolveRequest(requestFor(pending, url => url === '/streams/A?mediaId=101'), textStreams());
+  const subtitleRequest = requestFor(pending, url => url.includes('/subtitles/A?subtitle=0'));
+  await resolveRequest(subtitleRequest, [{start: 5000, end: 6000, text: 'Solo'}]);
+
+  // Picking the entry sets the range to 4500–6500 (500ms padding).
+  fireEvent.click(screen.getByRole('button', {name: /Subtitle at 00:00:05/}));
+  await flush();
+  expect(screen.getByTestId('react-player').getAttribute('data-url'))
+    .toContain('/preview/A/00:00:04.500/00:00:06.500');
+
+  // Changing the offset refits the active selection without re-picking.
+  // +200ms → shifted 5200–6200 → padded 4700–6700.
+  await clickSubtitleOffset('later');
+  await clickSubtitleOffset('later');
+  expect(screen.getByTestId('react-player').getAttribute('data-url'))
+    .toContain('/preview/A/00:00:04.700/00:00:06.700');
+  expect(screen.getByTestId('react-player').getAttribute('data-url'))
+    .toContain('subtitleOffsetMs=200');
+  // Auto-applied — no stale button.
+  expect(screen.queryByRole('button', {name: 'Preview selection'})).not.toBeInTheDocument();
+});
+
+test('changing offset refits an active contiguous multi-selection around the full shifted span', async () => {
+  const pending = installFetch();
+  render(<App/>);
+  await flush();
+  await selectSession('Alpha');
+  await resolveRequest(requestFor(pending, url => url === '/streams/A?mediaId=101'), textStreams());
+  const subtitleRequest = requestFor(pending, url => url.includes('/subtitles/A?subtitle=0'));
+  await resolveRequest(subtitleRequest, [
+    {start: 5000, end: 6000, text: 'A'},
+    {start: 7000, end: 8000, text: 'B'},
+    {start: 9000, end: 10000, text: 'C'},
+  ]);
+
+  // Single pick on the first entry → 4500–6500.
+  fireEvent.click(screen.getByRole('button', {name: /Subtitle at 00:00:05: A/}));
+  await flush();
+  // Shift+click the third entry extends the selection to entries 0–2.
+  fireEvent.click(screen.getByRole('button', {name: /Subtitle at 00:00:09: C/}), {shiftKey: true});
+  await flush();
+  // Span 5000–10000 → padded 4500–10500.
+  expect(screen.getByTestId('react-player').getAttribute('data-url'))
+    .toContain('/preview/A/00:00:04.500/00:00:10.500');
+
+  // +500ms refits the whole selection: shifted 5500–10500 → padded 5000–11000.
+  for (let i = 0; i < 5; i++) await clickSubtitleOffset('later');
+  expect(screen.getByTestId('react-player').getAttribute('data-url'))
+    .toContain('/preview/A/00:00:05/00:00:11');
+  expect(screen.getByTestId('react-player').getAttribute('data-url'))
+    .toContain('subtitleOffsetMs=500');
+  expect(screen.queryByRole('button', {name: 'Preview selection'})).not.toBeInTheDocument();
+});
+
+test('changing offset does not alter a manually-set range when no subtitle selection is active', async () => {
+  const pending = installFetch();
+  render(<App/>);
+  await flush();
+  await selectSession('Alpha');
+  await resolveRequest(requestFor(pending, url => url === '/streams/A?mediaId=101'), textStreams());
+  // Subtitles load but nothing is picked — anchor stays -1.
+  await resolveRequest(
+    requestFor(pending, url => url.includes('/subtitles/A?subtitle=0')),
+    [{start: 5000, end: 6000, text: 'Unpicked'}]
+  );
+
+  // Initial manual range is 00:00:00–00:01:00.
+  expect(screen.getByTestId('react-player').getAttribute('data-url'))
+    .toBe('/preview/A/00:00:00/00:01:00?mediaId=101&subtitle=0');
+
+  // The offset still reaches the preview URL, but the range is untouched.
+  await clickSubtitleOffset('later');
+  await clickSubtitleOffset('later');
+  expect(screen.getByTestId('react-player').getAttribute('data-url'))
+    .toBe('/preview/A/00:00:00/00:01:00?mediaId=101&subtitle=0&subtitleOffsetMs=200');
+  expect(screen.getByRole('slider', {name: 'Clip start time'})).toHaveValue('0');
+  expect(screen.getByRole('slider', {name: 'Clip end time'})).toHaveValue('60000');
+  expect(screen.queryByRole('button', {name: 'Preview selection'})).not.toBeInTheDocument();
+});
+
 test('subtitle entry click sets clip range and auto-applies preview', async () => {
   const pending = installFetch();
   render(<App/>);

--- a/frontend/src/components/ClipWorkspace.js
+++ b/frontend/src/components/ClipWorkspace.js
@@ -16,9 +16,10 @@ export default function ClipWorkspace({
   onChangeSession, changeSessionDisabled, changeSessionDisabledReason,
   renderState, jobSpec, controlsChangedSinceJob,
   onCreateJob, onDownloadJob, onRetryJob, onRetryPoll, onCreateNewJob,
-  audioMode, onAudioModeChange,
-  subtitle, ...subProps
-}) {
+audioMode, onAudioModeChange,
+              subtitleOffsetMs, onSubtitleOffsetChange,
+              subtitle, ...subProps
+            }) {
   return (
     <>
       <SessionContext
@@ -65,7 +66,11 @@ export default function ClipWorkspace({
               Subtitles
             </Typography>
             <Box sx={{flex: 1, display: 'flex', flexDirection: 'column', minHeight: 0, mt: 0.5}}>
-              <SubtitlePanel {...subProps} />
+              <SubtitlePanel
+                subtitleOffsetMs={subtitleOffsetMs}
+                onSubtitleOffsetChange={onSubtitleOffsetChange}
+                {...subProps}
+              />
             </Box>
           </Paper>
           <RenderJobBar

--- a/frontend/src/components/RenderJobBar.js
+++ b/frontend/src/components/RenderJobBar.js
@@ -48,6 +48,14 @@ export default function RenderJobBar({
             sx={{borderColor: 'rgba(255,255,255,0.18)', color: 'text.secondary'}}/>
           <Chip size="small" label={spec.audioMode} variant="outlined"
             sx={{borderColor: 'rgba(255,255,255,0.18)', color: 'text.secondary'}}/>
+          {spec.subtitleOffsetMs !== 0 && (
+            <Chip size="small" label={spec.subtitleOffsetLabel} variant="outlined"
+              sx={{
+                borderColor: 'rgba(255,115,0,0.4)',
+                color: '#ffd9b0',
+                fontFamily: 'var(--cs-mono-font)',
+              }}/>
+          )}
         </Box>
       )}
 

--- a/frontend/src/components/SubtitleOffsetControl.js
+++ b/frontend/src/components/SubtitleOffsetControl.js
@@ -1,0 +1,151 @@
+import {Box, IconButton, Tooltip, Typography} from "@mui/material";
+
+// Subtitle offset stepper — a compact, contextual control that lives next to
+// the subtitle track selector. Positive values delay subtitles (they appear
+// later); negative values advance them (earlier). The value is retained
+// across subtitle selections and applied to both the preview URL and the
+// render-job request body as `subtitleOffsetMs`.
+//
+// Interactions:
+//   • − / + buttons step by SUBTITLE_OFFSET_STEP_MS (100ms)
+//   • clicking the value pill resets to 0
+//   • disabled entirely when no subtitle track is selected
+//
+// The pill uses the workspace orange accent so the active offset reads at a
+// glance without crowding the subtitle header.
+
+export const SUBTITLE_OFFSET_STEP_MS = 100
+export const SUBTITLE_OFFSET_MIN_MS = -60000
+export const SUBTITLE_OFFSET_MAX_MS = 60000
+
+export function clampSubtitleOffsetMs(value) {
+  const n = Number(value)
+  if (!Number.isFinite(n)) return 0
+  const rounded = Math.round(n)
+  return Math.max(SUBTITLE_OFFSET_MIN_MS, Math.min(SUBTITLE_OFFSET_MAX_MS, rounded))
+}
+
+export function formatSubtitleOffsetMs(ms) {
+  const n = clampSubtitleOffsetMs(ms)
+  if (n === 0) return '0 ms'
+  const sign = n > 0 ? '+' : '−' // U+2212 minus for visual symmetry with +
+  return `${sign}${Math.abs(n)} ms`
+}
+
+// Inline SVG glyphs — stays consistent with SubtitleList's hand-rolled icons
+// and avoids pulling in @mui/icons-material.
+function MinusIcon(props) {
+  return (
+    <svg viewBox="0 0 24 24" width="1em" height="1em" fill="none" stroke="currentColor"
+      strokeWidth="2.4" strokeLinecap="round" {...props}>
+      <path d="M5 12h14"/>
+    </svg>
+  )
+}
+function PlusIcon(props) {
+  return (
+    <svg viewBox="0 0 24 24" width="1em" height="1em" fill="none" stroke="currentColor"
+      strokeWidth="2.4" strokeLinecap="round" {...props}>
+      <path d="M12 5v14M5 12h14"/>
+    </svg>
+  )
+}
+
+export default function SubtitleOffsetControl({value, onChange, disabled}) {
+  const current = clampSubtitleOffsetMs(value)
+  const isNonZero = current !== 0
+  const step = (dir) => {
+    if (disabled) return
+    onChange(clampSubtitleOffsetMs(current + dir * SUBTITLE_OFFSET_STEP_MS))
+  }
+  const reset = () => {
+    if (disabled) return
+    if (current !== 0) onChange(0)
+  }
+
+  return (
+    <Tooltip
+      title="Shift subtitles earlier (−) or later (+). Applied to preview and render. Click the value to reset."
+      placement="bottom"
+    >
+      <Box
+        component="span"
+        sx={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 0.5,
+          // Subtle bordered pill keeps the stepper compact and visually
+          // distinct from the track Select while sharing the same row.
+          px: 0.5,
+          py: 0.25,
+          borderRadius: 999,
+          border: '1px solid',
+          borderColor: isNonZero && !disabled ? 'rgba(255,115,0,0.4)' : 'rgba(255,255,255,0.12)',
+          backgroundColor: isNonZero && !disabled ? 'rgba(255,115,0,0.08)' : 'transparent',
+          transition: 'border-color 160ms ease, background-color 160ms ease',
+          opacity: disabled ? 0.5 : 1,
+        }}
+      >
+        <Typography
+          variant="caption"
+          sx={{color: 'text.secondary', px: 0.25, fontWeight: 600, letterSpacing: '0.04em'}}
+        >
+          Offset
+        </Typography>
+        <IconButton
+          size="small"
+          aria-label="Subtitles earlier"
+          title="Earlier"
+          disabled={disabled}
+          onClick={() => step(-1)}
+          sx={{
+            p: 0.25,
+            color: 'text.secondary',
+            '&:hover': {color: '#ff7300', backgroundColor: 'rgba(255,115,0,0.12)'},
+          }}
+        >
+          <MinusIcon sx={{fontSize: 16}}/>
+        </IconButton>
+        <Box
+          component="button"
+          type="button"
+          aria-label="Reset subtitle offset"
+          disabled={disabled || !isNonZero}
+          onClick={reset}
+          sx={{
+            border: 0,
+            background: 'transparent',
+            px: 0.75,
+            py: 0.25,
+            borderRadius: 999,
+            cursor: disabled || !isNonZero ? 'default' : 'pointer',
+            font: 'inherit',
+            fontFamily: 'var(--cs-mono-font)',
+            fontSize: '0.78rem',
+            fontWeight: 600,
+            minWidth: 58,
+            textAlign: 'center',
+            color: isNonZero && !disabled ? '#ffd9b0' : 'text.secondary',
+            '&:hover': disabled || !isNonZero ? {} : {backgroundColor: 'rgba(255,115,0,0.14)'},
+          }}
+        >
+          {formatSubtitleOffsetMs(current)}
+        </Box>
+        <IconButton
+          size="small"
+          aria-label="Subtitles later"
+          title="Later"
+          disabled={disabled}
+          onClick={() => step(1)}
+          sx={{
+            p: 0.25,
+            color: 'text.secondary',
+            '&:hover': {color: '#ff7300', backgroundColor: 'rgba(255,115,0,0.12)'},
+          }}
+        >
+          <PlusIcon sx={{fontSize: 16}}/>
+        </IconButton>
+      </Box>
+    </Tooltip>
+  )
+}

--- a/frontend/src/components/SubtitlePanel.js
+++ b/frontend/src/components/SubtitlePanel.js
@@ -1,19 +1,25 @@
 import {Box, FormControl, InputLabel, MenuItem, Select, Typography} from "@mui/material";
 import SubtitleList from "./SubtitleList";
+import SubtitleOffsetControl from "./SubtitleOffsetControl";
 
 // Right-rail subtitle control room: track selector on top, searchable list below.
+// The subtitle offset stepper lives beside the track selector so all subtitle
+// timing controls sit together; the offset is retained across subtitle
+// selections and applied to both preview and render requests.
 export default function SubtitlePanel({
   streams, selectedSubtitle, onSubtitleChange, streamsLoading, streamsError,
+  subtitleOffsetMs, onSubtitleOffsetChange,
   listMode, listEntries, totalCount, anchor, selectionRange,
   onPick, search, onSearchChange, onClearSearch,
   loading, error, listRef,
 }) {
   const hasStreams = streams.length > 0
   const currentCodec = streams.find(s => s.index === selectedSubtitle)?.codec
+  const offsetDisabled = selectedSubtitle < 0
 
   return (
     <Box className="cs-rise-3" sx={{display: 'flex', flexDirection: 'column', minHeight: 0, height: '100%'}}>
-      <Box sx={{display: 'flex', alignItems: 'center', gap: 2, flexWrap: 'wrap'}}>
+      <Box sx={{display: 'flex', alignItems: 'center', gap: 1.5, flexWrap: 'wrap'}}>
         <FormControl fullWidth size="small" sx={{maxWidth: 280}}>
           <InputLabel id="subtitle-select">Subtitle track</InputLabel>
           <Select
@@ -37,6 +43,11 @@ export default function SubtitlePanel({
             {currentCodec}
           </Typography>
         )}
+        <SubtitleOffsetControl
+          value={subtitleOffsetMs}
+          onChange={onSubtitleOffsetChange}
+          disabled={offsetDisabled}
+        />
       </Box>
 
       {streamsError ? (

--- a/frontend/src/components/render-jobs.js
+++ b/frontend/src/components/render-jobs.js
@@ -1,4 +1,5 @@
 import {millisToDuration} from "../utils";
+import {clampSubtitleOffsetMs, formatSubtitleOffsetMs} from "./SubtitleOffsetControl";
 
 // Render job states matching the backend renderJobState constants.
 export const JOB_STATES = {
@@ -42,7 +43,10 @@ export function audioModeLabel(value) {
 }
 
 // Build the POST /render-jobs request body from the current clip spec.
-export function buildRenderJobRequest(session, startPosition, endPosition, selectedSubtitle, audioMode) {
+// `subtitleOffsetMs` shifts subtitle timing in the rendered output — positive
+// delays subtitles (later), negative advances them (earlier). It is always
+// present in the payload so the backend can rely on the field.
+export function buildRenderJobRequest(session, startPosition, endPosition, selectedSubtitle, audioMode, subtitleOffsetMs) {
   const mediaId = normalizeMediaId(session?.Media?.[0]?.Part?.[0]?.id)
   if (mediaId == null) throw new Error('The selected media part has an invalid media ID.')
   return {
@@ -52,6 +56,7 @@ export function buildRenderJobRequest(session, startPosition, endPosition, selec
     toMs: endPosition,
     subtitleIndex: selectedSubtitle,
     audioMode: audioMode || AUDIO_MODES.STANDARD,
+    subtitleOffsetMs: clampSubtitleOffsetMs(subtitleOffsetMs),
   }
 }
 
@@ -66,6 +71,7 @@ export function buildRenderJobRequestFromSpec(spec) {
     toMs: spec.toMs,
     subtitleIndex: spec.subtitleIndex,
     audioMode: spec.audioMode || AUDIO_MODES.STANDARD,
+    subtitleOffsetMs: clampSubtitleOffsetMs(spec?.subtitleOffsetMs),
   }
 }
 
@@ -86,8 +92,9 @@ export function isTransportError(error) {
 // Snapshot an immutable submitted spec for display. This is captured at job
 // creation time and never mutated — it represents what was actually submitted,
 // not the current (possibly edited) controls.
-export function snapshotJobSpec(session, startPosition, endPosition, selectedSubtitle, streams, audioMode) {
+export function snapshotJobSpec(session, startPosition, endPosition, selectedSubtitle, streams, audioMode, subtitleOffsetMs) {
   const stream = selectedSubtitle >= 0 ? streams.find(s => s.index === selectedSubtitle) : null
+  const offsetMs = clampSubtitleOffsetMs(subtitleOffsetMs)
   return {
     ratingKey: session.ratingKey,
     mediaId: normalizeMediaId(session?.Media?.[0]?.Part?.[0]?.id),
@@ -102,6 +109,8 @@ export function snapshotJobSpec(session, startPosition, endPosition, selectedSub
       : 'None',
     clipDuration: Math.max(0, endPosition - startPosition),
     audioMode: audioMode || AUDIO_MODES.STANDARD,
+    subtitleOffsetMs: offsetMs,
+    subtitleOffsetLabel: `Offset ${formatSubtitleOffsetMs(offsetMs)}`,
   }
 }
 
@@ -155,5 +164,7 @@ export function formatJobSpec(spec) {
     duration: millisToDuration(spec.clipDuration),
     subtitle: spec.subtitleLabel,
     audioMode: audioModeLabel(spec.audioMode),
+    subtitleOffsetMs: clampSubtitleOffsetMs(spec?.subtitleOffsetMs),
+    subtitleOffsetLabel: `Offset ${formatSubtitleOffsetMs(spec?.subtitleOffsetMs)}`,
   }
 }

--- a/render_jobs.go
+++ b/render_jobs.go
@@ -55,14 +55,15 @@ const (
 )
 
 type RenderJobCreateRequest struct {
-	RatingKey     string    `json:"ratingKey"`
-	MediaID       int64     `json:"mediaId"`
-	FromMs        int64     `json:"fromMs"`
-	ToMs          int64     `json:"toMs"`
-	SubtitleIndex int       `json:"subtitleIndex"`
-	Height        int       `json:"height"`
-	QP            int       `json:"qp"`
-	AudioMode     AudioMode `json:"audioMode"`
+	RatingKey        string    `json:"ratingKey"`
+	MediaID          int64     `json:"mediaId"`
+	FromMs           int64     `json:"fromMs"`
+	ToMs             int64     `json:"toMs"`
+	SubtitleIndex    int       `json:"subtitleIndex"`
+	SubtitleOffsetMs int64     `json:"subtitleOffsetMs"`
+	Height           int       `json:"height"`
+	QP               int       `json:"qp"`
+	AudioMode        AudioMode `json:"audioMode"`
 }
 
 type renderJobSpec struct {
@@ -74,6 +75,7 @@ type renderJobSpec struct {
 	FromMs                int64
 	ToMs                  int64
 	SubtitleIndex         int
+	SubtitleOffsetMs      int64
 	SubtitlePGS           bool
 	SubtitleExternal      bool
 	SubtitleStreamKey     string
@@ -1038,6 +1040,9 @@ func validateRenderJobRequestWithMetadata(request RenderJobCreateRequest, user U
 	if request.SubtitleIndex < -1 {
 		return renderJobSpec{}, errors.New("subtitleIndex is invalid")
 	}
+	if err := validateSubtitleOffsetMs(request.SubtitleOffsetMs); err != nil {
+		return renderJobSpec{}, err
+	}
 	if request.Height < 0 || request.Height > 2160 || request.Height > 0 && (request.Height < 144 || request.Height%2 != 0) {
 		return renderJobSpec{}, errors.New("height is invalid")
 	}
@@ -1085,6 +1090,7 @@ func validateRenderJobRequestWithMetadata(request RenderJobCreateRequest, user U
 			FromMs:                request.FromMs,
 			ToMs:                  request.ToMs,
 			SubtitleIndex:         request.SubtitleIndex,
+			SubtitleOffsetMs:      request.SubtitleOffsetMs,
 			SubtitlePGS:           subtitle.PGS,
 			SubtitleExternal:      subtitle.External,
 			SubtitleStreamKey:     subtitle.StreamKey,
@@ -1150,6 +1156,7 @@ func validateRenderJobRequestWithMetadata(request RenderJobCreateRequest, user U
 					FromMs:                request.FromMs,
 					ToMs:                  request.ToMs,
 					SubtitleIndex:         request.SubtitleIndex,
+					SubtitleOffsetMs:      request.SubtitleOffsetMs,
 					SubtitlePGS:           subtitlePGS,
 					SubtitleEmbeddedIndex: subtitleEmbeddedIndex,
 					Height:                request.Height,
@@ -1208,7 +1215,7 @@ func (a *Application) executeRenderSpec(ctx context.Context, spec renderJobSpec,
 				External:  true,
 			}
 			var err error
-			subtitleFile, err = a.prepareExternalSubtitle(ctx, source, spec.FromMs, spec.ToMs)
+			subtitleFile, err = a.prepareExternalSubtitle(ctx, source, spec.FromMs, spec.ToMs, spec.SubtitleOffsetMs)
 			if err != nil {
 				return newRenderStageFailure("subtitle", "subtitle_unavailable", err)
 			}
@@ -1221,7 +1228,7 @@ func (a *Application) executeRenderSpec(ctx context.Context, spec renderJobSpec,
 			if err != nil {
 				return classifyRenderStageError("subtitle", err)
 			}
-			subtitleFile, err = ExtractSubtitleContext(ctx, sourceURL, from, to, embeddedIndex)
+			subtitleFile, err = ExtractSubtitleContext(ctx, sourceURL, from, to, embeddedIndex, spec.SubtitleOffsetMs)
 			release()
 			if err != nil {
 				return classifyRenderStageError("subtitle", err)
@@ -1233,7 +1240,7 @@ func (a *Application) executeRenderSpec(ctx context.Context, spec renderJobSpec,
 		URL: sourceURL, From: from, To: to, Filename: "job.mp4", OutputPath: outputPartial,
 		Codec: a.config.Ffmpeg.Codec, Height: spec.Height, QP: spec.QP,
 		AudioMode:    spec.AudioMode,
-		SubtitleFile: subtitleFile, SubtitleIndex: -1, Context: ctx,
+		SubtitleFile: subtitleFile, SubtitleIndex: -1, SubtitleOffsetMs: spec.SubtitleOffsetMs, Context: ctx,
 		Metadata: FfmpegParamsMetadata{Title: spec.Title},
 	}
 	if spec.SubtitlePGS {

--- a/render_jobs_test.go
+++ b/render_jobs_test.go
@@ -26,6 +26,20 @@ func TestDecodeRenderJobRequestIsStrictAndBoundedByCaller(t *testing.T) {
 	if _, err := decodeRenderJobRequest([]byte(`{"ratingKey":"movie-1"} {}`)); err == nil {
 		t.Fatal("trailing JSON must be rejected")
 	}
+	request, err = decodeRenderJobRequest([]byte(`{"ratingKey":"movie-1","mediaId":42,"fromMs":0,"toMs":1000,"subtitleOffsetMs":-250}`))
+	if err != nil || request.SubtitleOffsetMs != -250 {
+		t.Fatalf("signed subtitle offset decode = %+v, %v", request, err)
+	}
+}
+
+func TestRenderJobValidationRejectsSubtitleOffsetOutsideRange(t *testing.T) {
+	request := RenderJobCreateRequest{
+		RatingKey: "movie-1", MediaID: 42, FromMs: 0, ToMs: 1000,
+		SubtitleIndex: -1, SubtitleOffsetMs: maxSubtitleOffsetMs + 1,
+	}
+	if _, err := validateRenderJobRequest(request, User{Uuid: "owner-a"}, nil); err == nil {
+		t.Fatal("out-of-range subtitle offset was accepted")
+	}
 }
 
 func TestFfmpegRenderOutputForcesMP4Muxer(t *testing.T) {


### PR DESCRIPTION
## Summary
- add a signed subtitle offset control for preview and render jobs
- shift text, external, and PGS subtitle timing consistently
- snapshot offsets with render jobs and cover signed timing behavior

## Verification
- go test ./...
- CI=true npm test -- --watchAll=false App.test.js
- npm run build