### PR TITLE
Enhance live session dashboard

### DIFF
--- a/api_render_jobs_test.go
+++ b/api_render_jobs_test.go
@@ -96,6 +96,87 @@ func TestAuthMiddlewareRestoresUserWhenTokenAlreadyExists(t *testing.T) {
 	}
 }
 
+func TestGetSessionsAnnotatesOwnershipByNumericUserID(t *testing.T) {
+	plex := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/status/sessions" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"MediaContainer":{"Metadata":[
+			{"title":"Different title","key":"matching","User":{"id":1,"title":"Owner"}},
+			{"title":"Owner","key":"nonmatching","User":{"id":"7","title":"Owner"}}
+		]}}`)
+	}))
+	defer plex.Close()
+
+	config := Config{}
+	config.Plex.Host = plex.URL
+	app := &Application{config: config, ownerEmail: "owner@example.com"}
+	api := &API{
+		app: app,
+		validateUser: func(ctx context.Context) (*User, error) {
+			if AuthTokenFromContext(ctx) == nil {
+				t.Fatal("authentication token was not propagated")
+			}
+			return &User{Id: 42, Username: "Owner", Email: "owner@example.com"}, nil
+		},
+	}
+	httpApp := fiber.New()
+	httpApp.Use(func(ctx fiber.Ctx) error {
+		ctx.SetUserContext(ContextWithAuthToken(context.Background(), "user-token"))
+		return ctx.Next()
+	})
+	httpApp.Get("/sessions", api.getSessions, api.authMiddleware)
+
+	response, err := httpApp.Test(httptest.NewRequest(http.MethodGet, "/sessions", nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", response.StatusCode)
+	}
+
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var sessions []sessionMetadata
+	if err := json.Unmarshal(body, &sessions); err != nil {
+		t.Fatal(err)
+	}
+	var wireSessions []map[string]json.RawMessage
+	if err := json.Unmarshal(body, &wireSessions); err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions) != 2 {
+		t.Fatalf("got %d sessions, want 2", len(sessions))
+	}
+	for i, want := range []bool{true, false} {
+		rawOwned, ok := wireSessions[i]["ownedByCurrentUser"]
+		if !ok {
+			t.Fatalf("session %d omitted ownedByCurrentUser", i)
+		}
+		var owned bool
+		if err := json.Unmarshal(rawOwned, &owned); err != nil {
+			t.Fatalf("session %d ownedByCurrentUser was not a JSON boolean: %v", i, err)
+		}
+		if owned != want {
+			t.Errorf("session %d ownedByCurrentUser = %v, want %v", i, owned, want)
+		}
+	}
+	if !sessions[0].OwnedByCurrentUser {
+		t.Errorf("session with matching numeric user ID was not marked owned: %+v", sessions[0])
+	}
+	if sessions[1].OwnedByCurrentUser {
+		t.Error("session with nonmatching numeric user ID was marked owned")
+	}
+	if sessions[0].Title != "Different title" || sessions[0].Key != "matching" {
+		t.Errorf("existing session fields were not preserved: %+v", sessions[0])
+	}
+}
+
 func testAuthenticatedRoute(handler fiber.Handler) *fiber.App {
 	app := fiber.New()
 	app.Use(func(ctx fiber.Ctx) error {

--- a/application.go
+++ b/application.go
@@ -83,24 +83,21 @@ type sessionContainer struct {
 }
 
 type sessionMetadata struct {
-	Title            string  `json:"title"`
-	Type             string  `json:"type"`
-	GrandparentTitle *string `json:"grandparentTitle,omitempty"`
-	ParentIndex      *int    `json:"parentIndex,omitempty"`
-	Index            *int    `json:"index,omitempty"`
-	Year             *int    `json:"year,omitempty"`
-	Thumb            *string `json:"thumb,omitempty"`
-	GrandparentThumb *string `json:"grandparentThumb,omitempty"`
-	Key              string  `json:"key"`
-	RatingKey        *string `json:"ratingKey,omitempty"`
-	Duration         *int    `json:"duration,omitempty"`
-	ViewOffset       *int64  `json:"viewOffset,omitempty"`
-	User             struct {
-		ID    string `json:"id"`
-		Title string `json:"title"`
-		Thumb string `json:"thumb"`
-	} `json:"User"`
-	Player struct {
+	Title              string      `json:"title"`
+	Type               string      `json:"type"`
+	GrandparentTitle   *string     `json:"grandparentTitle,omitempty"`
+	ParentIndex        *int        `json:"parentIndex,omitempty"`
+	Index              *int        `json:"index,omitempty"`
+	Year               *int        `json:"year,omitempty"`
+	Thumb              *string     `json:"thumb,omitempty"`
+	GrandparentThumb   *string     `json:"grandparentThumb,omitempty"`
+	Key                string      `json:"key"`
+	RatingKey          *string     `json:"ratingKey,omitempty"`
+	Duration           *int        `json:"duration,omitempty"`
+	ViewOffset         *int64      `json:"viewOffset,omitempty"`
+	User               sessionUser `json:"User"`
+	OwnedByCurrentUser bool        `json:"ownedByCurrentUser"`
+	Player             struct {
 		Title             string `json:"title"`
 		UUID              string `json:"uuid"`
 		MachineIdentifier string `json:"machineIdentifier"`
@@ -113,6 +110,34 @@ type sessionMetadata struct {
 		Location  string `json:"location,omitempty"`
 	} `json:"Session"`
 	Media []sessionMedia `json:"Media,omitempty"`
+}
+
+// sessionUser accepts both forms emitted by Plex: User.id is normally a
+// quoted value, but some Plex versions serialize it as a JSON number.
+type sessionUser struct {
+	ID    string `json:"id"`
+	Title string `json:"title"`
+	Thumb string `json:"thumb"`
+}
+
+func (u *sessionUser) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		ID    json.RawMessage `json:"id"`
+		Title string          `json:"title"`
+		Thumb string          `json:"thumb"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	id, err := plexNumericIDText(raw.ID)
+	if err != nil {
+		return fmt.Errorf("invalid session user id: %w", err)
+	}
+	u.ID = id
+	u.Title = raw.Title
+	u.Thumb = raw.Thumb
+	return nil
 }
 
 type sessionMedia struct {
@@ -304,13 +329,17 @@ func (a *Application) GetSessions(ctx context.Context) ([]sessionMetadata, error
 		return nil, fmt.Errorf("could not decode sessions: %w\nRaw response:\n%s", err, string(body))
 	}
 
-	// Non-owner users see only their own sessions
 	user := UserFromContext(ctx)
-	if user != nil && user.Email != a.ownerEmail {
-		userIdStr := strconv.Itoa(user.Id)
+	serverOwner := user != nil && user.Email == a.ownerEmail
+	for i := range sessions.MediaContainer.Metadata {
+		sessions.MediaContainer.Metadata[i].OwnedByCurrentUser = sessionOwnedByCurrentUser(sessions.MediaContainer.Metadata[i], user, serverOwner)
+	}
+
+	// Non-owner users see only their own sessions
+	if user != nil && !serverOwner {
 		var filtered []sessionMetadata
 		for _, s := range sessions.MediaContainer.Metadata {
-			if s.User.ID == userIdStr {
+			if sessionVisibleToCurrentUser(s, user) {
 				filtered = append(filtered, s)
 			}
 		}
@@ -318,6 +347,51 @@ func (a *Application) GetSessions(ctx context.Context) ([]sessionMetadata, error
 	}
 
 	return sessions.MediaContainer.Metadata, nil
+}
+
+func sessionOwnedByCurrentUser(session sessionMetadata, user *User, serverOwner bool) bool {
+	if user == nil {
+		return false
+	}
+
+	sessionUserID, err := strconv.ParseInt(session.User.ID, 10, 64)
+	if err != nil {
+		return false
+	}
+
+	// PMS uses local playback-profile IDs. The configured server owner's
+	// profile is the stable local ID 1, not necessarily the Plex account ID.
+	if serverOwner {
+		return sessionUserID == 1
+	}
+
+	// A non-owner must never claim the owner's local profile. For other local
+	// IDs, retain the direct numeric match as an additional positive signal.
+	if sessionUserID == 1 {
+		return false
+	}
+	if sessionUserID == int64(user.Id) {
+		return true
+	}
+
+	for _, identity := range []string{user.Username, user.Title, user.Email} {
+		if identity != "" && strings.EqualFold(strings.TrimSpace(session.User.Title), strings.TrimSpace(identity)) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// sessionVisibleToCurrentUser intentionally remains ID-based. Ownership
+// annotations must not change the existing non-owner access boundary.
+func sessionVisibleToCurrentUser(session sessionMetadata, user *User) bool {
+	if user == nil {
+		return false
+	}
+
+	sessionUserID, err := strconv.ParseInt(session.User.ID, 10, 64)
+	return err == nil && sessionUserID == int64(user.Id)
 }
 
 // SubtitleStream describes a subtitle track available in a media item.

--- a/application_test.go
+++ b/application_test.go
@@ -800,6 +800,120 @@ func TestUsersHasUser(t *testing.T) {
 	}
 }
 
+func TestPlexUserIDAcceptsNumericWireForms(t *testing.T) {
+	for _, id := range []string{`42`, `"42"`} {
+		t.Run(id, func(t *testing.T) {
+			var response GetUserResp
+			if err := json.Unmarshal([]byte(`{"user":{"id":`+id+`,"uuid":"user-uuid","title":"Viewer Title"}}`), &response); err != nil {
+				t.Fatal(err)
+			}
+			if response.User.Id != 42 {
+				t.Fatalf("user id = %d, want 42", response.User.Id)
+			}
+			if response.User.Title != "Viewer Title" {
+				t.Fatalf("user title = %q, want Viewer Title", response.User.Title)
+			}
+		})
+	}
+}
+
+func TestGetSessionsFiltersNonOwnerByNumericUserID(t *testing.T) {
+	plex := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"MediaContainer":{"Metadata":[
+			{"key":"owned","User":{"id":42}},
+			{"key":"other","User":{"id":"7"}}
+		]}}`)
+	}))
+	defer plex.Close()
+
+	config := Config{}
+	config.Plex.Host = plex.URL
+	app := &Application{config: config, ownerEmail: "owner@example.com"}
+	sessions, err := app.GetSessions(ContextWithUser(context.Background(), User{
+		Id:    42,
+		Email: "viewer@example.com",
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions) != 1 || sessions[0].Key != "owned" || !sessions[0].OwnedByCurrentUser {
+		t.Fatalf("filtered sessions = %+v, want only the numerically matching owned session", sessions)
+	}
+}
+
+func TestSessionOwnershipMappingUsesPlexLocalProfileAndIdentity(t *testing.T) {
+	identity := &User{
+		Id:       42,
+		Username: "ViewerName",
+		Title:    "Viewer Title",
+		Email:    "viewer@example.com",
+	}
+	session := func(id, title string) sessionMetadata {
+		return sessionMetadata{User: sessionUser{ID: id, Title: title}}
+	}
+
+	tests := []struct {
+		name        string
+		session     sessionMetadata
+		user        *User
+		serverOwner bool
+		want        bool
+	}{
+		{
+			name:        "configured owner local profile one",
+			session:     session("1", "PMS Owner"),
+			user:        &User{Id: 9001, Email: "owner@example.com"},
+			serverOwner: true,
+			want:        true,
+		},
+		{
+			name:    "non-owner title case insensitive",
+			session: session("77", "vIeWeRnAmE"),
+			user:    identity,
+			want:    true,
+		},
+		{
+			name:    "non-owner identity title",
+			session: session("77", "viewer title"),
+			user:    identity,
+			want:    true,
+		},
+		{
+			name:    "non-owner identity email",
+			session: session("77", "VIEWER@EXAMPLE.COM"),
+			user:    identity,
+			want:    true,
+		},
+		{
+			name:    "non-owner direct ID remains positive",
+			session: session("42", "another display name"),
+			user:    identity,
+			want:    true,
+		},
+		{
+			name:    "non-owner mismatch",
+			session: session("77", "someone else"),
+			user:    identity,
+			want:    false,
+		},
+		{
+			name:    "non-owner cannot claim owner local profile",
+			session: session("1", "ViewerName"),
+			user:    identity,
+			want:    false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := sessionOwnedByCurrentUser(test.session, test.user, test.serverOwner); got != test.want {
+				t.Fatalf("ownership = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
 // ---------------------------------------------------------------------------
 // FFmpeg KwArgs mapping behavior tests
 // ---------------------------------------------------------------------------

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -41,7 +41,10 @@
   background-clip: text;
 }
 
-/* Workspace grid */
+/* Workspace grid. grid-template-columns is animatable in Chromium 111+; in
+   browsers without it, the grid snaps while the container width and gap ease
+   the rest of the geometry — a graceful progressive enhancement. The shared
+   cubic-bezier matches the orchestrated cs-rise reveal for a cohesive feel. */
 .cs-workspace {
   display: grid;
   gap: 20px;
@@ -49,6 +52,15 @@
   width: 100%;
   position: relative;
   z-index: 2;
+  transition: grid-template-columns 320ms cubic-bezier(0.2, 0.7, 0.2, 1),
+              gap 320ms cubic-bezier(0.2, 0.7, 0.2, 1);
+}
+
+/* Main container widens (lg → xl) when theater mode is on. Transitioning
+   max-width lets the whole workspace "breathe" outward in sync with the grid
+   collapse instead of snapping to the wider breakpoint. */
+.cs-main-container {
+  transition: max-width 320ms cubic-bezier(0.2, 0.7, 0.2, 1);
 }
 
 @media (min-width: 960px) {
@@ -56,9 +68,44 @@
     grid-template-columns: minmax(0, 1.45fr) minmax(360px, 1fr);
     align-items: start;
   }
+  /* Theater mode: collapse to a single full-width column so the preview rail
+     (player + trim + render) sits on top and the subtitle panel drops beneath
+     it — a wider, more immersive preview like YouTube theater mode. */
+  .cs-workspace--theater {
+    grid-template-columns: minmax(0, 1fr);
+  }
 }
 
-/* Player frame with cinematic letterbox bars */
+/* Subtitle reflow softening. When theater mode engages, the subtitle rail
+   drops from the right column to beneath the preview. A short, translate-only
+   settle gives the repositioning a sense of weight without ever hiding content
+   (no opacity change) — keeping it readable for low-vision users. The class is
+   applied once on toggle, so the animation runs a single time. */
+@keyframes cs-theater-subtitle-settle {
+  from { transform: translateY(10px); }
+  to   { transform: translateY(0); }
+}
+@media (min-width: 960px) {
+  .cs-workspace--theater .cs-workspace-subtitles {
+    animation: cs-theater-subtitle-settle 260ms cubic-bezier(0.2, 0.7, 0.2, 1) both;
+  }
+}
+
+/* Player toolbar hosts the theater-mode toggle above the preview frame. */
+.cs-player-toolbar {
+  min-height: 32px;
+}
+
+/* Theater toggle pill — accent fill reads as "on" at a glance. */
+.cs-theater-toggle {
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  text-transform: none;
+}
+
+/* Player frame with cinematic letterbox bars. border-radius and box-shadow
+   transition so entering theater mode deepens the frame's presence alongside
+   the geometry change. */
 .cs-player-frame {
   position: relative;
   width: 100%;
@@ -68,7 +115,19 @@
   overflow: hidden;
   border: 1px solid rgba(255,255,255,0.07);
   box-shadow: 0 24px 60px -28px rgba(0,0,0,0.8);
-  transition: border-color 300ms ease;
+  transition: border-color 300ms ease,
+              border-radius 320ms cubic-bezier(0.2, 0.7, 0.2, 1),
+              box-shadow 320ms cubic-bezier(0.2, 0.7, 0.2, 1);
+}
+
+/* Theater mode deepens the frame: a touch more rounding and a wider, darker
+   shadow so the widened preview reads as more cinematic, not just larger. */
+@media (min-width: 960px) {
+  .cs-workspace--theater .cs-player-frame {
+    border-radius: 16px;
+    box-shadow: 0 34px 84px -32px rgba(0,0,0,0.86),
+                0 0 0 1px rgba(255,115,0,0.06);
+  }
 }
 
 .cs-player-frame::before,
@@ -103,6 +162,12 @@
 
 @media (prefers-reduced-motion: reduce) {
   .cs-player-frame[data-stale="true"] { animation: none; }
+  /* Theater mode geometry changes resolve instantly — no width/grid/gap easing
+     and no subtitle settle animation. Content stays fully readable throughout. */
+  .cs-workspace,
+  .cs-main-container,
+  .cs-player-frame { transition: none; }
+  .cs-workspace--theater .cs-workspace-subtitles { animation: none; }
 }
 
 /* Preview button overlay on the player frame */

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -14,6 +14,7 @@ import {
 } from "./utils";
 
 const POLL_INTERVAL_MS = 2000
+const SESSION_REFRESH_INTERVAL_MS = 10000
 const MAX_NETWORK_RETRIES = 5
 const EXPIRY_TICK_MS = 1000
 
@@ -31,6 +32,13 @@ function App() {
   const [playerError, setPlayerError] = useState(false)
   const [previewStale, setPreviewStale] = useState(false)
   const [audioMode, setAudioMode] = useState(AUDIO_MODES.STANDARD)
+
+  // --- Theater mode ---
+  // Desktop-only view toggle: widens the preview rail (Container lg → xl) and
+  // collapses the workspace grid to a single column so subtitles drop beneath
+  // the player. Reset on session change alongside the other ephemeral
+  // workspace state for a predictable per-session default.
+  const [theaterMode, setTheaterMode] = useState(false)
 
   // --- Subtitle offset ---
   // Positive = subtitles appear later, negative = earlier. Retained across
@@ -72,6 +80,14 @@ function App() {
   const pollTimeoutRef = useRef(null)
   const networkRetryCountRef = useRef(0)
   const jobIdRef = useRef(null)
+  const sessionRefreshControllerRef = useRef(null)
+  const sessionRefreshTimeoutRef = useRef(null)
+  const sessionRefreshInFlightRef = useRef(false)
+  const sessionRefreshGenerationRef = useRef(0)
+  const sessionRefreshRequestRef = useRef(0)
+  const sessionRefreshActiveRef = useRef(false)
+  const sessionRefreshRunnerRef = useRef(null)
+  const sessionsHaveDataRef = useRef(false)
 
   // ---------------------------------------------------------------- render-job cleanup
   const stopPolling = useCallback(() => {
@@ -109,27 +125,108 @@ function App() {
   }, [])
 
   // ---------------------------------------------------------------- sessions
-  useEffect(() => {
-    let active = true
-    fetch('/sessions', {redirect: "manual"})
+  const [sessionsRetry, setSessionsRetry] = useState(0)
+  const [documentVisible, setDocumentVisible] = useState(() => document.visibilityState !== 'hidden')
+
+  const stopSessionRefresh = useCallback(() => {
+    sessionRefreshActiveRef.current = false
+    sessionRefreshGenerationRef.current += 1
+    if (sessionRefreshTimeoutRef.current) {
+      clearTimeout(sessionRefreshTimeoutRef.current)
+      sessionRefreshTimeoutRef.current = null
+    }
+    if (sessionRefreshControllerRef.current) {
+      sessionRefreshControllerRef.current.abort()
+      sessionRefreshControllerRef.current = null
+    }
+    sessionRefreshInFlightRef.current = false
+  }, [])
+
+  const scheduleSessionRefresh = useCallback(() => {
+    if (!sessionRefreshActiveRef.current || sessionRefreshInFlightRef.current || sessionRefreshTimeoutRef.current) return
+    sessionRefreshTimeoutRef.current = setTimeout(() => {
+      sessionRefreshTimeoutRef.current = null
+      sessionRefreshRunnerRef.current?.()
+    }, SESSION_REFRESH_INTERVAL_MS)
+  }, [])
+
+  const refreshSessions = useCallback(() => {
+    if (!sessionRefreshActiveRef.current || sessionRefreshInFlightRef.current) return
+
+    const generation = sessionRefreshGenerationRef.current
+    const requestId = sessionRefreshRequestRef.current + 1
+    sessionRefreshRequestRef.current = requestId
+    const controller = new AbortController()
+    sessionRefreshControllerRef.current = controller
+    sessionRefreshInFlightRef.current = true
+
+    const isCurrent = () => (
+      sessionRefreshActiveRef.current &&
+      sessionRefreshGenerationRef.current === generation &&
+      sessionRefreshRequestRef.current === requestId
+    )
+
+    fetch('/sessions', {redirect: "manual", signal: controller.signal})
       .then(response => {
-        if (response.type === "opaqueredirect") {
+        if (!isCurrent()) return undefined
+        if (response.type === "opaqueredirect" || response.status === 401 || response.status === 403) {
           setNeedsAuth(true)
-          return null
+          stopSessionRefresh()
+          return undefined
         }
         if (!response.ok) {
           throw new Error(`Error fetching sessions: ${response.status} ${response.statusText}`)
         }
         return response.json()
       })
-      .then(json => { if (active) setSessions(json || []) })
-      .catch(err => {
-        if (!active) return
-        console.error('Error fetching sessions:', err)
-        setSessionsError(err)
+      .then(json => {
+        if (!isCurrent() || json === undefined) return
+        sessionsHaveDataRef.current = true
+        setSessions(json || [])
+        setSessionsError(null)
       })
-    return () => { active = false }
+      .catch(err => {
+        if (!isCurrent() || isAbortError(err)) return
+        console.error('Error refreshing sessions:', err)
+        // Refresh failures retain the last good picker data. Only the initial
+        // load uses the error state so the existing retry UX remains intact.
+        if (!sessionsHaveDataRef.current) setSessionsError(err)
+      })
+      .finally(() => {
+        if (sessionRefreshGenerationRef.current !== generation || sessionRefreshRequestRef.current !== requestId) return
+        sessionRefreshInFlightRef.current = false
+        if (sessionRefreshControllerRef.current === controller) sessionRefreshControllerRef.current = null
+        scheduleSessionRefresh()
+      })
+  }, [scheduleSessionRefresh, stopSessionRefresh])
+
+  sessionRefreshRunnerRef.current = refreshSessions
+
+  useEffect(() => {
+    const handleVisibilityChange = () => setDocumentVisible(document.visibilityState !== 'hidden')
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+    return () => document.removeEventListener('visibilitychange', handleVisibilityChange)
   }, [])
+
+  useEffect(() => {
+    const pickerVisible = !selectedSession && !needsAuth && documentVisible
+    if (!pickerVisible) {
+      stopSessionRefresh()
+      return undefined
+    }
+
+    sessionRefreshActiveRef.current = true
+    refreshSessions()
+    return stopSessionRefresh
+  }, [documentVisible, needsAuth, refreshSessions, selectedSession, sessionsRetry, stopSessionRefresh])
+
+  const retrySessions = useCallback(() => {
+    stopSessionRefresh()
+    sessionsHaveDataRef.current = false
+    setSessionsError(null)
+    setSessions(null)
+    setSessionsRetry(n => n + 1)
+  }, [stopSessionRefresh])
 
   // ---------------------------------------------------------------- player URL builder
   const setPlayerPosition = useCallback((start, end, subtitleOverride = selectedSubtitle, audioModeOverride = audioMode, offsetOverride = subtitleOffsetMs) => {
@@ -689,6 +786,7 @@ function App() {
     sessionAbortControllerRef.current?.abort()
     sessionGenerationRef.current += 1
     stopPolling()
+    stopSessionRefresh()
     setSelectedSession(null)
     setPlayerUrl(null)
     playerReadyRef.current = false
@@ -712,13 +810,22 @@ function App() {
     setEndPosition(null)
     setAudioMode(AUDIO_MODES.STANDARD)
     setSubtitleOffsetMs(0)
+    setTheaterMode(false)
     setTrimFlashKey(0)
-  }, [jobIsActive, stopPolling])
+  }, [jobIsActive, stopPolling, stopSessionRefresh])
+
+  const handleSelectSession = useCallback((session) => {
+    stopSessionRefresh()
+    setSelectedSession(session)
+  }, [stopSessionRefresh])
 
   // ---------------------------------------------------------------- cleanup on unmount
   useEffect(() => {
-    return () => stopPolling()
-  }, [stopPolling])
+    return () => {
+      stopPolling()
+      stopSessionRefresh()
+    }
+  }, [stopPolling, stopSessionRefresh])
 
   // ---------------------------------------------------------------- render
   const sessionsLoading = sessions === null && !sessionsError && !needsAuth
@@ -741,24 +848,12 @@ function App() {
               </Typography>
             </Box>
             <Box sx={{flex: 1}}/>
-            {selectedSession && (
-              <Button
-                variant="outlined"
-                size="small"
-                onClick={handleChangeSession}
-                disabled={jobIsActive}
-                title={jobIsActive ? changeSessionDisabledReason : ''}
-                sx={{borderColor: 'rgba(255,255,255,0.2)'}}
-              >
-                Change session
-              </Button>
-            )}
           </Toolbar>
         </Container>
       </Box>
 
       <Box component="main" sx={{flex: 1, py: {xs: 2, md: 3}, position: 'relative', zIndex: 2}}>
-        <Container maxWidth="lg">
+        <Container className="cs-main-container" maxWidth={selectedSession && theaterMode ? 'xl' : 'lg'}>
           {needsAuth ? (
             <Stack spacing={2} alignItems="center" className="cs-rise" sx={{py: 5, textAlign: 'center'}}>
               <Typography variant="h4">Connect CutScene to Plex</Typography>
@@ -785,7 +880,8 @@ function App() {
                 loading={sessionsLoading}
                 error={sessionsError}
                 selectedKey={selectedSession?.ratingKey}
-                onSelect={setSelectedSession}
+                onSelect={handleSelectSession}
+                onRetry={retrySessions}
               />
             </Stack>
           ) : (
@@ -815,6 +911,8 @@ function App() {
               onCreateNewJob={() => createRenderJob()}
               audioMode={audioMode}
               onAudioModeChange={setAudioMode}
+              theaterMode={theaterMode}
+              onToggleTheater={() => setTheaterMode(mode => !mode)}
               subtitleOffsetMs={subtitleOffsetMs}
               onSubtitleOffsetChange={setSubtitleOffsetMs}
               subtitle={selectedSubtitle}

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -60,6 +60,19 @@ function installFetch(sessionsResponse = response(sessions)) {
   return pending;
 }
 
+function installTrackedSessionsFetch() {
+  const sessionRequests = [];
+  const pending = [];
+  global.fetch = jest.fn((url, options = {}) => {
+    const request = deferred();
+    const tracked = {url, options, ...request};
+    if (url === '/sessions') sessionRequests.push(tracked);
+    else pending.push(tracked);
+    return request.promise;
+  });
+  return {sessionRequests, pending};
+}
+
 async function flush() {
   await act(async () => {
     await Promise.resolve();
@@ -99,6 +112,15 @@ async function advancePolling(ms = 2000) {
   await act(async () => {
     jest.advanceTimersByTime(ms);
     await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+async function setDocumentVisibility(state) {
+  Object.defineProperty(document, 'visibilityState', {configurable: true, value: state});
+  await act(async () => {
+    document.dispatchEvent(new Event('visibilitychange'));
     await Promise.resolve();
     await Promise.resolve();
   });
@@ -169,6 +191,7 @@ function textStreams() {
 afterEach(() => {
   jest.useRealTimers();
   jest.restoreAllMocks();
+  Object.defineProperty(document, 'visibilityState', {configurable: true, value: 'visible'});
   mockPlayerUrls.length = 0;
 });
 
@@ -707,6 +730,296 @@ test('session loading exposes a live status message', async () => {
   expect(screen.getByText('Alpha')).toBeInTheDocument();
 });
 
+test('sessions owned by the current user are highlighted with a Your session badge', async () => {
+  const ownedSessions = [
+    {
+      ratingKey: 'A', type: 'movie', title: 'Alpha', year: 2024, viewOffset: 0, duration: 120000,
+      User: {title: 'viewer'}, Media: [{Part: [{id: '101'}]}],
+      ownedByCurrentUser: true,
+    },
+    {
+      ratingKey: 'B', type: 'movie', title: 'Beta', year: 2024, viewOffset: 5000, duration: 120000,
+      User: {title: 'someone else'}, Media: [{Part: [{id: '202'}]}],
+      ownedByCurrentUser: false,
+    },
+    {
+      ratingKey: 'C', type: 'movie', title: 'Gamma', year: 2024, viewOffset: 0, duration: 120000,
+      User: {title: 'viewer'}, Media: [{Part: [{id: '303'}]}],
+      // ownedByCurrentUser omitted → treated as not owned (graceful default).
+    },
+  ];
+  installFetch(response(ownedSessions));
+  render(<App/>);
+  await flush();
+
+  // The owned card carries the visible "Your session" badge and a data hook.
+  const alphaCard = screen.getByRole('button', {name: /Your session.*Alpha/});
+  expect(alphaCard).toHaveTextContent('Your session');
+  expect(alphaCard).toHaveAttribute('data-owned', 'true');
+
+  // Explicitly-not-owned card: no badge, no data hook.
+  const betaCard = screen.getByRole('button', {name: /Beta/});
+  expect(betaCard).not.toHaveTextContent('Your session');
+  expect(betaCard).not.toHaveAttribute('data-owned');
+
+  // Field omitted entirely: treated as not owned — no badge.
+  const gammaCard = screen.getByRole('button', {name: /Gamma/});
+  expect(gammaCard).not.toHaveTextContent('Your session');
+  expect(gammaCard).not.toHaveAttribute('data-owned');
+
+  // Exactly one badge across the picker.
+  expect(screen.getAllByText('Your session')).toHaveLength(1);
+});
+
+test('session cards surface existing metadata: progress, player state, resolution, audio, location', async () => {
+  const richSessions = [
+    {
+      ratingKey: 'A', type: 'episode',
+      grandparentTitle: 'The Show', parentIndex: 2, index: 7, title: 'A Long Descriptive Episode Title',
+      year: 2024, viewOffset: 1500000, duration: 3000000,
+      thumb: '/thumb/A', User: {title: 'viewer'}, Media: [{Part: [{id: '101'}], videoResolution: '1080', audioChannels: 6}],
+      Player: {title: 'Plex Web (Chrome)', state: 'playing'},
+      Session: {location: 'lan'},
+      ownedByCurrentUser: true,
+    },
+    {
+      ratingKey: 'B', type: 'movie', title: 'Beta', year: 2023, viewOffset: 0, duration: 5400000,
+      thumb: '/thumb/B', User: {title: 'someone else'}, Media: [{Part: [{id: '202'}], videoResolution: '4k', audioChannels: 8}],
+      Player: {title: 'Apple TV', state: 'paused'},
+      Session: {location: 'wan'},
+      ownedByCurrentUser: false,
+    },
+    {
+      ratingKey: 'C', type: 'movie', title: 'Gamma', year: 2022, viewOffset: 0, duration: 3600000,
+      thumb: '/thumb/C', User: {title: 'viewer'}, Media: [{Part: [{id: '303'}]}],
+      // No Player / Session.location, minimal Media — quality + footer gracefully absent.
+    },
+  ];
+  installFetch(response(richSessions));
+  render(<App/>);
+  await flush();
+
+  // Alpha — episode primary is the show title; secondary is S02E07 + episode title.
+  const alphaCard = screen.getByRole('button', {name: /Your session.*The Show/});
+  expect(alphaCard).toHaveTextContent('The Show');
+  expect(alphaCard).toHaveTextContent('S02E07 A Long Descriptive Episode Title');
+  // Progress (viewOffset 1,500,000ms / duration 3,000,000ms → 50%).
+  expect(alphaCard).toHaveTextContent('00:25:00');
+  expect(alphaCard).toHaveTextContent('00:50:00');
+  // Player state dot label.
+  expect(alphaCard).toHaveTextContent('Playing');
+  // Quality accent pill — resolution + audio combined.
+  expect(alphaCard).toHaveTextContent('1080 · 5.1');
+  // Footer — device + location. The user ('viewer') is omitted on owned cards
+  // because the "Your session" badge already conveys ownership.
+  expect(alphaCard).toHaveTextContent('Plex Web (Chrome)');
+  expect(alphaCard).toHaveTextContent('Local');
+  expect(alphaCard).not.toHaveTextContent('viewer');
+
+  // Beta — paused, 4k/7.1, remote, not owned.
+  const betaCard = screen.getByRole('button', {name: /Beta/});
+  expect(betaCard).toHaveTextContent('Paused');
+  expect(betaCard).toHaveTextContent('4K · 7.1');
+  // Footer includes the user (not owned), device, and location.
+  expect(betaCard).toHaveTextContent('someone else');
+  expect(betaCard).toHaveTextContent('Apple TV');
+  expect(betaCard).toHaveTextContent('Remote');
+  // Not owned → no badge.
+  expect(betaCard).not.toHaveTextContent('Your session');
+
+  // Gamma — minimal metadata: no player-state label, no quality pill, no footer.
+  const gammaCard = screen.getByRole('button', {name: /Gamma/});
+  expect(gammaCard).not.toHaveTextContent('Playing');
+  expect(gammaCard).not.toHaveTextContent('Paused');
+  expect(gammaCard).not.toHaveTextContent('Local');
+  expect(gammaCard).not.toHaveTextContent('Remote');
+  expect(gammaCard).not.toHaveTextContent('Your session');
+  expect(gammaCard).not.toHaveTextContent('·');
+  // Duration still surfaces as the upper bound.
+  expect(gammaCard).toHaveTextContent('01:00:00');
+});
+
+test('episode cards fall back to the show poster when the episode has no thumbnail', async () => {
+  const noThumbSessions = [
+    {
+      ratingKey: 'A', type: 'episode',
+      grandparentTitle: 'The Show', parentIndex: 1, index: 1, title: 'Pilot',
+      viewOffset: 0, duration: 1200000,
+      // No thumb; grandparentThumb should be used instead.
+      grandparentThumb: '/show/poster',
+      User: {title: 'viewer'}, Media: [{Part: [{id: '101'}]}],
+      ownedByCurrentUser: true,
+    },
+    {
+      ratingKey: 'B', type: 'movie', title: 'NoArt Movie', year: 2024, viewOffset: 0, duration: 1200000,
+      // Neither thumb nor grandparentThumb → placeholder, no broken image request.
+      User: {title: 'viewer'}, Media: [{Part: [{id: '202'}]}],
+    },
+  ];
+  installFetch(response(noThumbSessions));
+  render(<App/>);
+  await flush();
+
+  // Episode card uses the show poster URL.
+  const episodeCard = screen.getByRole('button', {name: /Your session.*The Show/});
+  const episodeImg = episodeCard.querySelector('img');
+  expect(episodeImg).not.toBeNull();
+  expect(episodeImg.getAttribute('src')).toBe('/thumb?path=/show/poster');
+
+  // Movie with no artwork renders a placeholder and no <img> at all.
+  const movieCard = screen.getByRole('button', {name: /NoArt Movie/});
+  expect(movieCard.querySelector('img')).toBeNull();
+  // The placeholder SVG is present.
+  expect(movieCard.querySelector('svg')).not.toBeNull();
+});
+
+test('owned sessions sort first while preserving original relative order within each group', async () => {
+  // Mix owned and non-owned in a scrambled order; each group keeps its
+  // original relative order after the stable partition.
+  const mixedSessions = [
+    {ratingKey: 'N1', type: 'movie', title: 'Non-A', year: 2024, viewOffset: 0, duration: 60000,
+      User: {title: 'x'}, Media: [{Part: [{id: '1'}]}], ownedByCurrentUser: false},
+    {ratingKey: 'O1', type: 'movie', title: 'Own-A', year: 2024, viewOffset: 0, duration: 60000,
+      User: {title: 'me'}, Media: [{Part: [{id: '2'}]}], ownedByCurrentUser: true},
+    {ratingKey: 'N2', type: 'movie', title: 'Non-B', year: 2024, viewOffset: 0, duration: 60000,
+      User: {title: 'y'}, Media: [{Part: [{id: '3'}]}], ownedByCurrentUser: false},
+    {ratingKey: 'O2', type: 'movie', title: 'Own-B', year: 2024, viewOffset: 0, duration: 60000,
+      User: {title: 'me'}, Media: [{Part: [{id: '4'}]}], ownedByCurrentUser: true},
+    {ratingKey: 'N3', type: 'movie', title: 'Non-C', year: 2024, viewOffset: 0, duration: 60000,
+      User: {title: 'z'}, Media: [{Part: [{id: '5'}]}], ownedByCurrentUser: false},
+  ];
+  installFetch(response(mixedSessions));
+  render(<App/>);
+  await flush();
+
+  // The cards render in DOM order. Owned cards (O1, O2) come first, preserving
+  // their original relative order; non-owned (N1, N2, N3) follow, also in
+  // their original relative order.
+  const cards = screen.getAllByRole('button');
+  const cardTitles = cards.map(card => card.textContent);
+  const indexOf = title => cardTitles.findIndex(t => t.includes(title));
+  const o1 = indexOf('Own-A');
+  const o2 = indexOf('Own-B');
+  const n1 = indexOf('Non-A');
+  const n2 = indexOf('Non-B');
+  const n3 = indexOf('Non-C');
+
+  // All found.
+  [o1, o2, n1, n2, n3].forEach(i => expect(i).toBeGreaterThanOrEqual(0));
+
+  // Owned group leads, in original relative order.
+  expect(o1).toBeLessThan(o2);
+  expect(o2).toBeLessThan(n1);
+
+  // Non-owned group preserves original relative order.
+  expect(n1).toBeLessThan(n2);
+  expect(n2).toBeLessThan(n3);
+});
+
+test('sessions error state offers a retry that re-fetches the sessions list', async () => {
+  const failing = jest.fn(() => Promise.reject(new Error('boom')));
+  global.fetch = jest.fn((url) => {
+    if (url === '/sessions') return failing();
+    return Promise.resolve(response([]));
+  });
+  render(<App/>);
+  await flush();
+
+  expect(screen.getByText(/Couldn’t load your Plex sessions/)).toBeInTheDocument();
+  const retryButton = screen.getByRole('button', {name: 'Try again'});
+  expect(retryButton).toBeInTheDocument();
+
+  // First fetch failed; retry re-fetches.
+  expect(failing).toHaveBeenCalledTimes(1);
+  fireEvent.click(retryButton);
+  await flush();
+  expect(failing).toHaveBeenCalledTimes(2);
+});
+
+test('refreshes sessions on a ten-second picker cadence and restarts immediately on return', async () => {
+  jest.useFakeTimers();
+  const {sessionRequests} = installTrackedSessionsFetch();
+  render(<App/>);
+
+  expect(sessionRequests).toHaveLength(1);
+  await resolveRequest(sessionRequests[0], sessions);
+  await advancePolling(9999);
+  expect(sessionRequests).toHaveLength(1);
+  await advancePolling(1);
+  expect(sessionRequests).toHaveLength(2);
+
+  await resolveRequest(sessionRequests[1], sessions);
+  await advancePolling(10000);
+  expect(sessionRequests).toHaveLength(3);
+  // A refresh already in flight is aborted before opening the workspace.
+  await selectSession('Alpha');
+  expect(sessionRequests[2].options.signal.aborted).toBe(true);
+
+  await changeSession();
+  expect(sessionRequests).toHaveLength(4);
+});
+
+test('visibility pauses and aborts refreshes, then performs an immediate refresh when visible', async () => {
+  jest.useFakeTimers();
+  const {sessionRequests} = installTrackedSessionsFetch();
+  render(<App/>);
+  await resolveRequest(sessionRequests[0], sessions);
+
+  await advancePolling(10000);
+  expect(sessionRequests).toHaveLength(2);
+  await setDocumentVisibility('hidden');
+  expect(sessionRequests[1].options.signal.aborted).toBe(true);
+  await advancePolling(20000);
+  expect(sessionRequests).toHaveLength(2);
+
+  await setDocumentVisibility('visible');
+  expect(sessionRequests).toHaveLength(3);
+});
+
+test('transient refresh failures retain the last good sessions and retry on the next tick', async () => {
+  jest.useFakeTimers();
+  const {sessionRequests} = installTrackedSessionsFetch();
+  render(<App/>);
+  await resolveRequest(sessionRequests[0], sessions);
+
+  await advancePolling(10000);
+  await rejectRequest(sessionRequests[1]);
+  expect(screen.getByText('Alpha')).toBeInTheDocument();
+  expect(screen.queryByText(/Couldn’t load your Plex sessions/)).not.toBeInTheDocument();
+
+  await advancePolling(10000);
+  expect(sessionRequests).toHaveLength(3);
+});
+
+test('auth responses stop session refresh and show the login state', async () => {
+  jest.useFakeTimers();
+  const {sessionRequests} = installTrackedSessionsFetch();
+  render(<App/>);
+  await resolveRequest(sessionRequests[0], sessions);
+  await advancePolling(10000);
+  await resolveRequestWith(sessionRequests[1], null, {ok: false, status: 401, statusText: 'Unauthorized'});
+
+  expect(screen.getByRole('link', {name: 'Log in with Plex'})).toBeInTheDocument();
+  await advancePolling(30000);
+  expect(sessionRequests).toHaveLength(2);
+});
+
+test('stale refresh results cannot replace sessions after selection', async () => {
+  jest.useFakeTimers();
+  const {sessionRequests} = installTrackedSessionsFetch();
+  render(<App/>);
+  await resolveRequest(sessionRequests[0], sessions);
+  await advancePolling(10000);
+  const stale = [{...sessions[0], title: 'Stale session'}];
+
+  await selectSession('Alpha');
+  await resolveRequest(sessionRequests[1], stale);
+  await changeSession();
+
+  expect(screen.getByText('Alpha')).toBeInTheDocument();
+  expect(screen.queryByText('Stale session')).not.toBeInTheDocument();
+});
+
 test('streams loading is shown before the empty-stream state', async () => {
   const pending = installFetch();
   render(<App/>);
@@ -1101,7 +1414,7 @@ test('active render jobs constrain session changes and keep polling alive', asyn
   await resolveRequest(poll, {id: 'job-session', status: 'running'});
 
   const changeButtons = screen.getAllByRole('button', {name: 'Change session'});
-  expect(changeButtons).toHaveLength(2);
+  expect(changeButtons).toHaveLength(1);
   changeButtons.forEach(button => {
     expect(button).toBeDisabled();
     expect(button).toHaveAttribute(
@@ -1198,4 +1511,107 @@ test('session context shows the active session title in the workspace', async ()
 
   expect(screen.getByText('Now clipping')).toBeInTheDocument();
   expect(screen.getByText('Alpha')).toBeInTheDocument();
+});
+
+// ---------------------------------------------------------------------------
+// Theater mode — desktop-only preview toggle (mobile stays single-column).
+// ---------------------------------------------------------------------------
+
+async function openWorkspaceWithStreams() {
+  const pending = installFetch();
+  render(<App/>);
+  await flush();
+  await selectSession('Alpha');
+  await resolveRequest(requestFor(pending, url => url === '/streams/A?mediaId=101'), textStreams());
+  return pending;
+}
+
+test('theater toggle is rendered near the preview with an accessible pressed state', async () => {
+  await openWorkspaceWithStreams();
+
+  const toggle = screen.getByRole('button', {name: 'Theater mode'});
+  expect(toggle).toBeInTheDocument();
+  // Off by default — aria-pressed communicates state to assistive tech.
+  expect(toggle).toHaveAttribute('aria-pressed', 'false');
+  expect(toggle).toHaveTextContent('Theater mode');
+});
+
+test('clicking the theater toggle flips state, label, and the workspace modifier class', async () => {
+  await openWorkspaceWithStreams();
+
+  const toggle = screen.getByRole('button', {name: 'Theater mode'});
+  // Workspace starts in the normal two-pane layout.
+  expect(document.querySelector('.cs-workspace')).not.toHaveClass('cs-workspace--theater');
+
+  fireEvent.click(toggle);
+  await flush();
+
+  // On: pressed, relabeled, and the workspace grid collapses to one column.
+  expect(toggle).toHaveAttribute('aria-pressed', 'true');
+  expect(toggle).toHaveTextContent('Default view');
+  expect(document.querySelector('.cs-workspace')).toHaveClass('cs-workspace--theater');
+
+  // Toggling back restores the normal layout and the original label.
+  fireEvent.click(toggle);
+  await flush();
+  expect(toggle).toHaveAttribute('aria-pressed', 'false');
+  expect(toggle).toHaveTextContent('Theater mode');
+  expect(document.querySelector('.cs-workspace')).not.toHaveClass('cs-workspace--theater');
+});
+
+test('theater mode preserves trim, render, and subtitle controls in the DOM', async () => {
+  await openWorkspaceWithStreams();
+
+  fireEvent.click(screen.getByRole('button', {name: 'Theater mode'}));
+  await flush();
+
+  // Trim controls remain available.
+  expect(screen.getByRole('textbox', {name: 'Start time as hours minutes seconds milliseconds'})).toBeInTheDocument();
+  expect(screen.getByRole('textbox', {name: 'End time as hours minutes seconds milliseconds'})).toBeInTheDocument();
+  // Render controls remain available.
+  expect(screen.getByRole('button', {name: 'Render clip'})).toBeInTheDocument();
+  // Subtitle panel remains available beneath the preview.
+  expect(screen.getByRole('combobox', {name: 'Subtitle track'})).toBeInTheDocument();
+  expect(screen.getByText('Subtitles')).toBeInTheDocument();
+});
+
+test('theater mode does not alter the preview URL or trigger a render request', async () => {
+  const pending = await openWorkspaceWithStreams();
+  const playerUrlBefore = screen.getByTestId('react-player').getAttribute('data-url');
+  const renderRequestsBefore = pending.filter(r => r.url === '/render-jobs').length;
+
+  fireEvent.click(screen.getByRole('button', {name: 'Theater mode'}));
+  await flush();
+
+  expect(screen.getByTestId('react-player').getAttribute('data-url')).toBe(playerUrlBefore);
+  expect(pending.filter(r => r.url === '/render-jobs').length).toBe(renderRequestsBefore);
+});
+
+test('changing sessions resets theater mode to its default off state', async () => {
+  const pending = await openWorkspaceWithStreams();
+
+  fireEvent.click(screen.getByRole('button', {name: 'Theater mode'}));
+  await flush();
+  expect(document.querySelector('.cs-workspace')).toHaveClass('cs-workspace--theater');
+
+  await changeSession();
+  // Theater toggle is gone while the picker is showing.
+  expect(screen.queryByRole('button', {name: 'Theater mode'})).not.toBeInTheDocument();
+
+  await selectSession('Beta');
+  await resolveRequest(requestFor(pending, url => url === '/streams/B?mediaId=202'), textStreams());
+
+  // New session opens in the normal two-pane layout with the toggle off.
+  expect(document.querySelector('.cs-workspace')).not.toHaveClass('cs-workspace--theater');
+  const toggle = screen.getByRole('button', {name: 'Theater mode'});
+  expect(toggle).toHaveAttribute('aria-pressed', 'false');
+  expect(toggle).toHaveTextContent('Theater mode');
+});
+
+test('theater toggle is not rendered before a session is selected', async () => {
+  installFetch();
+  render(<App/>);
+  await flush();
+
+  expect(screen.queryByRole('button', {name: 'Theater mode'})).not.toBeInTheDocument();
 });

--- a/frontend/src/components/ClipWorkspace.js
+++ b/frontend/src/components/ClipWorkspace.js
@@ -6,7 +6,9 @@ import SubtitlePanel from "./SubtitlePanel";
 import RenderJobBar from "./RenderJobBar";
 
 // Two-pane workspace shell. CSS grid (.cs-workspace) reflows to one column
-// below 960px — no duplicate DOM trees per breakpoint.
+// below 960px — no duplicate DOM trees per breakpoint. Theater mode collapses
+// the desktop grid to a single full-width column (preview rail on top,
+// subtitles beneath) for an immersive preview, mirroring YouTube theater mode.
 export default function ClipWorkspace({
   session, playerUrl, onPlayerError, onPlayerReady,
   previewStale, onApplyPreview,
@@ -16,7 +18,8 @@ export default function ClipWorkspace({
   onChangeSession, changeSessionDisabled, changeSessionDisabledReason,
   renderState, jobSpec, controlsChangedSinceJob,
   onCreateJob, onDownloadJob, onRetryJob, onRetryPoll, onCreateNewJob,
-audioMode, onAudioModeChange,
+  audioMode, onAudioModeChange,
+  theaterMode, onToggleTheater,
               subtitleOffsetMs, onSubtitleOffsetChange,
               subtitle, ...subProps
             }) {
@@ -28,8 +31,8 @@ audioMode, onAudioModeChange,
         changeDisabled={changeSessionDisabled}
         changeDisabledReason={changeSessionDisabledReason}
       />
-      <Box className="cs-workspace">
-        {/* Left: player + trim */}
+      <Box className={`cs-workspace${theaterMode ? ' cs-workspace--theater' : ''}`}>
+        {/* Left: player + trim + render controls */}
         <Box sx={{display: 'flex', flexDirection: 'column', minWidth: 0}}>
           <PlayerPane
             playerUrl={playerUrl}
@@ -37,6 +40,8 @@ audioMode, onAudioModeChange,
             onReady={onPlayerReady}
             previewStale={previewStale}
             onApplyPreview={onApplyPreview}
+            theaterMode={theaterMode}
+            onToggleTheater={onToggleTheater}
           />
           <TrimScrubber
             duration={session.duration}
@@ -47,10 +52,27 @@ audioMode, onAudioModeChange,
             onEndChange={onEndChange}
             trimFlashKey={trimFlashKey}
           />
+          {/* Render job / status / controls live directly under the video and
+              trim times so the whole left rail reads as the "clip" workflow. */}
+          <RenderJobBar
+            startPosition={startPosition}
+            endPosition={endPosition}
+            selectedSubtitle={subtitle}
+            audioMode={audioMode}
+            onAudioModeChange={onAudioModeChange}
+            renderState={renderState}
+            jobSpec={jobSpec}
+            controlsChangedSinceJob={controlsChangedSinceJob}
+            onCreateJob={onCreateJob}
+            onDownload={onDownloadJob}
+            onRetry={onRetryJob}
+            onRetryPoll={onRetryPoll}
+            onCreateNew={onCreateNewJob}
+          />
         </Box>
 
-        {/* Right: subtitle panel + render job */}
-        <Box sx={{display: 'flex', flexDirection: 'column', minWidth: 0, gap: 2}}>
+        {/* Right: subtitle panel */}
+        <Box className="cs-workspace-subtitles" sx={{display: 'flex', flexDirection: 'column', minWidth: 0}}>
           <Paper
             variant="outlined"
             sx={{
@@ -73,21 +95,6 @@ audioMode, onAudioModeChange,
               />
             </Box>
           </Paper>
-          <RenderJobBar
-            startPosition={startPosition}
-            endPosition={endPosition}
-            selectedSubtitle={subtitle}
-            audioMode={audioMode}
-            onAudioModeChange={onAudioModeChange}
-            renderState={renderState}
-            jobSpec={jobSpec}
-            controlsChangedSinceJob={controlsChangedSinceJob}
-            onCreateJob={onCreateJob}
-            onDownload={onDownloadJob}
-            onRetry={onRetryJob}
-            onRetryPoll={onRetryPoll}
-            onCreateNew={onCreateNewJob}
-          />
         </Box>
       </Box>
     </>

--- a/frontend/src/components/PlayerPane.js
+++ b/frontend/src/components/PlayerPane.js
@@ -1,13 +1,78 @@
-import {Box, Button, Typography} from "@mui/material";
+import {Box, Button, Tooltip, Typography} from "@mui/material";
 import ReactPlayer from "react-player";
+
+// Theater-mode glyph — a widescreen rectangle with side bars. Inline SVG keeps
+// the control dependency-free, matching SubtitleOffsetControl's hand-rolled
+// icons. Filled variant reads as "active" when theater mode is on.
+function TheaterIcon({active, ...props}) {
+  return (
+    <svg viewBox="0 0 24 24" width="1em" height="1em" fill="none"
+      stroke="currentColor" strokeWidth="2" strokeLinecap="round"
+      strokeLinejoin="round" {...props}>
+      <rect x="2.5" y="6" width="19" height="12" rx="2.5"/>
+      {active
+        ? <path d="M6 9.5h12v5H6z" fill="currentColor" stroke="none"/>
+        : <path d="M6 9.5h12v5H6z"/>}
+    </svg>
+  )
+}
 
 // Player pane. Receives the preview URL and surfaces load errors via onError.
 // Responsive via CSS aspect-ratio container — no duplicate DOM per breakpoint.
 // When previewStale is true, shows a "Preview selection" button overlay so the
 // user controls when the player reloads, preventing jank during trim editing.
-export default function PlayerPane({playerUrl, onError, onReady, previewStale, onApplyPreview}) {
+//
+// Theater mode is a desktop-only view toggle (mobile is already single-column).
+// It widens the preview rail and drops the subtitle panel beneath it; the
+// toggle sits in a thin toolbar above the player frame so it never collides
+// with the stale-preview overlay. aria-pressed carries the on/off state for
+// assistive tech while the visible label flips between Theater/Default.
+export default function PlayerPane({
+  playerUrl, onError, onReady, previewStale, onApplyPreview,
+  theaterMode, onToggleTheater,
+}) {
+  const theaterOn = !!theaterMode
   return (
     <Box className="cs-rise">
+      <Box
+        className="cs-player-toolbar"
+        sx={{display: {xs: 'none', md: 'flex'}, justifyContent: 'flex-end', mb: 1, gap: 1}}
+      >
+        <Tooltip
+          title={theaterOn
+            ? 'Exit theater mode — show subtitles beside the preview'
+            : 'Enter theater mode — widen the preview and move subtitles below'}
+          placement="bottom"
+        >
+          <Button
+            size="small"
+            variant="text"
+            onClick={onToggleTheater}
+            aria-label="Theater mode"
+            aria-pressed={theaterOn ? 'true' : 'false'}
+            className="cs-theater-toggle"
+            startIcon={<TheaterIcon active={theaterOn} sx={{fontSize: 18}}/>}
+            sx={{
+              color: theaterOn ? '#ffd9b0' : 'text.secondary',
+              px: 1.25,
+              py: 0.25,
+              borderRadius: 999,
+              border: '1px solid',
+              borderColor: theaterOn ? 'rgba(255,115,0,0.45)' : 'rgba(255,255,255,0.12)',
+              backgroundColor: theaterOn ? 'rgba(255,115,0,0.10)' : 'transparent',
+              transition: 'border-color 160ms ease, background-color 160ms ease, color 160ms ease',
+              '&:hover': {
+                color: '#ffd9b0',
+                borderColor: 'rgba(255,115,0,0.45)',
+                backgroundColor: 'rgba(255,115,0,0.10)',
+              },
+              '&.Mui-focusVisible': {outline: '2px solid #ffd9b0', outlineOffset: 2},
+            }}
+          >
+            {theaterOn ? 'Default view' : 'Theater mode'}
+          </Button>
+        </Tooltip>
+      </Box>
       <Box className="cs-player-frame" data-stale={previewStale ? 'true' : undefined}>
         {playerUrl ? (
           <ReactPlayer

--- a/frontend/src/components/SessionPicker.js
+++ b/frontend/src/components/SessionPicker.js
@@ -1,4 +1,5 @@
-import {Box, Card, CardActionArea, CardContent, CardMedia, Grid, Typography} from "@mui/material";
+import {Box, Button, Card, CardActionArea, CardContent, CardMedia, Grid, LinearProgress, Typography} from "@mui/material";
+import {useMemo} from "react";
 import StateMessage from "./StateMessage";
 
 const visuallyHidden = {
@@ -30,7 +31,86 @@ function getVideoName(session) {
   return {top: `${session.title}`, bottom: session.year ? `(${session.year})` : ''}
 }
 
+// Map Plex player state → a colored status dot + short label. All states are
+// existing fields from the session API; nothing is invented.
+function getPlayerState(state) {
+  switch (state) {
+    case 'playing': return {color: '#7fd391', label: 'Playing'}
+    case 'paused': return {color: '#ffd9a0', label: 'Paused'}
+    case 'buffering': return {color: '#8fb8ff', label: 'Buffering'}
+    default: return null
+  }
+}
+
+// Audio channels → human layout. The API delivers a channel count; the 5.1/7.1
+// mapping is the standard industry convention (5.1 = 6 channels incl. LFE),
+// not an inferred detail. Defensive for missing/odd values.
+function audioLayoutLabel(channels) {
+  if (channels == null) return null
+  const n = Number(channels)
+  if (!Number.isFinite(n) || n <= 0) return null
+  if (n === 1) return '1.0'
+  if (n === 2) return '2.0'
+  if (n === 6) return '5.1'
+  if (n === 8) return '7.1'
+  return `${n}ch`
+}
+
+// Resolution → tidy uppercase chip text. Plex sends values like "4k", "1080",
+// "720", "sd". Uppercase the raw value; do not synthesize a "p" suffix since
+// the API does not distinguish interlaced vs progressive.
+function resolutionLabel(res) {
+  if (!res) return null
+  const s = String(res).trim()
+  return s ? s.toUpperCase() : null
+}
+
+// Combine resolution + audio layout into one compact quality summary, e.g.
+// "1080 · 5.1". Each part optional; returns null when neither is present so
+// the pill can be omitted entirely.
+function qualitySummary(res, audio) {
+  const parts = [res, audio].filter(Boolean)
+  return parts.length ? parts.join(' · ') : null
+}
+
+// Session.location ("lan" | "wan") → local/remote label.
+function locationLabel(loc) {
+  if (loc === 'lan') return 'Local'
+  if (loc === 'wan') return 'Remote'
+  return null
+}
+
+// Inline film placeholder — used when neither thumb nor grandparentThumb is
+// available, so the card never emits a broken image request.
+function FilmPlaceholder() {
+  return (
+    <Box sx={{
+      position: 'absolute', inset: 0, display: 'grid', placeItems: 'center',
+      background: 'linear-gradient(135deg, #1b1e26, #11141a)',
+    }}>
+      <svg viewBox="0 0 24 24" width="42" height="42" fill="none" stroke="rgba(255,255,255,0.18)"
+        strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+        <rect x="3" y="4" width="18" height="16" rx="2"/>
+        <path d="M3 9h18M3 15h18M8 4v16M16 4v16"/>
+      </svg>
+    </Box>
+  )
+}
+
 export default function SessionPicker({sessions, loading, error, selectedKey, onSelect, onRetry}) {
+  // Stable owned-first ordering: owned sessions surface first so the user's
+  // own sessions lead the scan, while the original relative order is preserved
+  // within each group (stable partition, no secondary sort key). This hook must
+  // run before every conditional return.
+  const orderedSessions = useMemo(() => {
+    if (!sessions) return sessions
+    return sessions.reduce((acc, session) => {
+      (session.ownedByCurrentUser === true ? acc.owned : acc.rest).push(session)
+      return acc
+    }, {owned: [], rest: []})
+  }, [sessions])
+  const sortedSessions = orderedSessions ? [...orderedSessions.owned, ...orderedSessions.rest] : orderedSessions
+
   if (loading) {
     return (
       <>
@@ -39,18 +119,25 @@ export default function SessionPicker({sessions, loading, error, selectedKey, on
         </Box>
         <Grid
           container
-          spacing={2.5}
-          sx={{maxWidth: 1100, mx: 'auto', px: {xs: 2, sm: 3}}}
+          spacing={3}
+          sx={{mx: 'auto', px: {xs: 2, sm: 3}}}
           aria-busy="true"
           aria-label="Loading active Plex sessions"
         >
-          {[0, 1, 2].map(i => (
+          {[0, 1, 2, 3, 4, 5].map(i => (
             <Grid item xs={12} sm={6} md={4} key={i}>
-              <Card sx={{height: '100%'}}>
-                <Box sx={{height: 168, background: 'linear-gradient(110deg,#222633,#1b1e26)', borderBottom: '1px solid rgba(255,255,255,0.06)'}}/>
-                <CardContent>
-                  <Box sx={{height: 22, width: '80%', borderRadius: 1, background: '#2a2f3a', mb: 1.5}}/>
-                  <Box sx={{height: 14, width: '45%', borderRadius: 1, background: '#232733'}}/>
+              <Card sx={{height: '100%', display: 'flex', flexDirection: 'column', overflow: 'hidden'}}>
+                <Box sx={{
+                  width: '100%', aspectRatio: '16 / 9', flexShrink: 0,
+                  background: 'linear-gradient(110deg,#222633,#1b1e26)',
+                  borderBottom: '1px solid rgba(255,255,255,0.06)',
+                }}/>
+                <CardContent sx={{display: 'flex', flexDirection: 'column', gap: 1.25}}>
+                  <Box sx={{height: 24, width: '76%', borderRadius: 1, background: '#2a2f3a'}}/>
+                  <Box sx={{height: 16, width: '42%', borderRadius: 1, background: '#232733', mb: 0.5}}/>
+                  <Box sx={{height: 6, width: '100%', borderRadius: 999, background: '#232733', mb: 0.75}}/>
+                  <Box sx={{height: 8, width: '38%', borderRadius: 999, background: '#2a2f3a'}}/>
+                  <Box sx={{height: 12, width: '64%', borderRadius: 1, background: '#232733', mt: 0.5}}/>
                 </CardContent>
               </Card>
             </Grid>
@@ -67,6 +154,12 @@ export default function SessionPicker({sessions, loading, error, selectedKey, on
         title="Couldn’t load your Plex sessions."
         hint="Check that the CutScene server is reachable and Plex is linked."
         live
+        action={onRetry && (
+          <Button variant="outlined" color="primary" size="small" onClick={onRetry}
+            sx={{mt: 1, borderColor: 'rgba(255,255,255,0.2)'}}>
+            Try again
+          </Button>
+        )}
       />
     )
   }
@@ -83,47 +176,215 @@ export default function SessionPicker({sessions, loading, error, selectedKey, on
   }
 
   return (
-    <Grid container spacing={2.5} sx={{maxWidth: 1100, mx: 'auto', px: {xs: 2, sm: 3}}}>
-      {sessions.map(session => {
+    <Grid container spacing={3} sx={{mx: 'auto', px: {xs: 2, sm: 3}}}>
+      {sortedSessions.map((session, index) => {
         const name = getVideoName(session)
         const active = session.ratingKey === selectedKey
+        // The session API tags sessions owned by the current user with
+        // `ownedByCurrentUser: true`. Treat absent/false as not owned so the
+        // UI degrades gracefully when the field isn't supplied.
+        const owned = session.ownedByCurrentUser === true
+
+        // Existing session metadata, surfaced defensively — each is optional.
+        const duration = session.duration
+        const viewOffset = session.viewOffset
+        const hasProgress = duration != null && viewOffset != null && duration > 0
+        const progressPct = hasProgress ? Math.min(100, Math.max(0, (viewOffset / duration) * 100)) : 0
+        const playerState = getPlayerState(session.Player?.state)
+        const playerTitle = session.Player?.title
+        const res = resolutionLabel(session.Media?.[0]?.videoResolution)
+        const audio = audioLayoutLabel(session.Media?.[0]?.audioChannels)
+        const quality = qualitySummary(res, audio)
+        const loc = locationLabel(session.Session?.location)
+        const userTitle = session.User?.title
+        // Thumbnail: episode still first, fall back to the show poster
+        // (grandparentThumb) when the episode has no art. If neither exists,
+        // render a placeholder instead of a broken image request.
+        const thumbPath = session.thumb || session.grandparentThumb || null
+
+        // Muted footer line — supporting context, dot-separated. The user is
+        // omitted on owned cards because the "Your session" badge already
+        // conveys ownership; showing your own name would be redundant.
+        const footerParts = []
+        if (!owned && userTitle) footerParts.push(userTitle)
+        if (playerTitle) footerParts.push(playerTitle)
+        if (loc) footerParts.push(loc)
+        const footer = footerParts.join('  ·  ')
+
         return (
           <Grid item xs={12} sm={6} md={4} key={session.ratingKey}>
             <Card
               sx={{
                 height: '100%',
+                position: 'relative',
+                display: 'flex',
+                flexDirection: 'column',
+                overflow: 'hidden',
                 transition: 'transform 180ms ease, border-color 180ms ease, box-shadow 180ms ease',
-                borderColor: active ? 'rgba(255,115,0,0.55)' : undefined,
-                boxShadow: active ? '0 14px 40px -22px rgba(255,115,0,0.7)' : undefined,
+                borderColor: active
+                  ? 'rgba(255,115,0,0.6)'
+                  : owned ? 'rgba(255,115,0,0.4)' : 'rgba(255,255,255,0.08)',
+                // Owned cards get a stronger warm wash — a richer gradient that
+                // reads at a glance, plus a faint inset ring so the highlight
+                // has structure without competing with the selected state's
+                // stronger border + shadow. Selected/active stays dominant.
+                background: owned
+                  ? 'linear-gradient(180deg, rgba(255,115,0,0.13), rgba(255,115,0,0.02) 68%, rgba(255,115,0,0) 100%)'
+                  : undefined,
+                boxShadow: active
+                  ? '0 14px 40px -22px rgba(255,115,0,0.7)'
+                  : owned ? '0 10px 30px -22px rgba(255,115,0,0.45)' : undefined,
                 '&:hover': {transform: 'translateY(-2px)', borderColor: 'rgba(255,115,0,0.4)'},
               }}
             >
               <CardActionArea
                 onClick={() => onSelect(session)}
-                sx={{display: 'flex', alignItems: 'stretch', height: '100%'}}
+                data-owned={owned ? 'true' : undefined}
+                aria-label={owned ? `Your session. ${name.top}${name.bottom ? ' ' + name.bottom : ''}` : undefined}
+                sx={{
+                  display: 'flex', flexDirection: 'column', alignItems: 'stretch', height: '100%',
+                  // Explicit, accessible focus ring — the default ripple is hard
+                  // to see on the dark background.
+                  '&.Mui-focusVisible, &:focus-visible': {
+                    outline: '2px solid #ff7300',
+                    outlineOffset: '2px',
+                  },
+                }}
                 focusRipple
               >
-                <CardMedia
-                  component="img"
-                  sx={{width: 132, flexShrink: 0, objectFit: 'cover'}}
-                  image={`/thumb?path=${session.thumb}`}
-                  alt=""
-                />
-                <CardContent sx={{flex: 1, alignSelf: 'center', minWidth: 0}}>
-                  <Typography noWrap sx={{fontWeight: 600, fontSize: '1.02rem'}}>
+                {/* Thumbnail — full-width 16:9, with graceful fallback */}
+                <Box sx={{position: 'relative', width: '100%', aspectRatio: '16 / 9', background: '#11141a', flexShrink: 0}}>
+                  {thumbPath ? (
+                    <CardMedia
+                      component="img"
+                      sx={{position: 'absolute', inset: 0, width: '100%', height: '100%', objectFit: 'cover'}}
+                      image={`/thumb?path=${thumbPath}`}
+                      alt=""
+                    />
+                  ) : (
+                    <FilmPlaceholder/>
+                  )}
+                  {/* Player state dot — bottom-left over the thumbnail */}
+                  {playerState && (
+                    <Box
+                      sx={{
+                        position: 'absolute', left: 10, bottom: 10, zIndex: 1, pointerEvents: 'none',
+                        display: 'inline-flex', alignItems: 'center', gap: 0.75,
+                        px: 1, py: 0.4, borderRadius: 999,
+                        backgroundColor: 'rgba(13,15,20,0.72)',
+                        backdropFilter: 'blur(4px)',
+                      }}
+                    >
+                      <Box sx={{
+                        width: 8, height: 8, borderRadius: '50%',
+                        backgroundColor: playerState.color,
+                        boxShadow: `0 0 8px ${playerState.color}`,
+                      }}/>
+                      <Typography
+                        component="span"
+                        sx={{
+                          fontSize: '0.66rem', fontWeight: 700, letterSpacing: '0.06em',
+                          textTransform: 'uppercase', lineHeight: 1, color: 'rgba(255,255,255,0.92)',
+                        }}
+                      >
+                        {playerState.label}
+                      </Typography>
+                    </Box>
+                  )}
+                  {/* Your-session badge — top-right over the thumbnail */}
+                  {owned && (
+                    <Box
+                      sx={{
+                        position: 'absolute',
+                        top: 10,
+                        right: 10,
+                        zIndex: 1,
+                        pointerEvents: 'none',
+                        px: 1.25,
+                        py: 0.4,
+                        borderRadius: 999,
+                        fontSize: '0.7rem',
+                        fontWeight: 700,
+                        letterSpacing: '0.05em',
+                        textTransform: 'uppercase',
+                        lineHeight: 1,
+                        whiteSpace: 'nowrap',
+                        color: '#1a1206',
+                        backgroundColor: '#ff7300',
+                        boxShadow: '0 4px 14px -4px rgba(255,115,0,0.7)',
+                      }}
+                    >
+                      Your session
+                    </Box>
+                  )}
+                </Box>
+
+                <CardContent sx={{flex: 1, display: 'flex', flexDirection: 'column', gap: 1, p: 2, minWidth: 0}}>
+                  {/* Primary + secondary — full card width, one line each */}
+                  <Typography noWrap sx={{fontWeight: 700, fontSize: '1.08rem', lineHeight: 1.25}}>
                     {name.top}
                   </Typography>
-                  <Typography noWrap variant="body2" sx={{color: 'text.secondary', mt: 0.2}}>
-                    {name.bottom}
-                  </Typography>
-                  <Box sx={{display: 'flex', gap: 1.5, mt: 1.5, flexWrap: 'wrap'}}>
-                    <Typography variant="caption" sx={{fontFamily: 'var(--cs-mono-font)', color: '#ff7300'}}>
-                      {millisToDuration(session.viewOffset)}
+                  {name.bottom && (
+                    <Typography noWrap variant="body2" sx={{color: 'text.secondary', mt: -0.5}}>
+                      {name.bottom}
                     </Typography>
-                    <Typography variant="caption" sx={{color: 'text.secondary'}}>
-                      {session.User?.title}
+                  )}
+
+                  {/* Progress — viewOffset / duration, with times */}
+                  {hasProgress && (
+                    <Box sx={{mt: 0.5, minWidth: 0}}>
+                      <LinearProgress
+                        variant="determinate"
+                        value={progressPct}
+                        aria-hidden
+                        sx={{
+                          height: 6, borderRadius: 999,
+                          backgroundColor: 'rgba(255,255,255,0.08)',
+                          '& .MuiLinearProgress-bar': {
+                            borderRadius: 999,
+                            backgroundColor: '#ff7300',
+                          },
+                        }}
+                      />
+                      <Box sx={{display: 'flex', justifyContent: 'space-between', mt: 0.5, gap: 1}}>
+                        <Typography variant="caption" sx={{fontFamily: 'var(--cs-mono-font)', color: '#ff7300'}}>
+                          {millisToDuration(viewOffset)}
+                        </Typography>
+                        <Typography variant="caption" sx={{fontFamily: 'var(--cs-mono-font)', color: 'text.disabled'}}>
+                          {millisToDuration(duration)}
+                        </Typography>
+                      </Box>
+                    </Box>
+                  )}
+
+                  {/* Quality accent — resolution · audio layout, the most
+                      decision-useful technical signal (source quality you'll
+                      get). Accent-styled so it reads above the footer. */}
+                  {quality && (
+                    <Box sx={{
+                      alignSelf: 'flex-start',
+                      mt: 0.5,
+                      px: 1.25, py: 0.35,
+                      borderRadius: 999,
+                      fontSize: '0.72rem',
+                      fontWeight: 700,
+                      letterSpacing: '0.03em',
+                      fontFamily: 'var(--cs-mono-font)',
+                      whiteSpace: 'nowrap',
+                      color: '#ffd9b0',
+                      backgroundColor: 'rgba(255,115,0,0.12)',
+                      border: '1px solid rgba(255,115,0,0.32)',
+                    }}>
+                      {quality}
+                    </Box>
+                  )}
+
+                  {/* Footer — supporting context (who/where), muted */}
+                  {footer && (
+                    <Typography noWrap variant="caption" sx={{color: 'text.secondary', mt: 'auto', pt: 0.5}}>
+                      {footer}
                     </Typography>
-                  </Box>
+                  )}
                 </CardContent>
               </CardActionArea>
             </Card>

--- a/frontend/src/components/StateMessage.js
+++ b/frontend/src/components/StateMessage.js
@@ -1,7 +1,8 @@
 import {Box, CircularProgress, Typography} from "@mui/material";
 
-// Shared loading / empty / error affordance with a live-region option.
-export default function StateMessage({variant = 'empty', title, hint, live = false}) {
+// Shared loading / empty / error affordance with a live-region option. An
+// optional `action` node (e.g. a retry button) renders under the hint.
+export default function StateMessage({variant = 'empty', title, hint, live = false, action}) {
   const tone =
     variant === 'error' ? '#ffb4a8' :
     variant === 'loading' ? 'text.secondary' : 'text.secondary';
@@ -31,6 +32,7 @@ export default function StateMessage({variant = 'empty', title, hint, live = fal
           {hint}
         </Typography>
       )}
+      {action}
     </Box>
   );
 }

--- a/frontend/src/components/SubtitlePanel.js
+++ b/frontend/src/components/SubtitlePanel.js
@@ -19,7 +19,12 @@ export default function SubtitlePanel({
 
   return (
     <Box className="cs-rise-3" sx={{display: 'flex', flexDirection: 'column', minHeight: 0, height: '100%'}}>
-      <Box sx={{display: 'flex', alignItems: 'center', gap: 1.5, flexWrap: 'wrap'}}>
+      <Box sx={{
+        display: 'flex', alignItems: 'center', gap: 1.5, flexWrap: 'wrap',
+        // Slightly taller bar gives the track selector + offset stepper more
+        // presence as a distinct subtitle control bar.
+        py: 0.75, minHeight: 52,
+      }}>
         <FormControl fullWidth size="small" sx={{maxWidth: 280}}>
           <InputLabel id="subtitle-select">Subtitle track</InputLabel>
           <Select

--- a/plex_tv.go
+++ b/plex_tv.go
@@ -1,11 +1,14 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
-	"github.com/google/uuid"
 	"net/http"
+	"strconv"
+
+	"github.com/google/uuid"
 )
 
 type PlexTV struct {
@@ -75,7 +78,63 @@ type User struct {
 	Id       int    `json:"id"`
 	Uuid     string `json:"uuid"`
 	Username string `json:"username"`
+	Title    string `json:"title"`
 	Email    string `json:"email"`
+}
+
+// Plex has returned account IDs as both JSON numbers and quoted numbers over
+// time. Keep the application identity numeric while accepting either wire
+// representation.
+func (u *User) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		ID       json.RawMessage `json:"id"`
+		UUID     string          `json:"uuid"`
+		Username string          `json:"username"`
+		Title    string          `json:"title"`
+		Email    string          `json:"email"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	id, err := plexNumericID(raw.ID)
+	if err != nil {
+		return fmt.Errorf("invalid Plex user id: %w", err)
+	}
+	if int64(int(id)) != id {
+		return fmt.Errorf("Plex user id %d does not fit in int", id)
+	}
+	u.Id = int(id)
+	u.Uuid = raw.UUID
+	u.Username = raw.Username
+	u.Title = raw.Title
+	u.Email = raw.Email
+	return nil
+}
+
+func plexNumericID(raw json.RawMessage) (int64, error) {
+	text, err := plexNumericIDText(raw)
+	if err != nil || text == "" {
+		return 0, err
+	}
+	return strconv.ParseInt(text, 10, 64)
+}
+
+func plexNumericIDText(raw json.RawMessage) (string, error) {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
+		return "", nil
+	}
+
+	if raw[0] == '"' {
+		var text string
+		if err := json.Unmarshal(raw, &text); err != nil {
+			return "", err
+		}
+		return text, nil
+	}
+
+	return string(raw), nil
 }
 
 type GetUserResp struct {


### PR DESCRIPTION
## Summary
- Refresh active Plex sessions every 10 seconds while the picker is visible.
- Identify and prioritize the current user sessions, including PMS owner profiles.
- Refine session cards, subtitle workspace layout, and preview theater mode.

## Verification
- `go test ./...`
- `CI=true npx react-scripts test --watchAll=false --testPathPattern="src/(App|utils).test.js"`
- `npm run build`