### PR TITLE
Add durable saved clips

### DIFF
--- a/.ignore
+++ b/.ignore
@@ -1,0 +1,2 @@
+!.slim/deepwork/
+!.slim/deepwork/**

--- a/README.md
+++ b/README.md
@@ -18,6 +18,55 @@ docker compose up
 
 If you changed the listen address or port, update the port mapping in [docker-compose.yaml](docker-compose.yaml).
 
+### Durable clips and storage
+
+Completed renders are promoted to durable clips. Configure `storage.root` (the
+sample uses `/data`) as the local application-data directory. CutScene stores
+the SQLite clip metadata database there, MP4s below `clips/`, and the
+`clip-token.key` encryption key. The default Compose file mounts the named
+`cutscene-data` volume at `/data`; it deliberately does not mount `/tmp`, which
+contains transient render jobs and may be cleared on restart.
+
+If `storage.root` is omitted it defaults to `./data` relative to the CutScene
+process working directory. If `storage.database` is omitted it defaults to
+`clips.sqlite3` directly below that root; configured database paths must remain
+relative to the root.
+
+Do not use `docker compose down -v` unless you intend to delete the durable
+volume and all saved clips.
+
+The storage root and clip directory are created with owner-only permissions;
+the root and clip directory use `0700`, and `clip-token.key` must be exactly
+`0600`. Restrict access to that key as you would any capability secret. Keep
+the database, MP4s, and key in the same encrypted backup set. Before upgrading
+from an older release, take a complete encrypted backup of the storage root;
+the key is required to preserve encrypted share links. Backups should be taken
+with CutScene stopped (or with a filesystem/database snapshot) so metadata and
+files represent one point in time. If the key is missing or wrong, startup
+refuses to run until the matching key is restored; it does not generate a
+replacement key. The MP4s may remain, but the service will not expose or serve
+encrypted share links without that matching key.
+
+To use a host path or a custom volume, set `storage.root` and mount that exact
+path into the container. For example, with `storage.root: /srv/cutscene`, use
+`/host/cutscene:/srv/cutscene` rather than mounting `/data`; the database path
+is relative to the root by default and absolute or escaping paths are rejected.
+Startup validates the restored schema, key, encrypted tokens, and clip files.
+A missing database, missing/wrong key, or ambiguous restore fails closed and
+leaves existing MP4s untouched; restore the matching backup and retry.
+
+Durable clip capacity is intentionally unbounded by application policy. Monitor
+the mounted filesystem and plan disk alerts/backups; the existing queue,
+per-owner, FFmpeg, and transient render limits still apply.
+
+On startup, CutScene preflights clip metadata and files before any migration
+or reconciliation. Mismatched, stale, partial, or unreferenced durable state
+fails closed without deleting either side. A legacy Phase 1 hash-only database
+is migrated to encrypted token storage; because the old
+raw token was not retained, those legacy clips receive newly generated share
+tokens while their metadata and MP4s are preserved. Deleting a clip is a hard
+delete of both its SQLite metadata and MP4 bytes and is permanent.
+
 ### Authentication
 
 Open the CutScene URL in a browser and choose **Log in with Plex**. CutScene uses Plex's browser authentication flow and keeps the authenticated session in the browser. The session, preview, and render endpoints require that authenticated session; an HTTP client must preserve the session cookie established by its Plex login.

--- a/api.go
+++ b/api.go
@@ -81,6 +81,13 @@ func NewAPI(config Config, app *Application) (*API, error) {
 	api.http.Post("/render-jobs", api.createRenderJob, api.authMiddlewareJSON)
 	api.http.Get("/render-jobs/:id", api.getRenderJob, api.authMiddlewareJSON)
 	api.http.Get("/render-jobs/:id/download", api.downloadRenderJob, api.authMiddlewareJSON)
+	api.http.Get("/clips", api.listClips, api.authMiddlewareJSON)
+	api.http.Get("/clips/:id/download", api.downloadClip, api.authMiddlewareJSON)
+	api.http.Get("/clips/:id/artwork", api.downloadClipArtwork, api.authMiddlewareJSON)
+	api.http.Get("/clips/:id", api.getClip, api.authMiddlewareJSON)
+	api.http.Delete("/clips/:id", api.deleteClip, api.authMiddlewareJSON)
+	api.http.Get("/shared/clips/:token/download", api.publicDownloadClip)
+	api.http.Get("/shared/clips/:token", api.publicClip)
 	api.http.Get("/preview/:ratingKey/:from/:to", api.preview, api.authMiddleware)
 
 	api.http.Get("/authUrl", api.authUrl).Name(routeNameAuthUrl)
@@ -268,7 +275,9 @@ func (a *API) Shutdown() error {
 	}
 	var shutdownErr error
 	if a.app != nil {
-		shutdownErr = a.app.Close()
+		// Cancel active work first, but keep SQLite open while the HTTP server
+		// drains handlers that may still be reading clip metadata or bytes.
+		a.app.stopWork()
 	}
 	if a.http != nil {
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), apiShutdownTimeout)
@@ -276,6 +285,13 @@ func (a *API) Shutdown() error {
 		cancel()
 		if shutdownErr == nil {
 			shutdownErr = err
+		}
+	}
+	if a.app != nil {
+		if err := a.app.Close(); shutdownErr == nil && err != nil {
+			shutdownErr = err
+		} else if err != nil {
+			shutdownErr = errors.Join(shutdownErr, err)
 		}
 	}
 	return shutdownErr

--- a/api_render_jobs_test.go
+++ b/api_render_jobs_test.go
@@ -180,7 +180,7 @@ func TestGetSessionsAnnotatesOwnershipByNumericUserID(t *testing.T) {
 func testAuthenticatedRoute(handler fiber.Handler) *fiber.App {
 	app := fiber.New()
 	app.Use(func(ctx fiber.Ctx) error {
-		ctx.SetUserContext(ContextWithUser(context.Background(), User{Uuid: "owner-a"}))
+		ctx.SetUserContext(ContextWithUser(context.Background(), User{Uuid: "owner-a", Email: "owner@example.com"}))
 		return ctx.Next()
 	})
 	app.All("/*", handler)
@@ -190,7 +190,7 @@ func testAuthenticatedRoute(handler fiber.Handler) *fiber.App {
 func testAuthenticatedParamRoute(method, path string, handler fiber.Handler) *fiber.App {
 	app := fiber.New()
 	authenticated := func(ctx fiber.Ctx) error {
-		ctx.SetUserContext(ContextWithUser(context.Background(), User{Uuid: "owner-a"}))
+		ctx.SetUserContext(ContextWithUser(context.Background(), User{Uuid: "owner-a", Email: "owner@example.com"}))
 		return handler(ctx)
 	}
 	app.Add([]string{method}, path, authenticated)
@@ -404,6 +404,7 @@ func TestPreviewHandlerReturnsBeforeStreamingCallback(t *testing.T) {
 	config.Plex.Host = plex.URL
 	application := &Application{
 		config:        config,
+		ownerEmail:    "owner@example.com",
 		plexAdmin:     plexgo.New(plexgo.WithServerURL(plex.URL), plexgo.WithSecurity(config.Plex.Token)),
 		ffmpegLimiter: newFFmpegLimiter(1),
 	}
@@ -570,6 +571,7 @@ func TestPreviewColdCacheUsesExternalSubtitleStream(t *testing.T) {
 	config.Plex.Host = plex.URL
 	application := &Application{
 		config:        config,
+		ownerEmail:    "owner@example.com",
 		plexAdmin:     plexgo.New(plexgo.WithServerURL(plex.URL), plexgo.WithSecurity(config.Plex.Token)),
 		subtitleCache: newSubtitleCache(4),
 		ffmpegLimiter: newFFmpegLimiter(1),
@@ -649,6 +651,7 @@ func TestRenderJobCreateAcceptsKeylessAuthorizedSessionPart(t *testing.T) {
 	config.Plex.Token = "admin-token"
 	app := &Application{
 		config:     config,
+		ownerEmail: "owner@example.com",
 		plexAdmin:  plexgo.New(plexgo.WithServerURL(plex.URL), plexgo.WithSecurity(config.Plex.Token)),
 		renderJobs: manager,
 	}
@@ -877,6 +880,71 @@ func TestAPIShutdownCancelsActivePreviewBeforeHTTPDrain(t *testing.T) {
 	case <-serveDone:
 	case <-time.After(time.Second):
 		t.Fatal("HTTP server did not stop")
+	}
+}
+
+func TestAPIShutdownDrainsClipHandlerBeforeClosingStorage(t *testing.T) {
+	store, err := newClipStore(t.TempDir(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	lifetime, cancelLifetime := context.WithCancel(context.Background())
+	application := &Application{clipStore: store, lifetime: lifetime, cancelLifetime: cancelLifetime}
+	started := make(chan struct{})
+	releaseHandler := make(chan struct{})
+	handlerErr := make(chan error, 1)
+	fiberApp := fiber.New()
+	fiberApp.Get("/clip", func(_ fiber.Ctx) error {
+		close(started)
+		<-releaseHandler
+		_, err := application.clipStore.list("", true)
+		handlerErr <- err
+		return nil
+	})
+	listener := fasthttputil.NewInmemoryListener()
+	serveDone := make(chan error, 1)
+	go func() { serveDone <- fiberApp.Listener(listener, fiber.ListenConfig{DisableStartupMessage: true}) }()
+	conn, err := listener.Dial()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	if _, err := io.WriteString(conn, "GET /clip HTTP/1.1\r\nHost: test\r\nConnection: close\r\n\r\n"); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("clip handler did not start")
+	}
+
+	api := &API{app: application, http: fiberApp}
+	shutdownDone := make(chan error, 1)
+	go func() { shutdownDone <- api.Shutdown() }()
+	select {
+	case err := <-shutdownDone:
+		t.Fatalf("shutdown completed before handler drained: %v", err)
+	case <-time.After(25 * time.Millisecond):
+	}
+	if err := store.db.Ping(); err != nil {
+		t.Fatalf("clip storage closed before HTTP drain: %v", err)
+	}
+	close(releaseHandler)
+	if err := <-handlerErr; err != nil {
+		t.Fatalf("clip handler could not use storage during drain: %v", err)
+	}
+	select {
+	case err := <-shutdownDone:
+		if err != nil && !errors.Is(err, fiber.ErrNotRunning) {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("shutdown did not finish after handler drained")
+	}
+	select {
+	case <-serveDone:
+	case <-time.After(time.Second):
+		t.Fatal("Fiber server did not stop")
 	}
 }
 

--- a/application.go
+++ b/application.go
@@ -1,17 +1,25 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"image"
+	_ "image/gif"
+	_ "image/jpeg"
+	_ "image/png"
 	"io"
+	"log"
+	"mime"
 	"net/http"
 	"net/url"
 	"os"
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/LukeHagar/plexgo"
 	"github.com/LukeHagar/plexgo/models/components"
@@ -180,12 +188,15 @@ type Application struct {
 	plexTv            *PlexTV
 	machineIdentifier string
 	ownerEmail        string
+	ownerUUID         string
 	subtitleCache     *subtitleCache
 	ffmpegLimiter     *ffmpegLimiter
 	renderJobs        *renderJobManager
+	clipStore         *clipStore
 	lifetime          context.Context
 	cancelLifetime    context.CancelFunc
 	closeOnce         sync.Once
+	closeErr          error
 }
 
 func NewApplication(config Config) (*Application, error) {
@@ -217,6 +228,7 @@ func NewApplication(config Config) (*Application, error) {
 	}
 
 	app.ownerEmail = tokenDetails.UserPlexAccount.Email
+	app.ownerUUID = tokenDetails.UserPlexAccount.UUID
 
 	// TODO: If configured, ignore auth from context and just use the configured token for all requests
 	app.plexUser = plexgo.New(
@@ -224,8 +236,32 @@ func NewApplication(config Config) (*Application, error) {
 		plexgo.WithSecuritySource(app.plexSecurityUserToken),
 	)
 
-	app.renderJobs, err = newRenderJobManagerWithContext(app.lifetime, renderRoot, app.executeRenderSpec)
+	app.clipStore, err = newClipStore(durableStorageRoot(config), config.Storage.Database)
 	if err != nil {
+		return nil, fmt.Errorf("could not initialize clip storage: %w", err)
+	}
+	app.renderJobs, err = newRenderJobManagerWithContextAndPromotion(app.lifetime, renderRoot, app.executeRenderSpec, func(job *renderJob, outputPath string) error {
+		artworkContext, cancelArtwork := context.WithTimeout(app.lifetime, 30*time.Second)
+		defer cancelArtwork()
+		artworkPath, artworkMIME, artworkErr := app.fetchClipArtwork(artworkContext, job.spec.ThumbnailURL)
+		if artworkErr != nil {
+			log.Printf("clip artwork snapshot unavailable: %s", redactedDiagnostic(artworkErr))
+		}
+		if artworkPath != "" {
+			defer os.Remove(artworkPath)
+		}
+		clip, promoteErr := app.clipStore.promoteWithArtwork(job.spec, outputPath, artworkPath, artworkMIME)
+		if promoteErr != nil {
+			return newRenderStageFailure("storage", "storage_full", promoteErr)
+		}
+		job.mu.Lock()
+		job.clipID = clip.ID
+		job.shareURL = clipShareURLForDomain(config.API.Domain, clip.ShareToken)
+		job.mu.Unlock()
+		return nil
+	})
+	if err != nil {
+		_ = app.clipStore.close()
 		return nil, fmt.Errorf("could not initialize render jobs: %w", err)
 	}
 
@@ -239,14 +275,160 @@ func (a *Application) Close() error {
 		return nil
 	}
 	a.closeOnce.Do(func() {
-		if a.cancelLifetime != nil {
-			a.cancelLifetime()
-		}
-		if a.renderJobs != nil {
-			a.renderJobs.stopAndWait()
+		a.stopWork()
+		if a.clipStore != nil {
+			if err := a.clipStore.close(); err != nil {
+				a.closeErr = err
+				log.Printf("clip storage close failed: %s", redactedDiagnostic(err))
+			}
 		}
 	})
-	return nil
+	return a.closeErr
+}
+
+const maxClipArtworkBytes int64 = 8 << 20
+
+func (a *Application) fetchClipArtwork(ctx context.Context, artworkPath string) (string, string, error) {
+	if strings.TrimSpace(artworkPath) == "" {
+		return "", "", nil
+	}
+	base, err := url.Parse(a.config.Plex.Host)
+	if err != nil {
+		return "", "", err
+	}
+	if (base.Scheme != "http" && base.Scheme != "https") || base.Host == "" || base.User != nil {
+		return "", "", errors.New("configured Plex origin is invalid")
+	}
+	if strings.HasPrefix(artworkPath, "//") {
+		return "", "", errors.New("scheme-relative artwork URL is not allowed")
+	}
+	parsed, err := url.Parse(artworkPath)
+	if err != nil {
+		return "", "", err
+	}
+	if parsed.User != nil {
+		return "", "", errors.New("artwork URL userinfo is not allowed")
+	}
+	if !parsed.IsAbs() && !strings.HasPrefix(parsed.Path, "/") {
+		return "", "", errors.New("artwork URL must be an absolute Plex path")
+	}
+	if parsed.IsAbs() && (!strings.EqualFold(parsed.Scheme, base.Scheme) || !strings.EqualFold(parsed.Host, base.Host)) {
+		return "", "", errors.New("clip artwork is not hosted by configured Plex")
+	}
+	if !parsed.IsAbs() {
+		parsed = base.ResolveReference(parsed)
+	}
+	if parsed.User != nil || !strings.EqualFold(parsed.Scheme, base.Scheme) || !strings.EqualFold(parsed.Host, base.Host) {
+		return "", "", errors.New("clip artwork origin is not the configured Plex origin")
+	}
+	query := parsed.Query()
+	query.Set("X-Plex-Token", a.config.Plex.Token)
+	parsed.RawQuery = query.Encode()
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, parsed.String(), nil)
+	if err != nil {
+		return "", "", err
+	}
+	client := &http.Client{CheckRedirect: func(next *http.Request, via []*http.Request) error {
+		if len(via) == 0 {
+			return nil
+		}
+		previous := via[0].URL
+		if next.URL.User != nil || !strings.EqualFold(next.URL.Scheme, previous.Scheme) || !strings.EqualFold(next.URL.Host, previous.Host) {
+			return errors.New("artwork redirect leaves configured Plex origin")
+		}
+		return nil
+	}}
+	response, err := client.Do(request)
+	if err != nil {
+		return "", "", err
+	}
+	defer response.Body.Close()
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		return "", "", fmt.Errorf("artwork returned status %d", response.StatusCode)
+	}
+	contentType, _, err := mime.ParseMediaType(response.Header.Get("Content-Type"))
+	if err != nil {
+		return "", "", errors.New("artwork response has invalid content type")
+	}
+	data, err := io.ReadAll(io.LimitReader(response.Body, maxClipArtworkBytes+1))
+	if err != nil || int64(len(data)) == 0 || int64(len(data)) > maxClipArtworkBytes {
+		if err != nil {
+			return "", "", err
+		}
+		return "", "", errors.New("artwork response is empty or too large")
+	}
+	if err := validateRasterArtwork(contentType, data); err != nil {
+		return "", "", err
+	}
+	tmp, err := os.CreateTemp("", "cutscene-artwork-*")
+	if err != nil {
+		return "", "", err
+	}
+	tmpPath := tmp.Name()
+	count, copyErr := io.Copy(tmp, bytes.NewReader(data))
+	closeErr := tmp.Close()
+	if copyErr != nil || closeErr != nil || count == 0 || count > maxClipArtworkBytes {
+		_ = os.Remove(tmpPath)
+		if copyErr != nil {
+			return "", "", copyErr
+		}
+		if closeErr != nil {
+			return "", "", closeErr
+		}
+		return "", "", errors.New("artwork response is empty or too large")
+	}
+	return tmpPath, contentType, nil
+}
+
+func validateRasterArtwork(contentType string, data []byte) error {
+	switch strings.ToLower(contentType) {
+	case "image/jpeg", "image/png", "image/gif":
+		_, format, err := image.DecodeConfig(bytes.NewReader(data))
+		if err != nil || format == "" {
+			return errors.New("artwork bytes are not a valid raster image")
+		}
+		return nil
+	case "image/webp":
+		if len(data) < 12 || string(data[:4]) != "RIFF" || string(data[8:12]) != "WEBP" {
+			return errors.New("artwork bytes are not a valid WebP image")
+		}
+		return nil
+	default:
+		return errors.New("artwork response is not an allowed raster image")
+	}
+}
+
+// stopWork cancels request-scoped background work without closing durable
+// storage. API shutdown uses this before draining HTTP handlers so handlers
+// can finish their SQLite/file operations safely.
+func (a *Application) stopWork() {
+	if a == nil {
+		return
+	}
+	if a.cancelLifetime != nil {
+		a.cancelLifetime()
+	}
+	if a.renderJobs != nil {
+		a.renderJobs.stopAndWait()
+	}
+}
+
+func normalizeOwnerIdentity(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}
+
+// isServerOwner is the single administrator invariant. Plex account UUID is
+// stable and preferred; older/test identities without UUID fall back to the
+// normalized account email captured from the configured server-owner token.
+func (a *Application) isServerOwner(user *User) bool {
+	if a == nil || user == nil {
+		return false
+	}
+	if ownerUUID := normalizeOwnerIdentity(a.ownerUUID); ownerUUID != "" && normalizeOwnerIdentity(user.Uuid) != "" {
+		return ownerUUID == normalizeOwnerIdentity(user.Uuid)
+	}
+	ownerEmail := normalizeOwnerIdentity(a.ownerEmail)
+	return ownerEmail != "" && ownerEmail == normalizeOwnerIdentity(user.Email)
 }
 
 func (a *Application) operationContext(parent context.Context) (context.Context, func()) {
@@ -282,7 +464,7 @@ func (a *Application) GetValidatedUser(ctx context.Context) (*User, error) {
 		return nil, err
 	}
 
-	if user.Email == a.ownerEmail {
+	if a.isServerOwner(user) {
 		return user, nil
 	}
 
@@ -330,7 +512,7 @@ func (a *Application) GetSessions(ctx context.Context) ([]sessionMetadata, error
 	}
 
 	user := UserFromContext(ctx)
-	serverOwner := user != nil && user.Email == a.ownerEmail
+	serverOwner := a.isServerOwner(user)
 	for i := range sessions.MediaContainer.Metadata {
 		sessions.MediaContainer.Metadata[i].OwnedByCurrentUser = sessionOwnedByCurrentUser(sessions.MediaContainer.Metadata[i], user, serverOwner)
 	}

--- a/clips.go
+++ b/clips.go
@@ -1,0 +1,1355 @@
+package main
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/google/uuid"
+	_ "github.com/mattn/go-sqlite3"
+)
+
+const defaultDurableStorageRoot = "./data"
+
+var errClipNotFound = errors.New("clip not found")
+
+func setCapabilityResponseHeaders(ctx fiber.Ctx) {
+	ctx.Set("Cache-Control", "no-store")
+	ctx.Set("Referrer-Policy", "no-referrer")
+}
+
+// Clip is the durable representation of a completed render. FilePath and the
+// raw share token are intentionally not serialized; callers receive URLs
+// rather than storage implementation details or credentials.
+type Clip struct {
+	ID                 string    `json:"id"`
+	OwnerUUID          string    `json:"-"`
+	CreatorDisplayName string    `json:"creatorDisplayName,omitempty"`
+	MediaKind          string    `json:"mediaKind,omitempty"`
+	MovieTitle         string    `json:"movieTitle,omitempty"`
+	MovieYear          *int      `json:"movieYear,omitempty"`
+	ShowTitle          string    `json:"showTitle,omitempty"`
+	SeasonNumber       *int      `json:"seasonNumber,omitempty"`
+	EpisodeNumber      *int      `json:"episodeNumber,omitempty"`
+	EpisodeTitle       string    `json:"episodeTitle,omitempty"`
+	Title              string    `json:"title"`
+	RatingKey          string    `json:"ratingKey"`
+	MediaID            int64     `json:"mediaId"`
+	FromMs             int64     `json:"fromMs"`
+	ToMs               int64     `json:"toMs"`
+	CreatedAt          time.Time `json:"createdAt"`
+	FilePath           string    `json:"-"`
+	ArtworkPath        string    `json:"-"`
+	ThumbnailMIME      string    `json:"-"`
+	ShareToken         string    `json:"-"`
+	tokenCiphertext    []byte
+	tokenHash          string
+}
+
+type clipStore struct {
+	root      string
+	files     string
+	db        *sql.DB
+	tokenAEAD cipher.AEAD
+}
+
+func durableStorageRoot(config Config) string {
+	if strings.TrimSpace(config.Storage.Root) != "" {
+		return config.Storage.Root
+	}
+	return defaultDurableStorageRoot
+}
+
+const clipTokenKeyFile = "clip-token.key"
+
+func loadOrCreateTokenKey(root string, requireExisting bool) ([]byte, error) {
+	path := filepath.Join(root, clipTokenKeyFile)
+	readKey := func() ([]byte, error) {
+		info, err := os.Lstat(path)
+		if err != nil {
+			return nil, err
+		}
+		if !info.Mode().IsRegular() || info.Mode().Perm() != 0600 {
+			return nil, fmt.Errorf("clip token key must be a regular 0600 file")
+		}
+		key, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read clip token key: %w", err)
+		}
+		if len(key) != 32 {
+			return nil, fmt.Errorf("clip token key has invalid length")
+		}
+		return key, nil
+	}
+
+	if key, err := readKey(); err == nil {
+		return key, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return nil, err
+	} else if requireExisting {
+		return nil, fmt.Errorf("clip token key is required by existing encrypted clip records")
+	}
+
+	var key [32]byte
+	if _, err := io.ReadFull(rand.Reader, key[:]); err != nil {
+		return nil, fmt.Errorf("generate clip token key: %w", err)
+	}
+	tmp := filepath.Join(root, "."+clipTokenKeyFile+"."+uuid.NewString()+".tmp")
+	file, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
+	if err != nil {
+		if errors.Is(err, os.ErrExist) {
+			return readKey()
+		}
+		return nil, fmt.Errorf("create clip token key: %w", err)
+	}
+	writeErr := error(nil)
+	if _, writeErr = file.Write(key[:]); writeErr == nil {
+		writeErr = file.Sync()
+	}
+	if closeErr := file.Close(); writeErr == nil {
+		writeErr = closeErr
+	}
+	if writeErr != nil {
+		_ = os.Remove(tmp)
+		return nil, fmt.Errorf("write clip token key: %w", writeErr)
+	}
+	// A hard link gives create-if-absent semantics for the final name: a
+	// concurrent starter cannot replace an already durable key.
+	if err := os.Link(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		if errors.Is(err, os.ErrExist) {
+			return readKey()
+		}
+		return nil, fmt.Errorf("install clip token key: %w", err)
+	}
+	_ = os.Remove(tmp)
+	if err := syncDirectory(root); err != nil {
+		return nil, fmt.Errorf("sync clip token key: %w", err)
+	}
+	return key[:], nil
+}
+
+type clipSchemaKind int
+
+const (
+	clipSchemaNone clipSchemaKind = iota
+	clipSchemaPhase1HashOnly
+	clipSchemaPhase1Raw
+	clipSchemaPhase2Encrypted
+	clipSchemaCurrent
+	clipSchemaPresentation
+)
+
+type clipSchema struct {
+	kind   clipSchemaKind
+	rows   int64
+	exists bool
+}
+
+var clipBaseColumns = map[string]bool{
+	"id": true, "owner_uuid": true, "title": true, "rating_key": true,
+	"media_id": true, "from_ms": true, "to_ms": true, "created_at": true,
+	"share_token_hash": true,
+}
+
+var clipPresentationColumns = map[string]bool{
+	"creator_display_name": true, "media_kind": true, "movie_title": true,
+	"movie_year": true, "show_title": true, "season_number": true,
+	"episode_number": true, "episode_title": true, "thumbnail_mime": true,
+}
+
+func resolveClipDatabasePath(root, configured string) (string, error) {
+	rootAbs, err := filepath.Abs(root)
+	if err != nil {
+		return "", fmt.Errorf("resolve durable storage root: %w", err)
+	}
+	if strings.TrimSpace(configured) == "" {
+		configured = "clips.sqlite3"
+	}
+	if filepath.IsAbs(configured) {
+		return "", errors.New("storage.database must be relative to storage.root")
+	}
+	databasePath := filepath.Clean(filepath.Join(rootAbs, configured))
+	rel, err := filepath.Rel(rootAbs, databasePath)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", errors.New("storage.database must remain below storage.root")
+	}
+	canonicalRoot, err := filepath.EvalSymlinks(rootAbs)
+	if err != nil {
+		return "", fmt.Errorf("resolve durable storage root: %w", err)
+	}
+	current := rootAbs
+	parts := strings.Split(rel, string(filepath.Separator))
+	for index, part := range parts {
+		current = filepath.Join(current, part)
+		info, statErr := os.Lstat(current)
+		if errors.Is(statErr, os.ErrNotExist) {
+			break
+		}
+		if statErr != nil {
+			return "", fmt.Errorf("inspect storage.database path: %w", statErr)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return "", errors.New("storage.database cannot contain symlinked path components")
+		}
+		if index < len(parts)-1 && !info.IsDir() {
+			return "", errors.New("storage.database has a non-directory path component")
+		}
+	}
+	existing := databasePath
+	for {
+		if _, statErr := os.Lstat(existing); statErr == nil {
+			canonicalExisting, evalErr := filepath.EvalSymlinks(existing)
+			if evalErr != nil {
+				return "", fmt.Errorf("resolve storage.database target: %w", evalErr)
+			}
+			canonicalRel, relErr := filepath.Rel(canonicalRoot, canonicalExisting)
+			if relErr != nil || canonicalRel == ".." || strings.HasPrefix(canonicalRel, ".."+string(filepath.Separator)) {
+				return "", errors.New("storage.database target escapes storage.root")
+			}
+			break
+		} else if !errors.Is(statErr, os.ErrNotExist) {
+			return "", fmt.Errorf("inspect storage.database target: %w", statErr)
+		}
+		next := filepath.Dir(existing)
+		if next == existing {
+			break
+		}
+		existing = next
+	}
+	return databasePath, nil
+}
+
+func hasDurableClipEntries(files string) (bool, error) {
+	entries, err := os.ReadDir(files)
+	if err != nil {
+		return false, err
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func clipPathForFiles(files, id string) (string, error) {
+	if id == "" || filepath.Base(id) != id || id == "." || id == ".." {
+		return "", errors.New("clip id is invalid")
+	}
+	path := filepath.Join(files, id+".mp4")
+	rel, err := filepath.Rel(files, path)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", errors.New("clip path escapes durable storage")
+	}
+	return path, nil
+}
+
+func artworkPathForFiles(files, id string) (string, error) {
+	path, err := clipPathForFiles(files, id)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSuffix(path, ".mp4") + ".thumb", nil
+}
+
+func preflightClipFiles(db *sql.DB, files string, hasThumbnails bool) error {
+	query := "SELECT id"
+	if hasThumbnails {
+		query += ", thumbnail_mime"
+	}
+	query += " FROM clips"
+	rows, err := db.Query(query)
+	if err != nil {
+		return fmt.Errorf("preflight clip metadata: %w", err)
+	}
+	expected := make(map[string]string)
+	for rows.Next() {
+		var id string
+		var thumbnailMIME sql.NullString
+		args := []any{&id}
+		if hasThumbnails {
+			args = append(args, &thumbnailMIME)
+		}
+		if err := rows.Scan(args...); err != nil {
+			rows.Close()
+			return fmt.Errorf("preflight clip metadata: %w", err)
+		}
+		path, err := clipPathForFiles(files, id)
+		if err != nil {
+			rows.Close()
+			return fmt.Errorf("preflight clip %s: %w", id, err)
+		}
+		expected[path] = id
+		if hasThumbnails && thumbnailMIME.Valid && thumbnailMIME.String != "" {
+			artworkPath, err := artworkPathForFiles(files, id)
+			if err != nil {
+				rows.Close()
+				return fmt.Errorf("preflight artwork for clip %s: %w", id, err)
+			}
+			expected[artworkPath] = id
+		}
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return fmt.Errorf("preflight clip metadata: %w", err)
+	}
+	rows.Close()
+	entries, err := os.ReadDir(files)
+	if err != nil {
+		return fmt.Errorf("preflight durable clip files: %w", err)
+	}
+	actual := make(map[string]bool)
+	for _, entry := range entries {
+		if entry.IsDir() {
+			return fmt.Errorf("preflight found unexpected directory %q in clip storage", entry.Name())
+		}
+		path := filepath.Join(files, entry.Name())
+		ext := strings.ToLower(filepath.Ext(entry.Name()))
+		if ext != ".mp4" && !(hasThumbnails && ext == ".thumb") {
+			return fmt.Errorf("preflight found unexpected clip file %q", entry.Name())
+		}
+		info, err := os.Lstat(path)
+		if err != nil {
+			return fmt.Errorf("preflight clip file %q: %w", entry.Name(), err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() || info.Size() == 0 {
+			return fmt.Errorf("preflight clip file %q is not a regular nonempty file", entry.Name())
+		}
+		actual[path] = true
+	}
+	if len(expected) != len(actual) {
+		return errors.New("preflight database and clip files do not correspond exactly")
+	}
+	for path := range expected {
+		if !actual[path] {
+			return fmt.Errorf("preflight database references missing clip bytes %q", filepath.Base(path))
+		}
+	}
+	for path := range actual {
+		if _, ok := expected[path]; !ok {
+			return fmt.Errorf("preflight found unreferenced clip bytes %q", filepath.Base(path))
+		}
+	}
+	return nil
+}
+
+func inspectClipSchema(db *sql.DB) (clipSchema, error) {
+	var tableName string
+	err := db.QueryRow("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'clips'").Scan(&tableName)
+	if errors.Is(err, sql.ErrNoRows) {
+		return clipSchema{kind: clipSchemaNone}, nil
+	}
+	if err != nil {
+		return clipSchema{}, fmt.Errorf("inspect clip schema: %w", err)
+	}
+	rows, err := db.Query("PRAGMA table_info(clips)")
+	if err != nil {
+		return clipSchema{}, fmt.Errorf("inspect clip columns: %w", err)
+	}
+	columns := make(map[string]bool)
+	for rows.Next() {
+		var cid, notNull, primaryKey int
+		var name, columnType string
+		var defaultValue any
+		if err := rows.Scan(&cid, &name, &columnType, &notNull, &defaultValue, &primaryKey); err != nil {
+			rows.Close()
+			return clipSchema{}, fmt.Errorf("inspect clip columns: %w", err)
+		}
+		columns[name] = true
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return clipSchema{}, fmt.Errorf("inspect clip columns: %w", err)
+	}
+	rows.Close()
+	for column := range clipBaseColumns {
+		if !columns[column] {
+			return clipSchema{}, fmt.Errorf("clips table is missing required column %q", column)
+		}
+	}
+	kind := clipSchemaKind(0)
+	hasPath := columns["file_path"]
+	hasRaw := columns["share_token"]
+	hasCipher := columns["share_token_ciphertext"]
+	allowed := make(map[string]bool)
+	for column := range clipBaseColumns {
+		allowed[column] = true
+	}
+	presentationCount := 0
+	for column := range clipPresentationColumns {
+		if columns[column] {
+			presentationCount++
+		}
+		allowed[column] = true
+	}
+	if hasPath {
+		allowed["file_path"] = true
+	}
+	if hasRaw {
+		allowed["share_token"] = true
+	}
+	if hasCipher {
+		allowed["share_token_ciphertext"] = true
+	}
+	for column := range columns {
+		if !allowed[column] {
+			return clipSchema{}, fmt.Errorf("clips table has unknown column %q", column)
+		}
+	}
+	switch {
+	case hasCipher && !hasPath && !hasRaw && presentationCount == len(clipPresentationColumns):
+		kind = clipSchemaPresentation
+	case hasCipher && !hasPath && !hasRaw && presentationCount == 0:
+		kind = clipSchemaCurrent
+	case hasCipher && hasPath && !hasRaw && presentationCount == 0:
+		kind = clipSchemaPhase2Encrypted
+	case !hasCipher && hasPath && hasRaw && presentationCount == 0:
+		kind = clipSchemaPhase1Raw
+	case !hasCipher && hasPath && !hasRaw && presentationCount == 0:
+		kind = clipSchemaPhase1HashOnly
+	default:
+		return clipSchema{}, errors.New("clips table has an unsupported partial schema")
+	}
+	var count int64
+	if err := db.QueryRow("SELECT count(*) FROM clips").Scan(&count); err != nil {
+		return clipSchema{}, fmt.Errorf("count clips: %w", err)
+	}
+	return clipSchema{kind: kind, rows: count, exists: true}, nil
+}
+
+func newClipStore(root, databasePath string) (*clipStore, error) {
+	if strings.TrimSpace(root) == "" {
+		root = defaultDurableStorageRoot
+	}
+	if err := os.MkdirAll(root, 0700); err != nil {
+		return nil, fmt.Errorf("create durable storage root: %w", err)
+	}
+	if err := os.Chmod(root, 0700); err != nil {
+		return nil, fmt.Errorf("secure durable storage root: %w", err)
+	}
+	files := filepath.Join(root, "clips")
+	if err := os.MkdirAll(files, 0700); err != nil {
+		return nil, fmt.Errorf("create durable clip storage: %w", err)
+	}
+	if err := os.Chmod(files, 0700); err != nil {
+		return nil, fmt.Errorf("secure durable clip storage: %w", err)
+	}
+	filesInfo, err := os.Lstat(files)
+	if err != nil || filesInfo.Mode()&os.ModeSymlink != 0 {
+		return nil, errors.New("durable clip storage cannot be a symlink")
+	}
+	canonicalRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return nil, fmt.Errorf("resolve durable storage root: %w", err)
+	}
+	canonicalFiles, err := filepath.EvalSymlinks(files)
+	if err != nil {
+		return nil, fmt.Errorf("resolve durable clip storage: %w", err)
+	}
+	filesRel, err := filepath.Rel(canonicalRoot, canonicalFiles)
+	if err != nil || filesRel == ".." || strings.HasPrefix(filesRel, ".."+string(filepath.Separator)) {
+		return nil, errors.New("durable clip storage escapes storage.root")
+	}
+	databasePath, err = resolveClipDatabasePath(root, databasePath)
+	if err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(filepath.Dir(databasePath), 0700); err != nil {
+		return nil, fmt.Errorf("create clip database directory: %w", err)
+	}
+	databaseInfo, databaseErr := os.Lstat(databasePath)
+	databaseExists := databaseErr == nil
+	if databaseErr != nil && !errors.Is(databaseErr, os.ErrNotExist) {
+		return nil, fmt.Errorf("inspect clip database: %w", databaseErr)
+	}
+	hasMP4s, err := hasDurableClipEntries(files)
+	if err != nil {
+		return nil, fmt.Errorf("inspect durable clip files: %w", err)
+	}
+	if hasMP4s && (!databaseExists || databaseInfo.Size() == 0) {
+		return nil, errors.New("durable clip files exist but the selected database is missing or empty; refusing recovery cleanup")
+	}
+
+	var schema clipSchema
+	var db *sql.DB
+	if databaseExists {
+		db, err = sql.Open("sqlite3", databasePath)
+		if err != nil {
+			return nil, fmt.Errorf("open clip database: %w", err)
+		}
+		db.SetMaxOpenConns(1)
+		schema, err = inspectClipSchema(db)
+		if err != nil {
+			_ = db.Close()
+			return nil, err
+		}
+		if hasMP4s && (!schema.exists || schema.rows == 0) {
+			_ = db.Close()
+			return nil, errors.New("durable clip files exist but the selected database has no clip records; refusing recovery cleanup")
+		}
+		if !schema.exists {
+			_ = db.Close()
+			return nil, errors.New("existing clip database has no recognized clips table")
+		}
+		if err := preflightClipFiles(db, files, schema.kind == clipSchemaPresentation); err != nil {
+			_ = db.Close()
+			return nil, err
+		}
+	} else {
+		db, err = sql.Open("sqlite3", databasePath)
+		if err != nil {
+			return nil, fmt.Errorf("open clip database: %w", err)
+		}
+		db.SetMaxOpenConns(1)
+		schema = clipSchema{kind: clipSchemaNone}
+	}
+
+	requireExistingKey := schema.kind == clipSchemaPhase2Encrypted || schema.kind == clipSchemaCurrent || schema.kind == clipSchemaPresentation
+	tokenKey, err := loadOrCreateTokenKey(root, requireExistingKey)
+	if err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	block, err := aes.NewCipher(tokenKey)
+	if err != nil {
+		return nil, fmt.Errorf("initialize clip token encryption: %w", err)
+	}
+	tokenAEAD, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("initialize clip token encryption: %w", err)
+	}
+	store := &clipStore{root: root, files: files, db: db, tokenAEAD: tokenAEAD}
+	if err := store.initialize(schema); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	if err := store.validateEncryptedTokens(); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	if err := store.reconcile(); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	return store, nil
+}
+
+func (s *clipStore) initialize(schema clipSchema) error {
+	if schema.kind == clipSchemaNone {
+		_, err := s.db.Exec(`
+			CREATE TABLE clips (
+				id TEXT PRIMARY KEY,
+				owner_uuid TEXT NOT NULL,
+				title TEXT NOT NULL,
+				rating_key TEXT NOT NULL,
+				media_id INTEGER NOT NULL,
+				from_ms INTEGER NOT NULL,
+				to_ms INTEGER NOT NULL,
+				created_at TEXT NOT NULL,
+				share_token_hash TEXT NOT NULL UNIQUE,
+				share_token_ciphertext BLOB NOT NULL,
+				creator_display_name TEXT,
+				media_kind TEXT,
+				movie_title TEXT,
+				movie_year INTEGER,
+				show_title TEXT,
+				season_number INTEGER,
+				episode_number INTEGER,
+				episode_title TEXT,
+				thumbnail_mime TEXT
+			);
+			CREATE INDEX clips_owner_created ON clips(owner_uuid, created_at DESC);
+			CREATE INDEX clips_created ON clips(created_at DESC);
+		`)
+		if err != nil {
+			return fmt.Errorf("initialize clip database: %w", err)
+		}
+		return nil
+	}
+	if schema.kind == clipSchemaPresentation {
+		return nil
+	}
+	if _, err := s.db.Exec("PRAGMA secure_delete = ON"); err != nil {
+		return fmt.Errorf("prepare legacy clip migration: %w", err)
+	}
+	if err := s.migrateToEncryptedTokens(schema.kind == clipSchemaPhase1Raw, schema.kind == clipSchemaPhase2Encrypted || schema.kind == clipSchemaCurrent, schema.kind != clipSchemaCurrent); err != nil {
+		return err
+	}
+	if _, err := s.db.Exec("VACUUM"); err != nil {
+		return fmt.Errorf("vacuum legacy clip data: %w", err)
+	}
+	return nil
+}
+
+func (s *clipStore) migrateToEncryptedTokens(hasRawToken, hasCiphertext, hasPath bool) error {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin clip database migration: %w", err)
+	}
+	defer tx.Rollback()
+	_, err = tx.Exec(`CREATE TABLE clips_v2 (
+		id TEXT PRIMARY KEY,
+		owner_uuid TEXT NOT NULL,
+		title TEXT NOT NULL,
+		rating_key TEXT NOT NULL,
+		media_id INTEGER NOT NULL,
+		from_ms INTEGER NOT NULL,
+		to_ms INTEGER NOT NULL,
+		created_at TEXT NOT NULL,
+		share_token_hash TEXT NOT NULL UNIQUE,
+		share_token_ciphertext BLOB NOT NULL,
+		creator_display_name TEXT,
+		media_kind TEXT,
+		movie_title TEXT,
+		movie_year INTEGER,
+		show_title TEXT,
+		season_number INTEGER,
+		episode_number INTEGER,
+		episode_title TEXT,
+		thumbnail_mime TEXT
+	)`)
+	if err != nil {
+		return fmt.Errorf("create migrated clip table: %w", err)
+	}
+	selectColumns := "id, owner_uuid, title, rating_key, media_id, from_ms, to_ms, created_at, "
+	if hasRawToken {
+		selectColumns += "share_token, "
+	} else {
+		selectColumns += "'' AS share_token, "
+	}
+	if hasCiphertext {
+		selectColumns += "share_token_ciphertext, "
+	} else {
+		selectColumns += "NULL AS share_token_ciphertext, "
+	}
+	selectColumns += "share_token_hash"
+	if hasPath {
+		selectColumns += ", file_path"
+	}
+	rows, err := tx.Query("SELECT " + selectColumns + " FROM clips")
+	if err != nil {
+		return fmt.Errorf("read legacy clip metadata: %w", err)
+	}
+	type legacyClip struct {
+		id, owner, title, rating, created, oldToken, hash, path string
+		oldCiphertext                                           []byte
+		media, from, to                                         int64
+	}
+	var legacy []legacyClip
+	for rows.Next() {
+		var clip legacyClip
+		var scanErr error
+		scanArgs := []any{&clip.id, &clip.owner, &clip.title, &clip.rating, &clip.media, &clip.from, &clip.to, &clip.created, &clip.oldToken, &clip.oldCiphertext, &clip.hash}
+		if hasPath {
+			scanArgs = append(scanArgs, &clip.path)
+		}
+		scanErr = rows.Scan(scanArgs...)
+		if scanErr != nil {
+			rows.Close()
+			return fmt.Errorf("read legacy clip metadata: %w", scanErr)
+		}
+		legacy = append(legacy, clip)
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return fmt.Errorf("read legacy clip metadata: %w", err)
+	}
+	rows.Close()
+	for _, clip := range legacy {
+		token := clip.oldToken
+		if token == "" {
+			var tokenErr error
+			token, _, tokenErr = newShareToken()
+			if tokenErr != nil {
+				return tokenErr
+			}
+		}
+		ciphertext := clip.oldCiphertext
+		if len(ciphertext) == 0 {
+			var encryptErr error
+			ciphertext, encryptErr = s.encryptToken(token)
+			if encryptErr != nil {
+				return fmt.Errorf("encrypt legacy clip token: %w", encryptErr)
+			}
+		}
+		hash := clip.hash
+		if !hasCiphertext || hash == "" {
+			hash = hashShareToken(token)
+		}
+		if _, err := tx.Exec(`INSERT INTO clips_v2
+			(id, owner_uuid, title, rating_key, media_id, from_ms, to_ms, created_at, share_token_hash, share_token_ciphertext,
+			 creator_display_name, media_kind, movie_title, movie_year, show_title, season_number, episode_number, episode_title, thumbnail_mime)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, clip.id, clip.owner, clip.title, clip.rating,
+			clip.media, clip.from, clip.to, clip.created, hash, ciphertext, nil, nil, nil, nil, nil, nil, nil, nil, nil); err != nil {
+			return fmt.Errorf("copy clip metadata during migration: %w", err)
+		}
+	}
+	if _, err = tx.Exec("DROP TABLE clips"); err != nil {
+		return fmt.Errorf("remove old clip table: %w", err)
+	}
+	if _, err = tx.Exec("ALTER TABLE clips_v2 RENAME TO clips"); err != nil {
+		return fmt.Errorf("rename migrated clip table: %w", err)
+	}
+	if _, err = tx.Exec("CREATE INDEX IF NOT EXISTS clips_owner_created ON clips(owner_uuid, created_at DESC)"); err != nil {
+		return fmt.Errorf("recreate clip owner index: %w", err)
+	}
+	if _, err = tx.Exec("CREATE INDEX IF NOT EXISTS clips_created ON clips(created_at DESC)"); err != nil {
+		return fmt.Errorf("recreate clip index: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit clip database migration: %w", err)
+	}
+	return nil
+}
+
+func (s *clipStore) validateEncryptedTokens() error {
+	rows, err := s.db.Query("SELECT id, share_token_hash, share_token_ciphertext FROM clips")
+	if err != nil {
+		return fmt.Errorf("read encrypted clip tokens: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id, tokenHash string
+		var ciphertext []byte
+		if err := rows.Scan(&id, &tokenHash, &ciphertext); err != nil {
+			return fmt.Errorf("read encrypted clip token: %w", err)
+		}
+		token, err := s.decryptToken(ciphertext)
+		if err != nil || tokenHash != hashShareToken(token) {
+			if err == nil {
+				err = errors.New("encrypted clip token does not match its hash")
+			}
+			return fmt.Errorf("validate encrypted clip %s: %w", id, err)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("validate encrypted clip tokens: %w", err)
+	}
+	return nil
+}
+
+func syncDirectory(path string) error {
+	directory, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer directory.Close()
+	return directory.Sync()
+}
+
+func (s *clipStore) close() error {
+	if s == nil || s.db == nil {
+		return nil
+	}
+	return s.db.Close()
+}
+
+func newShareToken() (string, string, error) {
+	var raw [32]byte
+	if _, err := io.ReadFull(rand.Reader, raw[:]); err != nil {
+		return "", "", fmt.Errorf("generate share token: %w", err)
+	}
+	token := hex.EncodeToString(raw[:])
+	return token, hashShareToken(token), nil
+}
+
+func hashShareToken(token string) string {
+	hash := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(hash[:])
+}
+
+func (s *clipStore) encryptToken(token string) ([]byte, error) {
+	nonce := make([]byte, s.tokenAEAD.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, err
+	}
+	return s.tokenAEAD.Seal(nonce, nonce, []byte(token), nil), nil
+}
+
+func (s *clipStore) decryptToken(ciphertext []byte) (string, error) {
+	nonceSize := s.tokenAEAD.NonceSize()
+	if len(ciphertext) < nonceSize {
+		return "", errors.New("clip token ciphertext is invalid")
+	}
+	plaintext, err := s.tokenAEAD.Open(nil, ciphertext[:nonceSize], ciphertext[nonceSize:], nil)
+	if err != nil {
+		return "", fmt.Errorf("decrypt clip token: %w", err)
+	}
+	return string(plaintext), nil
+}
+
+func nullableString(value string) any {
+	if value == "" {
+		return nil
+	}
+	return value
+}
+
+func nullableInt(value *int) any {
+	if value == nil {
+		return nil
+	}
+	return *value
+}
+
+func (s *clipStore) promote(spec renderJobSpec, sourcePath string) (*Clip, error) {
+	return s.promoteWithArtwork(spec, sourcePath, "", "")
+}
+
+func (s *clipStore) promoteWithArtwork(spec renderJobSpec, sourcePath, artworkSource, artworkMIME string) (*Clip, error) {
+	if s == nil || s.db == nil {
+		return nil, errors.New("clip storage is unavailable")
+	}
+	if artworkSource == "" {
+		artworkMIME = ""
+	}
+	info, err := os.Stat(sourcePath)
+	if err != nil {
+		return nil, fmt.Errorf("stat completed render: %w", err)
+	}
+	if !info.Mode().IsRegular() || info.Size() == 0 {
+		return nil, errors.New("completed render is empty or not regular")
+	}
+
+	id := uuid.NewString()
+	token, tokenHash, err := newShareToken()
+	if err != nil {
+		return nil, err
+	}
+	path, err := s.clipPath(id)
+	if err != nil {
+		return nil, err
+	}
+	tmp := filepath.Join(s.files, "."+id+".partial")
+	artworkPath := ""
+	rollback := func() {
+		_ = os.Remove(tmp)
+		_ = os.Remove(path)
+		if artworkPath != "" {
+			_ = os.Remove(artworkPath)
+			_ = os.Remove(filepath.Join(s.files, "."+id+".thumb.partial"))
+		}
+		_ = syncDirectory(s.files)
+	}
+	if err := copyFileAtomically(sourcePath, tmp, path); err != nil {
+		rollback()
+		return nil, fmt.Errorf("persist clip bytes: %w", err)
+	}
+	if artworkSource != "" {
+		artworkPath, err = artworkPathForFiles(s.files, id)
+		if err != nil {
+			rollback()
+			return nil, err
+		}
+		artworkTmp := filepath.Join(s.files, "."+id+".thumb.partial")
+		if err := copyFileAtomically(artworkSource, artworkTmp, artworkPath); err != nil {
+			rollback()
+			return nil, fmt.Errorf("persist clip artwork: %w", err)
+		}
+	}
+
+	created := time.Now().UTC()
+	clip := &Clip{
+		ID: id, OwnerUUID: spec.OwnerUUID, Title: spec.Title,
+		RatingKey: spec.RatingKey, MediaID: spec.MediaID, FromMs: spec.FromMs,
+		ToMs: spec.ToMs, CreatedAt: created, FilePath: path, ShareToken: token,
+		CreatorDisplayName: spec.CreatorDisplayName, MediaKind: spec.MediaKind,
+		MovieTitle: spec.MovieTitle, MovieYear: spec.MovieYear, ShowTitle: spec.ShowTitle,
+		SeasonNumber: spec.SeasonNumber, EpisodeNumber: spec.EpisodeNumber,
+		EpisodeTitle: spec.EpisodeTitle, ArtworkPath: artworkPath, ThumbnailMIME: artworkMIME,
+		tokenHash: tokenHash,
+	}
+	ciphertext, err := s.encryptToken(token)
+	if err != nil {
+		rollback()
+		return nil, fmt.Errorf("encrypt clip token: %w", err)
+	}
+	_, err = s.db.Exec(`INSERT INTO clips
+		(id, owner_uuid, title, rating_key, media_id, from_ms, to_ms, created_at, share_token_hash, share_token_ciphertext,
+		 creator_display_name, media_kind, movie_title, movie_year, show_title, season_number, episode_number, episode_title, thumbnail_mime)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		clip.ID, clip.OwnerUUID, clip.Title, clip.RatingKey, clip.MediaID,
+		clip.FromMs, clip.ToMs, clip.CreatedAt.Format(time.RFC3339Nano),
+		tokenHash, ciphertext, nullableString(clip.CreatorDisplayName), nullableString(clip.MediaKind),
+		nullableString(clip.MovieTitle), nullableInt(clip.MovieYear), nullableString(clip.ShowTitle),
+		nullableInt(clip.SeasonNumber), nullableInt(clip.EpisodeNumber), nullableString(clip.EpisodeTitle),
+		nullableString(clip.ThumbnailMIME))
+	if err != nil {
+		rollback()
+		return nil, fmt.Errorf("persist clip metadata: %w", err)
+	}
+	return clip, nil
+}
+
+func copyFileAtomically(sourcePath, tmpPath, destinationPath string) error {
+	source, err := os.Open(sourcePath)
+	if err != nil {
+		return err
+	}
+	defer source.Close()
+	tmp, err := os.OpenFile(tmpPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
+	if err != nil {
+		return err
+	}
+	if _, err = io.Copy(tmp, source); err == nil {
+		err = tmp.Sync()
+	}
+	if closeErr := tmp.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		return err
+	}
+	if err := os.Rename(tmpPath, destinationPath); err != nil {
+		return err
+	}
+	return syncDirectory(filepath.Dir(destinationPath))
+}
+
+func parseClipTime(value string) (time.Time, error) {
+	return time.Parse(time.RFC3339Nano, value)
+}
+
+func (s *clipStore) clipPath(id string) (string, error) {
+	return clipPathForFiles(s.files, id)
+}
+
+func (s *clipStore) scanClip(scanner interface{ Scan(...any) error }) (*Clip, error) {
+	var clip Clip
+	var created string
+	var tokenHash string
+	var creator, mediaKind, movieTitle, showTitle, episodeTitle, thumbnailMIME sql.NullString
+	var movieYear, seasonNumber, episodeNumber sql.NullInt64
+	if err := scanner.Scan(&clip.ID, &clip.OwnerUUID, &clip.Title, &clip.RatingKey,
+		&clip.MediaID, &clip.FromMs, &clip.ToMs, &created, &tokenHash, &clip.tokenCiphertext,
+		&creator, &mediaKind, &movieTitle, &movieYear, &showTitle, &seasonNumber, &episodeNumber,
+		&episodeTitle, &thumbnailMIME); err != nil {
+		return nil, err
+	}
+	var err error
+	clip.CreatedAt, err = parseClipTime(created)
+	if err != nil {
+		return nil, fmt.Errorf("parse clip creation time: %w", err)
+	}
+	clip.FilePath, err = s.clipPath(clip.ID)
+	if err != nil {
+		return nil, err
+	}
+	clip.CreatorDisplayName = creator.String
+	clip.MediaKind = mediaKind.String
+	clip.MovieTitle = movieTitle.String
+	clip.ShowTitle = showTitle.String
+	clip.EpisodeTitle = episodeTitle.String
+	if movieYear.Valid {
+		value := int(movieYear.Int64)
+		clip.MovieYear = &value
+	}
+	if seasonNumber.Valid {
+		value := int(seasonNumber.Int64)
+		clip.SeasonNumber = &value
+	}
+	if episodeNumber.Valid {
+		value := int(episodeNumber.Int64)
+		clip.EpisodeNumber = &value
+	}
+	if thumbnailMIME.Valid && thumbnailMIME.String != "" {
+		clip.ThumbnailMIME = thumbnailMIME.String
+		clip.ArtworkPath, err = artworkPathForFiles(s.files, clip.ID)
+		if err != nil {
+			return nil, err
+		}
+	}
+	clip.tokenHash = tokenHash
+	return &clip, nil
+}
+
+const clipSelect = `id, owner_uuid, title, rating_key, media_id, from_ms, to_ms, created_at, share_token_hash, share_token_ciphertext,
+	creator_display_name, media_kind, movie_title, movie_year, show_title, season_number, episode_number, episode_title, thumbnail_mime`
+
+func (s *clipStore) get(id string) (*Clip, error) {
+	row := s.db.QueryRow("SELECT "+clipSelect+" FROM clips WHERE id = ?", id)
+	clip, err := s.scanClip(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, errClipNotFound
+	}
+	if err == nil {
+		err = s.verifyClipToken(clip)
+	}
+	return clip, err
+}
+
+func (s *clipStore) reconcile() error {
+	// Reconciliation is deliberately non-destructive. Complete correspondence
+	// is preflighted before migrations or startup reaches this point; a later
+	// mismatch is treated as an unsafe restore rather than repaired by delete.
+	return preflightClipFiles(s.db, s.files, true)
+}
+
+func (s *clipStore) getByShareToken(token string) (*Clip, error) {
+	row := s.db.QueryRow("SELECT "+clipSelect+" FROM clips WHERE share_token_hash = ?", hashShareToken(token))
+	clip, err := s.scanClip(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, errClipNotFound
+	}
+	if err == nil {
+		err = s.verifyClipToken(clip)
+	}
+	return clip, err
+}
+
+func (s *clipStore) verifyClipToken(clip *Clip) error {
+	if clip == nil || clip.tokenHash == "" {
+		return errors.New("clip token hash is missing")
+	}
+	token, err := s.decryptToken(clip.tokenCiphertext)
+	if err != nil {
+		return err
+	}
+	if hashShareToken(token) != clip.tokenHash {
+		return errors.New("clip token ciphertext does not match its row")
+	}
+	return nil
+}
+
+func (s *clipStore) list(owner string, all bool) ([]Clip, error) {
+	query := "SELECT " + clipSelect + " FROM clips"
+	args := []any{}
+	if !all {
+		query += " WHERE owner_uuid = ?"
+		args = append(args, owner)
+	}
+	query += " ORDER BY created_at DESC, id DESC"
+	rows, err := s.db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var result []Clip
+	for rows.Next() {
+		clip, err := s.scanClip(rows)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, *clip)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (s *clipStore) delete(id string) error {
+	clip, err := s.get(id)
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(clip.FilePath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove clip bytes: %w", err)
+	}
+	if clip.ArtworkPath != "" {
+		if err := os.Remove(clip.ArtworkPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("remove clip artwork: %w", err)
+		}
+	}
+	if err := syncDirectory(s.files); err != nil {
+		return fmt.Errorf("sync clip deletion: %w", err)
+	}
+	result, err := s.db.Exec("DELETE FROM clips WHERE id = ?", id)
+	if err != nil {
+		return fmt.Errorf("remove clip metadata: %w", err)
+	}
+	if count, _ := result.RowsAffected(); count != 1 {
+		return errClipNotFound
+	}
+	return nil
+}
+
+func (a *API) clipIsAdmin(user *User) bool {
+	return a != nil && a.app != nil && a.app.isServerOwner(user)
+}
+
+func (a *API) clipCanAccess(user *User, clip *Clip) bool {
+	return user != nil && clip != nil && (a.clipIsAdmin(user) || user.Uuid == clip.OwnerUUID)
+}
+
+func (a *API) clipShareURL(token string) string {
+	return clipShareURLForDomain(a.config.API.Domain, token)
+}
+
+func clipShareURLForDomain(domain, token string) string {
+	path := "/shared/clips/" + token + "/download"
+	if strings.TrimSpace(domain) == "" {
+		return path
+	}
+	return strings.TrimRight(domain, "/") + path
+}
+
+type clipAPIResponse struct {
+	ID                 string    `json:"id"`
+	CreatorDisplayName string    `json:"creatorDisplayName,omitempty"`
+	MediaKind          string    `json:"mediaKind,omitempty"`
+	MovieTitle         string    `json:"movieTitle,omitempty"`
+	MovieYear          *int      `json:"movieYear,omitempty"`
+	ShowTitle          string    `json:"showTitle,omitempty"`
+	SeasonNumber       *int      `json:"seasonNumber,omitempty"`
+	EpisodeNumber      *int      `json:"episodeNumber,omitempty"`
+	EpisodeTitle       string    `json:"episodeTitle,omitempty"`
+	ArtworkURL         string    `json:"artworkUrl,omitempty"`
+	Title              string    `json:"title"`
+	RatingKey          string    `json:"ratingKey"`
+	MediaID            int64     `json:"mediaId"`
+	FromMs             int64     `json:"fromMs"`
+	ToMs               int64     `json:"toMs"`
+	CreatedAt          time.Time `json:"createdAt"`
+	ShareURL           string    `json:"shareUrl,omitempty"`
+	DownloadURL        string    `json:"downloadUrl,omitempty"`
+	PublicDownloadURL  string    `json:"publicDownloadUrl,omitempty"`
+	CanDelete          bool      `json:"canDelete"`
+	IsAdmin            *bool     `json:"isAdmin,omitempty"`
+}
+
+type clipListResponse struct {
+	Clips   []clipAPIResponse `json:"clips"`
+	IsAdmin bool              `json:"isAdmin"`
+}
+
+func (a *API) clipResponse(clip *Clip, includeOwner, includeShare, canDelete, isAdmin, includeAdmin bool) (clipAPIResponse, error) {
+	result := clipAPIResponse{
+		ID: clip.ID, Title: clip.Title, RatingKey: clip.RatingKey, MediaID: clip.MediaID,
+		FromMs: clip.FromMs, ToMs: clip.ToMs, CreatedAt: clip.CreatedAt,
+		CanDelete: canDelete,
+	}
+	if includeAdmin {
+		result.IsAdmin = &isAdmin
+	}
+	if includeShare {
+		result.DownloadURL = "/clips/" + clip.ID + "/download"
+		token := clip.ShareToken
+		if token == "" {
+			if err := a.app.clipStore.verifyClipToken(clip); err != nil {
+				return clipAPIResponse{}, err
+			}
+			var err error
+			token, err = a.app.clipStore.decryptToken(clip.tokenCiphertext)
+			if err != nil {
+				return clipAPIResponse{}, err
+			}
+		} else if hashShareToken(token) != clip.tokenHash {
+			return clipAPIResponse{}, errors.New("clip token does not match its row")
+		}
+		result.ShareURL = a.clipShareURL(token)
+		result.PublicDownloadURL = result.ShareURL
+	}
+	if includeOwner {
+		result.CreatorDisplayName = clip.CreatorDisplayName
+		result.MediaKind = clip.MediaKind
+		result.MovieTitle = clip.MovieTitle
+		result.MovieYear = clip.MovieYear
+		result.ShowTitle = clip.ShowTitle
+		result.SeasonNumber = clip.SeasonNumber
+		result.EpisodeNumber = clip.EpisodeNumber
+		result.EpisodeTitle = clip.EpisodeTitle
+		if clip.ArtworkPath != "" {
+			result.ArtworkURL = "/clips/" + clip.ID + "/artwork"
+		}
+	}
+	return result, nil
+}
+
+func (a *API) listClips(ctx fiber.Ctx) error {
+	setCapabilityResponseHeaders(ctx)
+	user := UserFromContext(ctx.UserContext())
+	if user == nil || user.Uuid == "" {
+		return renderAPIErrorCode(ctx, http.StatusUnauthorized, "authentication_required", "authentication required")
+	}
+	if a.app == nil || a.app.clipStore == nil {
+		return renderAPIError(ctx, http.StatusServiceUnavailable, "clip storage is unavailable")
+	}
+	all := a.clipIsAdmin(user)
+	clips, err := a.app.clipStore.list(user.Uuid, all)
+	if err != nil {
+		return renderAPIError(ctx, http.StatusServiceUnavailable, "clip storage is unavailable")
+	}
+	result := make([]clipAPIResponse, 0, len(clips))
+	for i := range clips {
+		response, err := a.clipResponse(&clips[i], true, true, all || clips[i].OwnerUUID == user.Uuid, all, false)
+		if err != nil {
+			return renderAPIError(ctx, http.StatusServiceUnavailable, "clip storage is unavailable")
+		}
+		result = append(result, response)
+	}
+	return ctx.JSON(clipListResponse{Clips: result, IsAdmin: all})
+}
+
+func (a *API) getClip(ctx fiber.Ctx) error {
+	setCapabilityResponseHeaders(ctx)
+	user := UserFromContext(ctx.UserContext())
+	if user == nil || user.Uuid == "" {
+		return renderAPIErrorCode(ctx, http.StatusUnauthorized, "authentication_required", "authentication required")
+	}
+	if a.app == nil || a.app.clipStore == nil {
+		return renderAPIError(ctx, http.StatusServiceUnavailable, "clip storage is unavailable")
+	}
+	clip, err := a.app.clipStore.get(ctx.Params("id"))
+	if err != nil {
+		if errors.Is(err, errClipNotFound) {
+			return renderAPIError(ctx, http.StatusNotFound, "clip not found")
+		}
+		return renderAPIError(ctx, http.StatusServiceUnavailable, "clip storage is unavailable")
+	}
+	if !a.clipCanAccess(user, clip) {
+		return renderAPIError(ctx, http.StatusNotFound, "clip not found")
+	}
+	isAdmin := a.clipIsAdmin(user)
+	response, err := a.clipResponse(clip, true, true, isAdmin || clip.OwnerUUID == user.Uuid, isAdmin, true)
+	if err != nil {
+		return renderAPIError(ctx, http.StatusServiceUnavailable, "clip storage is unavailable")
+	}
+	return ctx.JSON(response)
+}
+
+func (a *API) downloadClip(ctx fiber.Ctx) error {
+	setCapabilityResponseHeaders(ctx)
+	user := UserFromContext(ctx.UserContext())
+	if user == nil || user.Uuid == "" {
+		return renderAPIErrorCode(ctx, http.StatusUnauthorized, "authentication_required", "authentication required")
+	}
+	if a.app == nil || a.app.clipStore == nil {
+		return renderAPIError(ctx, http.StatusServiceUnavailable, "clip storage is unavailable")
+	}
+	clip, err := a.app.clipStore.get(ctx.Params("id"))
+	if err != nil {
+		if errors.Is(err, errClipNotFound) {
+			return renderAPIError(ctx, http.StatusNotFound, "clip not found")
+		}
+		return renderAPIError(ctx, http.StatusServiceUnavailable, "clip storage is unavailable")
+	}
+	if !a.clipCanAccess(user, clip) {
+		return renderAPIError(ctx, http.StatusNotFound, "clip not found")
+	}
+	return a.sendClipFile(ctx, clip, true)
+}
+
+func (a *API) downloadClipArtwork(ctx fiber.Ctx) error {
+	setCapabilityResponseHeaders(ctx)
+	user := UserFromContext(ctx.UserContext())
+	if user == nil || user.Uuid == "" {
+		return renderAPIErrorCode(ctx, http.StatusUnauthorized, "authentication_required", "authentication required")
+	}
+	if a.app == nil || a.app.clipStore == nil {
+		return renderAPIError(ctx, http.StatusServiceUnavailable, "clip storage is unavailable")
+	}
+	clip, err := a.app.clipStore.get(ctx.Params("id"))
+	if err != nil {
+		if errors.Is(err, errClipNotFound) {
+			return renderAPIError(ctx, http.StatusNotFound, "clip not found")
+		}
+		return renderAPIError(ctx, http.StatusServiceUnavailable, "clip storage is unavailable")
+	}
+	if !a.clipCanAccess(user, clip) {
+		return renderAPIError(ctx, http.StatusNotFound, "clip not found")
+	}
+	if clip.ArtworkPath == "" {
+		return renderAPIError(ctx, http.StatusNotFound, "clip artwork is unavailable")
+	}
+	if _, err := os.Stat(clip.ArtworkPath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return renderAPIError(ctx, http.StatusGone, "clip artwork is unavailable")
+		}
+		return renderAPIError(ctx, http.StatusServiceUnavailable, "clip storage is unavailable")
+	}
+	ctx.Set("Content-Type", clip.ThumbnailMIME)
+	ctx.Set("X-Content-Type-Options", "nosniff")
+	return ctx.SendFile(clip.ArtworkPath, fiber.SendFile{ByteRange: true})
+}
+
+func (a *API) deleteClip(ctx fiber.Ctx) error {
+	setCapabilityResponseHeaders(ctx)
+	user := UserFromContext(ctx.UserContext())
+	if user == nil || user.Uuid == "" {
+		return renderAPIErrorCode(ctx, http.StatusUnauthorized, "authentication_required", "authentication required")
+	}
+	if a.app == nil || a.app.clipStore == nil {
+		return renderAPIError(ctx, http.StatusServiceUnavailable, "clip storage is unavailable")
+	}
+	clip, err := a.app.clipStore.get(ctx.Params("id"))
+	if err != nil {
+		if errors.Is(err, errClipNotFound) {
+			return renderAPIError(ctx, http.StatusNotFound, "clip not found")
+		}
+		return renderAPIError(ctx, http.StatusServiceUnavailable, "clip storage is unavailable")
+	}
+	if !a.clipCanAccess(user, clip) {
+		return renderAPIError(ctx, http.StatusNotFound, "clip not found")
+	}
+	if err := a.app.clipStore.delete(clip.ID); err != nil {
+		return renderAPIError(ctx, http.StatusServiceUnavailable, "clip storage is unavailable")
+	}
+	return ctx.SendStatus(http.StatusNoContent)
+}
+
+func (a *API) publicClip(ctx fiber.Ctx) error {
+	setCapabilityResponseHeaders(ctx)
+	if a.app == nil || a.app.clipStore == nil {
+		return renderAPIError(ctx, http.StatusServiceUnavailable, "clip storage is unavailable")
+	}
+	clip, err := a.app.clipStore.getByShareToken(ctx.Params("token"))
+	if errors.Is(err, errClipNotFound) {
+		return renderAPIError(ctx, http.StatusNotFound, "clip not found")
+	}
+	if err != nil {
+		return renderAPIError(ctx, http.StatusServiceUnavailable, "clip storage is unavailable")
+	}
+	response, err := a.clipResponse(clip, false, false, false, false, false)
+	if err != nil {
+		return renderAPIError(ctx, http.StatusServiceUnavailable, "clip storage is unavailable")
+	}
+	return ctx.JSON(response)
+}
+
+func (a *API) publicDownloadClip(ctx fiber.Ctx) error {
+	setCapabilityResponseHeaders(ctx)
+	if a.app == nil || a.app.clipStore == nil {
+		return renderAPIError(ctx, http.StatusServiceUnavailable, "clip storage is unavailable")
+	}
+	clip, err := a.app.clipStore.getByShareToken(ctx.Params("token"))
+	if errors.Is(err, errClipNotFound) {
+		return renderAPIError(ctx, http.StatusNotFound, "clip not found")
+	}
+	if err != nil {
+		return renderAPIError(ctx, http.StatusServiceUnavailable, "clip storage is unavailable")
+	}
+	return a.sendClipFile(ctx, clip, false)
+}
+
+func (a *API) sendClipFile(ctx fiber.Ctx, clip *Clip, attachment bool) error {
+	if _, err := os.Stat(clip.FilePath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return renderAPIError(ctx, http.StatusGone, "clip bytes are unavailable")
+		}
+		return renderAPIError(ctx, http.StatusServiceUnavailable, "clip storage is unavailable")
+	}
+	ctx.Type(".mp4")
+	setCapabilityResponseHeaders(ctx)
+	if attachment {
+		ctx.Set(fiber.HeaderContentDisposition, renderDownloadContentDisposition(renderJobSpec{
+			Title: clip.Title, FromMs: clip.FromMs, ToMs: clip.ToMs,
+		}))
+	} else {
+		ctx.Set(fiber.HeaderContentDisposition, "inline")
+	}
+	return ctx.SendFile(clip.FilePath, fiber.SendFile{ByteRange: true})
+}

--- a/clips_test.go
+++ b/clips_test.go
@@ -1,0 +1,1457 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"image"
+	"image/color"
+	"image/png"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/LukeHagar/plexgo"
+	"github.com/LukeHagar/plexgo/models/components"
+	"github.com/gofiber/fiber/v3"
+)
+
+func TestSuccessfulRenderPromotesToDurableClipAndSurvivesStoreReopen(t *testing.T) {
+	root := t.TempDir()
+	store, err := newClipStore(root, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.close()
+	manager, err := newRenderJobManagerWithContextAndPromotion(context.Background(), filepath.Join(root, "transient"), func(_ context.Context, spec renderJobSpec, output string) error {
+		return os.WriteFile(output, []byte("durable mp4"), 0600)
+	}, func(job *renderJob, output string) error {
+		clip, err := store.promote(job.spec, output)
+		if err == nil {
+			job.mu.Lock()
+			job.clipID = clip.ID
+			job.shareURL = clipShareURLForDomain("https://clips.example.test", clip.ShareToken)
+			job.mu.Unlock()
+		}
+		return err
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	job, err := manager.enqueue("creator-a", renderTestSpec("creator-a"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer manager.stopAndWait()
+	status := waitRenderStatus(t, manager, job.id, "creator-a", renderSucceeded)
+	if status.ClipID == "" {
+		t.Fatal("successful render did not return promoted clip id")
+	}
+	if status.ShareURL == "" {
+		t.Fatalf("successful promotion did not emit a share URL: %q", status.ShareURL)
+	}
+	clip, err := store.get(status.ClipID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, err := os.ReadFile(clip.FilePath); err != nil || string(got) != "durable mp4" {
+		t.Fatalf("durable clip bytes = %q, %v", got, err)
+	}
+
+	if err := store.close(); err != nil {
+		t.Fatal(err)
+	}
+	reopened, err := newClipStore(root, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reopened.close()
+	clips, err := reopened.list("creator-a", false)
+	if err != nil || len(clips) != 1 || clips[0].ID != clip.ID {
+		t.Fatalf("reopened clips = %+v, %v", clips, err)
+	}
+	if clips[0].ShareToken != "" {
+		t.Fatal("reopened clip leaked a raw share token")
+	}
+	rows, err := reopened.db.Query("PRAGMA table_info(clips)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var cid, notNull, primaryKey int
+		var name, columnType string
+		var defaultValue any
+		if err := rows.Scan(&cid, &name, &columnType, &notNull, &defaultValue, &primaryKey); err != nil {
+			t.Fatal(err)
+		}
+		if name == "share_token" {
+			t.Fatal("raw share token column remains in SQLite")
+		}
+	}
+}
+
+func TestClipStartupPreflightFailsClosedWithoutDeletingMismatchedDurableState(t *testing.T) {
+	root := t.TempDir()
+	store, err := newClipStore(root, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	missingSource := filepath.Join(t.TempDir(), "missing.mp4")
+	if err := os.WriteFile(missingSource, []byte("missing"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	missing, err := store.promote(renderTestSpec("missing-owner"), missingSource)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(missing.FilePath); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "clips", "orphan.mp4"), []byte("orphan"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "clips", ".crash.partial"), []byte("partial"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := newClipStore(root, ""); err == nil {
+		t.Fatal("mismatched database/files were reconciled destructively")
+	}
+	for _, path := range []string{filepath.Join(root, "clips", "orphan.mp4"), filepath.Join(root, "clips", ".crash.partial")} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("mismatched durable file was removed: %q: %v", path, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(root, "clips.sqlite3")); err != nil {
+		t.Fatalf("mismatched database was removed: %v", err)
+	}
+}
+
+func TestClipStartupPreflightRejectsPartialMP4SetWithoutMutation(t *testing.T) {
+	root := t.TempDir()
+	store, err := newClipStore(root, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	makeClip := func(name string) *Clip {
+		source := filepath.Join(t.TempDir(), name+".mp4")
+		if err := os.WriteFile(source, []byte(name), 0600); err != nil {
+			t.Fatal(err)
+		}
+		clip, err := store.promote(renderTestSpec(name), source)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return clip
+	}
+	first, second := makeClip("first"), makeClip("second")
+	if err := store.close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(second.FilePath); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := newClipStore(root, ""); err == nil {
+		t.Fatal("partial MP4 set was accepted")
+	}
+	if _, err := os.Stat(first.FilePath); err != nil {
+		t.Fatalf("preflight removed surviving MP4: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "clips.sqlite3")); err != nil {
+		t.Fatalf("preflight removed database: %v", err)
+	}
+}
+
+func TestClipStoreMigratesLegacyRawTokenColumnAway(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "clips"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	db, err := sql.Open("sqlite3", filepath.Join(root, "clips.sqlite3"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = db.Exec(`CREATE TABLE clips (
+		id TEXT PRIMARY KEY, owner_uuid TEXT NOT NULL, title TEXT NOT NULL,
+		rating_key TEXT NOT NULL, media_id INTEGER NOT NULL, from_ms INTEGER NOT NULL,
+		to_ms INTEGER NOT NULL, created_at TEXT NOT NULL, share_token TEXT NOT NULL UNIQUE,
+		share_token_hash TEXT NOT NULL UNIQUE, file_path TEXT NOT NULL UNIQUE
+	);
+	INSERT INTO clips VALUES ('legacy', 'owner', 'Legacy', 'movie', 1, 0, 1000,
+		'2026-01-01T00:00:00Z', 'raw-secret-token', 'hash-only', 'CLIP_PATH');`)
+	if err != nil {
+		db.Close()
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "clips", "legacy.mp4"), []byte("legacy bytes"), 0600); err != nil {
+		db.Close()
+		t.Fatal(err)
+	}
+	_, err = db.Exec("UPDATE clips SET file_path = ? WHERE id = 'legacy'", filepath.Join(root, "clips", "legacy.mp4"))
+	if err != nil {
+		db.Close()
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	store, err := newClipStore(root, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.close()
+	if _, err := store.get("legacy"); err != nil {
+		t.Fatalf("legacy clip was not retained after migration: %v", err)
+	}
+	var rawColumnCount int
+	if err := store.db.QueryRow("SELECT count(*) FROM pragma_table_info('clips') WHERE name = 'share_token'").Scan(&rawColumnCount); err != nil {
+		t.Fatal(err)
+	}
+	if rawColumnCount != 0 {
+		t.Fatal("legacy raw share token column survived migration")
+	}
+}
+
+func TestCurrentEncryptedSchemaAddsNullablePresentationColumns(t *testing.T) {
+	root := t.TempDir()
+	store, err := newClipStore(root, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	source := filepath.Join(t.TempDir(), "current.mp4")
+	if err := os.WriteFile(source, []byte("current"), 0600); err != nil {
+		store.close()
+		t.Fatal(err)
+	}
+	clip, err := store.promote(renderJobSpec{OwnerUUID: "creator-a", Title: "Old current", RatingKey: "movie", MediaID: 1, FromMs: 0, ToMs: 1000}, source)
+	if err != nil {
+		store.close()
+		t.Fatal(err)
+	}
+	var ciphertext []byte
+	if err := store.db.QueryRow("SELECT share_token_ciphertext FROM clips WHERE id = ?", clip.ID).Scan(&ciphertext); err != nil {
+		store.close()
+		t.Fatal(err)
+	}
+	if err := store.close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(filepath.Join(root, "clips.sqlite3")); err != nil {
+		t.Fatal(err)
+	}
+	db, err := sql.Open("sqlite3", filepath.Join(root, "clips.sqlite3"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = db.Exec(`CREATE TABLE clips (
+		id TEXT PRIMARY KEY, owner_uuid TEXT NOT NULL, title TEXT NOT NULL,
+		rating_key TEXT NOT NULL, media_id INTEGER NOT NULL, from_ms INTEGER NOT NULL,
+		to_ms INTEGER NOT NULL, created_at TEXT NOT NULL, share_token_hash TEXT NOT NULL UNIQUE,
+		share_token_ciphertext BLOB NOT NULL
+	);
+	INSERT INTO clips VALUES (?, 'creator-a', 'Old current', 'movie', 1, 0, 1000, ?, ?, ?);`, clip.ID, clip.CreatedAt.Format(time.RFC3339Nano), hashShareToken(clip.ShareToken), ciphertext)
+	if err != nil {
+		db.Close()
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	reopened, err := newClipStore(root, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reopened.close()
+	restored, err := reopened.get(clip.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if restored.CreatorDisplayName != "" || restored.ArtworkPath != "" {
+		t.Fatalf("old current clip did not retain nullable presentation defaults: %+v", restored)
+	}
+	encoded, err := json.Marshal(restored)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(encoded), "ownerUuid") || strings.Contains(string(encoded), "creator@example.test") {
+		t.Fatalf("old clip JSON exposed private identity data: %s", encoded)
+	}
+	api := &API{app: &Application{clipStore: reopened}}
+	var storedHash string
+	if err := reopened.db.QueryRow("SELECT share_token_hash FROM clips WHERE id = ?", clip.ID).Scan(&storedHash); err != nil {
+		t.Fatal(err)
+	}
+	if storedHash != hashShareToken(clip.ShareToken) {
+		t.Fatalf("preserved hash = %q, want %q", storedHash, hashShareToken(clip.ShareToken))
+	}
+	public := fiber.New()
+	public.Get("/shared/clips/:token/download", api.publicDownloadClip)
+	response, err := public.Test(httptest.NewRequest(http.MethodGet, "/shared/clips/"+clip.ShareToken+"/download", nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ := io.ReadAll(response.Body)
+	response.Body.Close()
+	if response.StatusCode != http.StatusOK || string(body) != "current" {
+		t.Fatalf("preserved old public URL = %d %q", response.StatusCode, body)
+	}
+}
+
+func TestServerOwnerUsesUUIDBeforeNormalizedEmailFallback(t *testing.T) {
+	app := &Application{ownerUUID: "plex-owner-uuid", ownerEmail: "owner@example.test"}
+	if app.isServerOwner(&User{Uuid: "other", Email: "owner@example.test"}) {
+		t.Fatal("matching email bypassed configured Plex account UUID")
+	}
+	if !app.isServerOwner(&User{Uuid: " PLEX-OWNER-UUID ", Email: "different@example.test"}) {
+		t.Fatal("configured Plex account UUID was not normalized")
+	}
+	if !app.isServerOwner(&User{Email: " OWNER@EXAMPLE.TEST "}) {
+		t.Fatal("owner email fallback did not apply when request UUID was unavailable")
+	}
+	app.ownerUUID = ""
+	if !app.isServerOwner(&User{Email: " OWNER@EXAMPLE.TEST "}) {
+		t.Fatal("normalized email fallback did not identify server owner")
+	}
+}
+
+func TestClipStorageFailureIsNotReportedAsAuthenticationOrNotFound(t *testing.T) {
+	store, err := newClipStore(t.TempDir(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.close(); err != nil {
+		t.Fatal(err)
+	}
+	api := &API{app: &Application{clipStore: store}}
+	app := fiber.New()
+	app.Use(func(ctx fiber.Ctx) error {
+		ctx.SetUserContext(ContextWithUser(context.Background(), User{Uuid: "creator-a"}))
+		return ctx.Next()
+	})
+	app.Get("/clips/:id", api.getClip)
+	response, err := app.Test(httptest.NewRequest(http.MethodGet, "/clips/clip-1", nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	response.Body.Close()
+	if response.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("closed clip storage status = %d, want 503", response.StatusCode)
+	}
+}
+
+func TestConfiguredDurableStorageRootFailureIsSurfacedAtStartup(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "storage-root")
+	if err := os.WriteFile(root, []byte("not a directory"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := newClipStore(root, ""); err == nil {
+		t.Fatal("inaccessible configured durable root was accepted")
+	}
+}
+
+func persistPhase3TestClip(t *testing.T) (string, *Clip) {
+	t.Helper()
+	root := t.TempDir()
+	store, err := newClipStore(root, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	source := filepath.Join(t.TempDir(), "persisted.mp4")
+	if err := os.WriteFile(source, []byte("persisted"), 0600); err != nil {
+		store.close()
+		t.Fatal(err)
+	}
+	clip, err := store.promote(renderTestSpec("creator-a"), source)
+	if err != nil {
+		store.close()
+		t.Fatal(err)
+	}
+	if err := store.close(); err != nil {
+		t.Fatal(err)
+	}
+	return root, clip
+}
+
+func TestClipStoreFailsClosedWhenDatabaseIsMissingBesideMP4s(t *testing.T) {
+	root, clip := persistPhase3TestClip(t)
+	if err := os.Remove(filepath.Join(root, "clips.sqlite3")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := newClipStore(root, ""); err == nil {
+		t.Fatal("missing database with durable MP4s was accepted")
+	}
+	if _, err := os.Stat(clip.FilePath); err != nil {
+		t.Fatalf("ambiguous recovery removed durable MP4: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "clips.sqlite3")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("ambiguous recovery created a replacement database: %v", err)
+	}
+}
+
+func TestClipStoreRejectsMissingOrWrongKeyWithoutReplacement(t *testing.T) {
+	root, _ := persistPhase3TestClip(t)
+	keyPath := filepath.Join(root, clipTokenKeyFile)
+	keyBefore, err := os.ReadFile(keyPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(keyPath); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := newClipStore(root, ""); err == nil {
+		t.Fatal("missing key for encrypted records was accepted")
+	}
+	if _, err := os.Stat(keyPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("missing required key was regenerated: %v", err)
+	}
+	if err := os.WriteFile(keyPath, bytes.Repeat([]byte{0xA5}, len(keyBefore)), 0600); err != nil {
+		t.Fatal(err)
+	}
+	wrongKey, err := os.ReadFile(keyPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := newClipStore(root, ""); err == nil {
+		t.Fatal("wrong key for encrypted records was accepted")
+	}
+	keyAfter, err := os.ReadFile(keyPath)
+	if err != nil || !bytes.Equal(wrongKey, keyAfter) {
+		t.Fatalf("wrong key was replaced: %v", err)
+	}
+}
+
+func TestClipStoreRelocatedRootDerivesFilePathFromClipID(t *testing.T) {
+	parent := t.TempDir()
+	oldRoot := filepath.Join(parent, "old")
+	newRoot := filepath.Join(parent, "restored")
+	store, err := newClipStore(oldRoot, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	source := filepath.Join(t.TempDir(), "relocated.mp4")
+	if err := os.WriteFile(source, []byte("relocated"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	clip, err := store.promote(renderTestSpec("creator-a"), source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldPath := clip.FilePath
+	if err := store.close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(oldRoot, newRoot); err != nil {
+		t.Fatal(err)
+	}
+	restored, err := newClipStore(newRoot, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer restored.close()
+	restoredClip, err := restored.get(clip.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if restoredClip.FilePath == oldPath || !strings.HasPrefix(restoredClip.FilePath, filepath.Join(newRoot, "clips")) {
+		t.Fatalf("restored clip path = %q, old path %q", restoredClip.FilePath, oldPath)
+	}
+	if body, err := os.ReadFile(restoredClip.FilePath); err != nil || string(body) != "relocated" {
+		t.Fatalf("restored MP4 = %q, %v", body, err)
+	}
+}
+
+func TestClipStoreRejectsAbsoluteAndEscapingDatabasePaths(t *testing.T) {
+	root := t.TempDir()
+	for _, database := range []string{"/tmp/clips.sqlite3", "../outside.sqlite3", "nested/../../outside.sqlite3"} {
+		if _, err := newClipStore(root, database); err == nil {
+			t.Fatalf("database path %q escaped validation", database)
+		}
+	}
+	outside := filepath.Join(t.TempDir(), "outside")
+	if err := os.MkdirAll(outside, 0700); err != nil {
+		t.Fatal(err)
+	}
+	componentLink := filepath.Join(root, "linked")
+	if err := os.Symlink(outside, componentLink); err != nil {
+		t.Skipf("symlink test unavailable: %v", err)
+	}
+	if _, err := newClipStore(root, "linked/clips.sqlite3"); err == nil {
+		t.Fatal("database path through an escaping symlink component was accepted")
+	}
+	outsideDB := filepath.Join(outside, "outside.sqlite3")
+	if err := os.WriteFile(outsideDB, []byte{}, 0600); err != nil {
+		t.Fatal(err)
+	}
+	finalLink := filepath.Join(root, "linked.sqlite3")
+	if err := os.Symlink(outsideDB, finalLink); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := newClipStore(root, "linked.sqlite3"); err == nil {
+		t.Fatal("database path through an escaping final symlink was accepted")
+	}
+}
+
+func TestDeployedPhase1HashOnlyMigrationIsIdempotentAndRetainsClip(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "clips"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	db, err := sql.Open("sqlite3", filepath.Join(root, "clips.sqlite3"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	clipID := "deployed-phase1-clip"
+	filePath := filepath.Join(root, "clips", clipID+".mp4")
+	if err := os.WriteFile(filePath, []byte("hash-only media"), 0600); err != nil {
+		db.Close()
+		t.Fatal(err)
+	}
+	_, err = db.Exec(`CREATE TABLE clips (
+		id TEXT PRIMARY KEY, owner_uuid TEXT NOT NULL, title TEXT NOT NULL,
+		rating_key TEXT NOT NULL, media_id INTEGER NOT NULL, from_ms INTEGER NOT NULL,
+		to_ms INTEGER NOT NULL, created_at TEXT NOT NULL, share_token_hash TEXT NOT NULL UNIQUE,
+		file_path TEXT NOT NULL UNIQUE
+	);
+	INSERT INTO clips VALUES (?, 'creator-a', 'Migrated', 'movie', 1, 0, 1000,
+		'2026-01-01T00:00:00Z', ?, ?);`, clipID, hashShareToken("lost-phase1-token"), filePath)
+	if err != nil {
+		db.Close()
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	store, err := newClipStore(root, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	api := &API{app: &Application{clipStore: store}}
+	list := fiber.New()
+	list.Use(func(ctx fiber.Ctx) error {
+		ctx.SetUserContext(ContextWithUser(context.Background(), User{Uuid: "creator-a"}))
+		return ctx.Next()
+	})
+	list.Get("/clips", api.listClips)
+	response, err := list.Test(httptest.NewRequest(http.MethodGet, "/clips", nil))
+	if err != nil {
+		store.close()
+		t.Fatal(err)
+	}
+	var first clipListResponse
+	if err := json.NewDecoder(response.Body).Decode(&first); err != nil {
+		response.Body.Close()
+		store.close()
+		t.Fatal(err)
+	}
+	response.Body.Close()
+	if response.StatusCode != http.StatusOK || len(first.Clips) != 1 || first.Clips[0].ShareURL == "" {
+		store.close()
+		t.Fatalf("migrated HTTP list = %d %+v", response.StatusCode, first)
+	}
+	shareURL := first.Clips[0].ShareURL
+	if err := store.close(); err != nil {
+		t.Fatal(err)
+	}
+
+	reopened, err := newClipStore(root, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reopened.close()
+	restartedAPI := &API{app: &Application{clipStore: reopened}}
+	restartedList := fiber.New()
+	restartedList.Use(func(ctx fiber.Ctx) error {
+		ctx.SetUserContext(ContextWithUser(context.Background(), User{Uuid: "creator-a"}))
+		return ctx.Next()
+	})
+	restartedList.Get("/clips", restartedAPI.listClips)
+	response, err = restartedList.Test(httptest.NewRequest(http.MethodGet, "/clips", nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var second clipListResponse
+	if err := json.NewDecoder(response.Body).Decode(&second); err != nil {
+		response.Body.Close()
+		t.Fatal(err)
+	}
+	response.Body.Close()
+	if response.StatusCode != http.StatusOK || len(second.Clips) != 1 || second.Clips[0].ShareURL != shareURL {
+		t.Fatalf("second migrated HTTP list = %d %+v, want URL %q", response.StatusCode, second, shareURL)
+	}
+	var pathColumns int
+	if err := reopened.db.QueryRow("SELECT count(*) FROM pragma_table_info('clips') WHERE name = 'file_path'").Scan(&pathColumns); err != nil {
+		t.Fatal(err)
+	}
+	if pathColumns != 0 {
+		t.Fatal("migrated schema retained root-dependent file_path")
+	}
+	for _, column := range []string{"creator_display_name", "media_kind", "movie_title", "movie_year", "show_title", "season_number", "episode_number", "episode_title", "thumbnail_mime"} {
+		var count int
+		if err := reopened.db.QueryRow("SELECT count(*) FROM pragma_table_info('clips') WHERE name = ?", column).Scan(&count); err != nil {
+			t.Fatal(err)
+		}
+		if count != 1 {
+			t.Fatalf("migrated schema missing nullable presentation column %q", column)
+		}
+	}
+}
+
+func TestRenderPresentationClassifiesMovieAndEpisodeAndSnapshotsCreator(t *testing.T) {
+	year := 1999
+	season, episode := 3, 7
+	show := "Example Show"
+	movie := presentationFromMetadata(User{Username: "plex-user", Email: "user@example.test"}, nil, "movie", &components.Metadata{
+		Type: "movie", Title: "Example Movie", Year: &year,
+	})
+	if movie.CreatorDisplayName != "plex-user" || movie.MediaKind != "movie" || movie.MovieTitle != "Example Movie" || movie.MovieYear == nil || *movie.MovieYear != year {
+		t.Fatalf("movie presentation = %+v", movie)
+	}
+	episodePresentation := presentationFromMetadata(User{Title: "Plex display title", Email: "fallback@example.test"}, nil, "episode", &components.Metadata{
+		Type: "episode", Title: "Episode Title", GrandparentTitle: &show, ParentIndex: &season, Index: &episode,
+	})
+	if episodePresentation.CreatorDisplayName != "Plex display title" || episodePresentation.MediaKind != "episode" || episodePresentation.ShowTitle != show || episodePresentation.SeasonNumber == nil || *episodePresentation.SeasonNumber != season || episodePresentation.EpisodeNumber == nil || *episodePresentation.EpisodeNumber != episode || episodePresentation.EpisodeTitle != "Episode Title" {
+		t.Fatalf("episode presentation = %+v", episodePresentation)
+	}
+	if got := creatorDisplayName(User{Email: "fallback@example.test"}); got != "" {
+		t.Fatalf("creator display name fell back to email: %q", got)
+	}
+}
+
+func TestClipArtworkCopiesServesAuthenticatedAndDeletesWithClip(t *testing.T) {
+	root := t.TempDir()
+	store, err := newClipStore(root, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.close()
+	video := filepath.Join(t.TempDir(), "video.mp4")
+	artwork := filepath.Join(t.TempDir(), "poster.jpg")
+	if err := os.WriteFile(video, []byte("video"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(artwork, []byte("poster bytes"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	year := 2024
+	clip, err := store.promoteWithArtwork(renderJobSpec{OwnerUUID: "creator-a", CreatorDisplayName: "plex-user", MediaKind: "movie", MovieTitle: "Artwork Movie", MovieYear: &year, Title: "Artwork clip", RatingKey: "movie", MediaID: 1, FromMs: 0, ToMs: 1000}, video, artwork, "image/jpeg")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if clip.ArtworkPath == "" {
+		t.Fatal("promoted clip has no durable artwork path")
+	}
+	api := &API{app: &Application{clipStore: store}}
+	httpApp := fiber.New()
+	httpApp.Use(func(ctx fiber.Ctx) error {
+		ctx.SetUserContext(ContextWithUser(context.Background(), User{Uuid: "creator-a"}))
+		return ctx.Next()
+	})
+	httpApp.Get("/clips/:id/artwork", api.downloadClipArtwork)
+	httpApp.Get("/clips/:id", api.getClip)
+	response, err := httpApp.Test(httptest.NewRequest(http.MethodGet, "/clips/"+clip.ID+"/artwork", nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ := io.ReadAll(response.Body)
+	response.Body.Close()
+	if response.StatusCode != http.StatusOK || string(body) != "poster bytes" || response.Header.Get("Content-Type") != "image/jpeg" || response.Header.Get("X-Content-Type-Options") != "nosniff" {
+		t.Fatalf("artwork response = %d %q type=%q nosniff=%q", response.StatusCode, body, response.Header.Get("Content-Type"), response.Header.Get("X-Content-Type-Options"))
+	}
+	response, err = httpApp.Test(httptest.NewRequest(http.MethodGet, "/clips/"+clip.ID, nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	detailBody, _ := io.ReadAll(response.Body)
+	var detail clipAPIResponse
+	if err := json.Unmarshal(detailBody, &detail); err != nil {
+		response.Body.Close()
+		t.Fatal(err)
+	}
+	response.Body.Close()
+	for _, privateValue := range []string{"ownerUuid", "user@example.test"} {
+		if strings.Contains(string(detailBody), privateValue) {
+			t.Fatalf("authenticated detail exposed private value %q: %s", privateValue, detailBody)
+		}
+	}
+	if detail.CreatorDisplayName != "plex-user" || detail.MediaKind != "movie" || detail.MovieTitle != "Artwork Movie" || detail.MovieYear == nil || *detail.MovieYear != year || detail.ArtworkURL != "/clips/"+clip.ID+"/artwork" {
+		t.Fatalf("authenticated presentation detail = %+v", detail)
+	}
+	public := fiber.New()
+	public.Get("/shared/clips/:token", api.publicClip)
+	response, err = public.Test(httptest.NewRequest(http.MethodGet, "/shared/clips/"+clip.ShareToken, nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	publicBody, _ := io.ReadAll(response.Body)
+	response.Body.Close()
+	for _, privateField := range []string{"ownerUuid", "user@example.test", "creatorDisplayName", "mediaKind", "movieTitle", "movieYear", "showTitle", "seasonNumber", "episodeNumber", "episodeTitle", "artworkUrl", "/library/"} {
+		if strings.Contains(string(publicBody), privateField) {
+			t.Fatalf("public metadata exposed private presentation data: %s", publicBody)
+		}
+	}
+	artworkPath := clip.ArtworkPath
+	if err := store.delete(clip.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(artworkPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("clip artwork survived hard deletion: %v", err)
+	}
+}
+
+func TestClipArtworkFetchFailureStillAllowsClipWithoutThumbnail(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = io.WriteString(w, "upstream failure")
+	}))
+	defer server.Close()
+	application := &Application{}
+	application.config.Plex.Host = server.URL
+	path, mimeType, err := application.fetchClipArtwork(context.Background(), "/library/metadata/1/thumb")
+	if err == nil || path != "" || mimeType != "" {
+		t.Fatalf("artwork failure = path %q mime %q err %v", path, mimeType, err)
+	}
+	root := t.TempDir()
+	store, err := newClipStore(root, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.close()
+	video := filepath.Join(t.TempDir(), "video.mp4")
+	if err := os.WriteFile(video, []byte("video"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	clip, err := store.promoteWithArtwork(renderJobSpec{OwnerUUID: "creator-a", Title: "No poster", RatingKey: "movie", MediaID: 1, FromMs: 0, ToMs: 1000}, video, path, mimeType)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if clip.ArtworkPath != "" || clip.ThumbnailMIME != "" {
+		t.Fatalf("failed artwork was persisted: %+v", clip)
+	}
+}
+
+func TestClipArtworkFetchRejectsUnsafeRedirectsMIMEsOversizeAndTimeout(t *testing.T) {
+	validImage := func() []byte {
+		var buffer bytes.Buffer
+		imageValue := image.NewRGBA(image.Rect(0, 0, 1, 1))
+		imageValue.Set(0, 0, color.RGBA{R: 255, A: 255})
+		if err := png.Encode(&buffer, imageValue); err != nil {
+			t.Fatal(err)
+		}
+		return buffer.Bytes()
+	}
+	otherRequests := 0
+	other := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		otherRequests++
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write(validImage())
+	}))
+	defer other.Close()
+	base := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/redirect":
+			http.Redirect(w, r, other.URL+"/image", http.StatusFound)
+		case "/text":
+			w.Header().Set("Content-Type", "text/plain")
+			_, _ = io.WriteString(w, "not an image")
+		case "/svg":
+			w.Header().Set("Content-Type", "image/svg+xml")
+			_, _ = io.WriteString(w, "<svg></svg>")
+		case "/large":
+			w.Header().Set("Content-Type", "image/png")
+			_, _ = w.Write(bytes.Repeat([]byte("x"), int(maxClipArtworkBytes)+1))
+		case "/timeout":
+			<-r.Context().Done()
+		default:
+			w.Header().Set("Content-Type", "image/png")
+			_, _ = w.Write(validImage())
+		}
+	}))
+	defer base.Close()
+	application := &Application{}
+	application.config.Plex.Host = base.URL
+	checks := []string{
+		"//evil.example/image",
+		other.URL + "/image",
+		"http://user@" + strings.TrimPrefix(base.URL, "http://") + "/image",
+		"/redirect",
+		"/text",
+		"/svg",
+		"/large",
+	}
+	for _, path := range checks {
+		if temporary, _, err := application.fetchClipArtwork(context.Background(), path); err == nil {
+			if temporary != "" {
+				os.Remove(temporary)
+			}
+			t.Fatalf("unsafe/invalid artwork path %q was accepted", path)
+		}
+	}
+	if otherRequests != 0 {
+		t.Fatalf("cross-origin redirect reached destination %d times", otherRequests)
+	}
+	timeoutContext, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	if temporary, _, err := application.fetchClipArtwork(timeoutContext, "/timeout"); err == nil || temporary != "" {
+		t.Fatalf("artwork timeout = path %q err %v", temporary, err)
+	}
+	temporary, mimeType, err := application.fetchClipArtwork(context.Background(), "/image")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(temporary)
+	if mimeType != "image/png" {
+		t.Fatalf("valid artwork MIME = %q", mimeType)
+	}
+}
+
+func TestClipPromotionRollsBackMP4AndArtworkAfterMetadataFailure(t *testing.T) {
+	root := t.TempDir()
+	store, err := newClipStore(root, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	video := filepath.Join(t.TempDir(), "video.mp4")
+	artwork := filepath.Join(t.TempDir(), "poster.png")
+	if err := os.WriteFile(video, []byte("video"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(artwork, []byte("poster"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.promoteWithArtwork(renderJobSpec{OwnerUUID: "creator-a", Title: "rollback", RatingKey: "movie", MediaID: 1, FromMs: 0, ToMs: 1000}, video, artwork, "image/png"); err == nil {
+		t.Fatal("promotion succeeded with closed metadata database")
+	}
+	entries, err := os.ReadDir(filepath.Join(root, "clips"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("promotion rollback left durable files: %+v", entries)
+	}
+}
+
+func TestClipStartupPreflightRejectsMissingReferencedThumbnail(t *testing.T) {
+	root := t.TempDir()
+	store, err := newClipStore(root, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	video := filepath.Join(t.TempDir(), "video.mp4")
+	artwork := filepath.Join(t.TempDir(), "poster.jpg")
+	if err := os.WriteFile(video, []byte("video"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(artwork, []byte("poster"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	clip, err := store.promoteWithArtwork(renderJobSpec{OwnerUUID: "creator-a", Title: "Poster", RatingKey: "movie", MediaID: 1, FromMs: 0, ToMs: 1000}, video, artwork, "image/jpeg")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(clip.ArtworkPath); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := newClipStore(root, ""); err == nil {
+		t.Fatal("missing referenced thumbnail was reconciled destructively")
+	}
+	if _, err := os.Stat(filepath.Join(root, "clips.sqlite3")); err != nil {
+		t.Fatalf("thumbnail preflight removed database: %v", err)
+	}
+}
+
+func TestHTTPRenderPromotionRestartAndPublicDownloadLifecycle(t *testing.T) {
+	var poster bytes.Buffer
+	posterImage := image.NewRGBA(image.Rect(0, 0, 1, 1))
+	posterImage.Set(0, 0, color.RGBA{B: 255, A: 255})
+	if err := png.Encode(&poster, posterImage); err != nil {
+		t.Fatal(err)
+	}
+	plex := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/status/sessions":
+			_, _ = io.WriteString(w, `{"MediaContainer":{"Metadata":[{"key":"movie-1","title":"Lifecycle movie","thumb":"/library/metadata/movie-1/thumb","Media":[{"id":293539,"duration":60000,"Part":[{"id":293546}]}]}]}}`)
+		case "/library/metadata/movie-1":
+			_, _ = io.WriteString(w, `{"MediaContainer":{"Metadata":[{"ratingKey":"movie-1","type":"movie","title":"Lifecycle movie","year":2024,"thumb":"/library/metadata/movie-1/thumb","Media":[{"id":293539,"duration":60000,"Part":[{"id":293546,"key":"/library/parts/293546/file.mp4","duration":60000}]}]}]}}`)
+		case "/library/metadata/movie-1/thumb":
+			w.Header().Set("Content-Type", "image/png")
+			_, _ = w.Write(poster.Bytes())
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer plex.Close()
+
+	root := t.TempDir()
+	store, err := newClipStore(root, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var application *Application
+	manager, err := newRenderJobManagerWithContextAndPromotion(context.Background(), filepath.Join(root, "transient"), writeRenderOutput, func(job *renderJob, output string) error {
+		artworkPath, artworkMIME, _ := application.fetchClipArtwork(application.lifetime, job.spec.ThumbnailURL)
+		if artworkPath != "" {
+			defer os.Remove(artworkPath)
+		}
+		clip, err := store.promoteWithArtwork(job.spec, output, artworkPath, artworkMIME)
+		if err != nil {
+			return err
+		}
+		job.mu.Lock()
+		job.clipID = clip.ID
+		job.shareURL = clipShareURLForDomain("", clip.ShareToken)
+		job.mu.Unlock()
+		return nil
+	})
+	if err != nil {
+		store.close()
+		t.Fatal(err)
+	}
+	defer manager.stopAndWait()
+	config := Config{}
+	config.Plex.Host = plex.URL
+	config.Plex.Token = "admin-token"
+	lifetime, cancelLifetime := context.WithCancel(context.Background())
+	defer cancelLifetime()
+	application = &Application{
+		config:     config,
+		ownerEmail: "owner@example.com",
+		plexAdmin:  plexgo.New(plexgo.WithServerURL(plex.URL), plexgo.WithSecurity(config.Plex.Token)),
+		renderJobs: manager,
+		clipStore:  store,
+		lifetime:   lifetime,
+	}
+	api := &API{config: config, app: application}
+	httpApp := fiber.New()
+	httpApp.Use(func(ctx fiber.Ctx) error {
+		ctx.SetUserContext(ContextWithUser(context.Background(), User{Uuid: "owner-a", Username: "plex-user", Title: "Plex display title", Email: "owner@example.com"}))
+		return ctx.Next()
+	})
+	httpApp.Post("/render-jobs", api.createRenderJob)
+	httpApp.Get("/render-jobs/:id", api.getRenderJob)
+	httpApp.Get("/clips", api.listClips)
+
+	request := httptest.NewRequest(http.MethodPost, "/render-jobs", strings.NewReader(`{"ratingKey":"movie-1","mediaId":293546,"fromMs":0,"toMs":1000}`))
+	request.Header.Set("Content-Type", "application/json")
+	response, err := httpApp.Test(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var created renderJobResponse
+	if err := json.NewDecoder(response.Body).Decode(&created); err != nil {
+		response.Body.Close()
+		t.Fatal(err)
+	}
+	response.Body.Close()
+	if response.StatusCode != http.StatusAccepted || created.ID == "" {
+		t.Fatalf("render creation = %d %+v", response.StatusCode, created)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		response, err = httpApp.Test(httptest.NewRequest(http.MethodGet, "/render-jobs/"+created.ID, nil))
+		if err != nil {
+			t.Fatal(err)
+		}
+		var status renderJobResponse
+		decodeErr := json.NewDecoder(response.Body).Decode(&status)
+		response.Body.Close()
+		if decodeErr != nil {
+			t.Fatal(decodeErr)
+		}
+		if status.Status == renderSucceeded {
+			created = status
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if created.Status != renderSucceeded || created.ClipID == "" || created.ShareURL == "" {
+		t.Fatalf("render did not promote through HTTP lifecycle: %+v", created)
+	}
+	response, err = httpApp.Test(httptest.NewRequest(http.MethodGet, "/clips", nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	listBody, _ := io.ReadAll(response.Body)
+	var listed clipListResponse
+	if err := json.Unmarshal(listBody, &listed); err != nil {
+		response.Body.Close()
+		t.Fatal(err)
+	}
+	response.Body.Close()
+	for _, privateValue := range []string{"ownerUuid", "user@example.test"} {
+		if strings.Contains(string(listBody), privateValue) {
+			t.Fatalf("authenticated list exposed private value %q: %s", privateValue, listBody)
+		}
+	}
+	if response.StatusCode != http.StatusOK || len(listed.Clips) != 1 || listed.Clips[0].ID != created.ClipID || listed.Clips[0].ArtworkURL == "" || listed.Clips[0].MediaKind != "movie" || listed.Clips[0].MovieTitle != "Lifecycle movie" || listed.Clips[0].CreatorDisplayName != "plex-user" {
+		t.Fatalf("promoted HTTP clip list = %d %+v", response.StatusCode, listed)
+	}
+	if err := store.close(); err != nil {
+		t.Fatal(err)
+	}
+	restartedStore, err := newClipStore(root, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer restartedStore.close()
+	restartedAPI := &API{app: &Application{clipStore: restartedStore}}
+	public := fiber.New()
+	public.Get("/shared/clips/:token/download", restartedAPI.publicDownloadClip)
+	response, err = public.Test(httptest.NewRequest(http.MethodGet, created.ShareURL, nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ := io.ReadAll(response.Body)
+	response.Body.Close()
+	if response.StatusCode != http.StatusOK || string(body) != "valid mp4 bytes" {
+		t.Fatalf("restarted public lifecycle download = %d %q", response.StatusCode, body)
+	}
+}
+
+func TestClipAuthorizationAndPublicShareToken(t *testing.T) {
+	store, err := newClipStore(t.TempDir(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.close()
+	source := filepath.Join(t.TempDir(), "output.mp4")
+	if err := os.WriteFile(source, []byte("clip bytes"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	clip, err := store.promote(renderTestSpec("creator-a"), source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if clip.ShareToken == "" || clip.ShareToken == clip.ID || len(clip.ShareToken) < 40 {
+		t.Fatalf("share token is not sufficiently unguessable: %q", clip.ShareToken)
+	}
+
+	config := Config{}
+	config.API.Domain = "https://clips.example.test"
+	application := &Application{clipStore: store, ownerEmail: "owner@example.test"}
+	api := &API{config: config, app: application}
+	creator := func(ctx fiber.Ctx) error {
+		ctx.SetUserContext(ContextWithUser(context.Background(), User{Uuid: "creator-a", Email: "creator@example.test"}))
+		return ctx.Next()
+	}
+	authApp := fiber.New()
+	authApp.Use(creator)
+	authApp.Get("/clips/:id", api.getClip)
+	authApp.Delete("/clips/:id", api.deleteClip)
+
+	response, err := authApp.Test(httptest.NewRequest(http.MethodGet, "/clips/"+clip.ID, nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var creatorDetail clipAPIResponse
+	if err := json.NewDecoder(response.Body).Decode(&creatorDetail); err != nil {
+		response.Body.Close()
+		t.Fatal(err)
+	}
+	response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("creator detail status = %d", response.StatusCode)
+	}
+	if creatorDetail.IsAdmin == nil || *creatorDetail.IsAdmin || !creatorDetail.CanDelete {
+		t.Fatalf("creator detail capabilities = %+v", creatorDetail)
+	}
+
+	adminAPI := &API{config: config, app: &Application{clipStore: store, ownerEmail: "owner@example.test"}}
+	adminApp := fiber.New()
+	adminApp.Use(func(ctx fiber.Ctx) error {
+		ctx.SetUserContext(ContextWithUser(context.Background(), User{Uuid: "admin", Email: "OWNER@example.test"}))
+		return ctx.Next()
+	})
+	adminApp.Get("/clips/:id", adminAPI.getClip)
+	response, err = adminApp.Test(httptest.NewRequest(http.MethodGet, "/clips/"+clip.ID, nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var adminDetail clipAPIResponse
+	if err := json.NewDecoder(response.Body).Decode(&adminDetail); err != nil {
+		response.Body.Close()
+		t.Fatal(err)
+	}
+	response.Body.Close()
+	if response.StatusCode != http.StatusOK || adminDetail.IsAdmin == nil || !*adminDetail.IsAdmin || !adminDetail.CanDelete {
+		t.Fatalf("admin detail capabilities = %d %+v", response.StatusCode, adminDetail)
+	}
+
+	otherApp := fiber.New()
+	otherApp.Use(func(ctx fiber.Ctx) error {
+		ctx.SetUserContext(ContextWithUser(context.Background(), User{Uuid: "creator-b", Email: "other@example.test"}))
+		return ctx.Next()
+	})
+	otherApp.Get("/clips/:id", api.getClip)
+	response, err = otherApp.Test(httptest.NewRequest(http.MethodGet, "/clips/"+clip.ID, nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	response.Body.Close()
+	if response.StatusCode != http.StatusNotFound {
+		t.Fatalf("other creator status = %d, want 404", response.StatusCode)
+	}
+
+	publicApp := fiber.New()
+	publicApp.Get("/shared/clips/:token", api.publicClip)
+	publicApp.Get("/shared/clips/:token/download", api.publicDownloadClip)
+	response, err = publicApp.Test(httptest.NewRequest(http.MethodGet, "/shared/clips/"+clip.ShareToken, nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("public detail status = %d", response.StatusCode)
+	}
+	if response.Header.Get("Cache-Control") != "no-store" || response.Header.Get("Referrer-Policy") != "no-referrer" {
+		t.Fatalf("public detail capability headers = cache=%q referrer=%q", response.Header.Get("Cache-Control"), response.Header.Get("Referrer-Policy"))
+	}
+	response, err = publicApp.Test(httptest.NewRequest(http.MethodGet, "/shared/clips/"+clip.ShareToken+"/download", nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ := io.ReadAll(response.Body)
+	response.Body.Close()
+	if response.StatusCode != http.StatusOK || string(body) != "clip bytes" {
+		t.Fatalf("public download = %d %q", response.StatusCode, body)
+	}
+	if response.Header.Get("Cache-Control") != "no-store" || response.Header.Get("Referrer-Policy") != "no-referrer" {
+		t.Fatalf("public download capability headers = cache=%q referrer=%q", response.Header.Get("Cache-Control"), response.Header.Get("Referrer-Policy"))
+	}
+	response, err = publicApp.Test(httptest.NewRequest(http.MethodGet, "/shared/clips/not-the-token", nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	response.Body.Close()
+	if response.StatusCode != http.StatusNotFound {
+		t.Fatalf("guessed share token status = %d, want 404", response.StatusCode)
+	}
+}
+
+func TestClipHTTPContractPersistsShareURLAndServesInlineMediaAfterRestart(t *testing.T) {
+	root := t.TempDir()
+	store, err := newClipStore(root, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	source := filepath.Join(t.TempDir(), "output.mp4")
+	if err := os.WriteFile(source, []byte("persistent media"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	clip, err := store.promote(renderTestSpec("creator-a"), source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	token := clip.ShareToken
+	keyPath := filepath.Join(root, clipTokenKeyFile)
+	keyInfo, err := os.Stat(keyPath)
+	if err != nil || keyInfo.Mode().Perm() != 0600 {
+		t.Fatalf("token key permissions = %v, want 0600", err)
+	}
+	keyBefore, err := os.ReadFile(keyPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	api := &API{app: &Application{clipStore: store}}
+	authApp := fiber.New()
+	authApp.Use(func(ctx fiber.Ctx) error {
+		ctx.SetUserContext(ContextWithUser(context.Background(), User{Uuid: "creator-a"}))
+		return ctx.Next()
+	})
+	authApp.Get("/clips", api.listClips)
+	response, err := authApp.Test(httptest.NewRequest(http.MethodGet, "/clips", nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var listed clipListResponse
+	if err := json.NewDecoder(response.Body).Decode(&listed); err != nil {
+		response.Body.Close()
+		t.Fatal(err)
+	}
+	response.Body.Close()
+	if response.StatusCode != http.StatusOK || len(listed.Clips) != 1 || listed.IsAdmin || !listed.Clips[0].CanDelete {
+		t.Fatalf("initial clip list = %d %+v", response.StatusCode, listed)
+	}
+	wantURL := "/shared/clips/" + token + "/download"
+	if listed.Clips[0].ShareURL != wantURL || listed.Clips[0].PublicDownloadURL != wantURL {
+		t.Fatalf("initial share URLs = %+v, want %q", listed.Clips[0], wantURL)
+	}
+	if listed.Clips[0].ShareURL == "/shared/clips/"+token {
+		t.Fatal("share URL points to public metadata instead of inline media")
+	}
+
+	if err := store.close(); err != nil {
+		t.Fatal(err)
+	}
+	databaseBytes, err := os.ReadFile(filepath.Join(root, "clips.sqlite3"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(databaseBytes, []byte(token)) {
+		t.Fatal("raw share token is present in SQLite database bytes")
+	}
+	restartedStore, err := newClipStore(root, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer restartedStore.close()
+	keyAfter, err := os.ReadFile(keyPath)
+	if err != nil || !bytes.Equal(keyBefore, keyAfter) {
+		t.Fatalf("durable token key changed across restart: %v", err)
+	}
+	restartedAPI := &API{app: &Application{clipStore: restartedStore}}
+	restartedAuth := fiber.New()
+	restartedAuth.Use(func(ctx fiber.Ctx) error {
+		ctx.SetUserContext(ContextWithUser(context.Background(), User{Uuid: "creator-a"}))
+		return ctx.Next()
+	})
+	restartedAuth.Get("/clips", restartedAPI.listClips)
+	response, err = restartedAuth.Test(httptest.NewRequest(http.MethodGet, "/clips", nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	listed = clipListResponse{}
+	if err := json.NewDecoder(response.Body).Decode(&listed); err != nil {
+		response.Body.Close()
+		t.Fatal(err)
+	}
+	response.Body.Close()
+	if response.StatusCode != http.StatusOK || len(listed.Clips) != 1 || listed.IsAdmin || !listed.Clips[0].CanDelete || listed.Clips[0].ShareURL != wantURL || listed.Clips[0].PublicDownloadURL != wantURL {
+		t.Fatalf("restarted clip list = %d %+v", response.StatusCode, listed)
+	}
+
+	public := fiber.New()
+	public.Get("/shared/clips/:token", restartedAPI.publicClip)
+	public.Get("/shared/clips/:token/download", restartedAPI.publicDownloadClip)
+	response, err = public.Test(httptest.NewRequest(http.MethodGet, "/shared/clips/"+token, nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var publicMetadata map[string]any
+	if err := json.NewDecoder(response.Body).Decode(&publicMetadata); err != nil {
+		response.Body.Close()
+		t.Fatal(err)
+	}
+	response.Body.Close()
+	if _, copied := publicMetadata["shareUrl"]; copied {
+		t.Fatal("public metadata exposes a copied share URL")
+	}
+	if _, exposed := publicMetadata["isAdmin"]; exposed {
+		t.Fatal("public metadata exposes authenticated role scope")
+	}
+	response, err = public.Test(httptest.NewRequest(http.MethodGet, wantURL, nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ := io.ReadAll(response.Body)
+	response.Body.Close()
+	if response.StatusCode != http.StatusOK || string(body) != "persistent media" || response.Header.Get("Content-Type") != "video/mp4" {
+		t.Fatalf("restarted public media = %d %q type=%q", response.StatusCode, body, response.Header.Get("Content-Type"))
+	}
+}
+
+func TestCiphertextRowSwapFailsSafelyWithoutIncorrectShareURL(t *testing.T) {
+	store, err := newClipStore(t.TempDir(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.close()
+	makeClip := func(owner string) *Clip {
+		source := filepath.Join(t.TempDir(), owner+".mp4")
+		if err := os.WriteFile(source, []byte(owner), 0600); err != nil {
+			t.Fatal(err)
+		}
+		clip, err := store.promote(renderTestSpec(owner), source)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return clip
+	}
+	first, second := makeClip("first"), makeClip("second")
+	var firstCipher, secondCipher []byte
+	if err := store.db.QueryRow("SELECT share_token_ciphertext FROM clips WHERE id = ?", first.ID).Scan(&firstCipher); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.db.QueryRow("SELECT share_token_ciphertext FROM clips WHERE id = ?", second.ID).Scan(&secondCipher); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.Exec("UPDATE clips SET share_token_ciphertext = ? WHERE id = ?", secondCipher, first.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.Exec("UPDATE clips SET share_token_ciphertext = ? WHERE id = ?", firstCipher, second.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	api := &API{app: &Application{clipStore: store}}
+	app := fiber.New()
+	app.Use(func(ctx fiber.Ctx) error {
+		ctx.SetUserContext(ContextWithUser(context.Background(), User{Uuid: "first"}))
+		return ctx.Next()
+	})
+	app.Get("/clips/:id", api.getClip)
+	response, err := app.Test(httptest.NewRequest(http.MethodGet, "/clips/"+first.ID, nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ := io.ReadAll(response.Body)
+	response.Body.Close()
+	if response.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("swapped ciphertext status = %d, want 503", response.StatusCode)
+	}
+	if strings.Contains(string(body), "/shared/clips/") || strings.Contains(string(body), first.ShareToken) || strings.Contains(string(body), second.ShareToken) {
+		t.Fatalf("swapped ciphertext response exposed a public URL/token: %s", body)
+	}
+}
+
+func TestClipListAndDeleteAuthorizationHardDeletesBytesAndMetadata(t *testing.T) {
+	store, err := newClipStore(t.TempDir(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.close()
+	makeClip := func(owner string) *Clip {
+		source := filepath.Join(t.TempDir(), owner+".mp4")
+		if err := os.WriteFile(source, []byte(owner), 0600); err != nil {
+			t.Fatal(err)
+		}
+		clip, err := store.promote(renderTestSpec(owner), source)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return clip
+	}
+	owned := makeClip("creator-a")
+	other := makeClip("creator-b")
+	api := &API{app: &Application{clipStore: store, ownerEmail: "owner@example.test"}}
+	requestApp := func(user User, handler fiber.Handler) *fiber.App {
+		app := fiber.New()
+		app.Use(func(ctx fiber.Ctx) error {
+			ctx.SetUserContext(ContextWithUser(context.Background(), user))
+			return ctx.Next()
+		})
+		app.Get("/clips", handler)
+		app.Delete("/clips/:id", handler)
+		return app
+	}
+	creatorApp := requestApp(User{Uuid: "creator-a", Email: "creator@example.test"}, api.listClips)
+	response, err := creatorApp.Test(httptest.NewRequest(http.MethodGet, "/clips", nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ := io.ReadAll(response.Body)
+	response.Body.Close()
+	if response.StatusCode != http.StatusOK || !strings.Contains(string(body), owned.ID) || strings.Contains(string(body), other.ID) {
+		t.Fatalf("creator list = %d %s", response.StatusCode, body)
+	}
+
+	adminApp := requestApp(User{Uuid: "admin", Email: "OWNER@example.test"}, api.listClips)
+	response, err = adminApp.Test(httptest.NewRequest(http.MethodGet, "/clips", nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ = io.ReadAll(response.Body)
+	response.Body.Close()
+	if response.StatusCode != http.StatusOK || !strings.Contains(string(body), owned.ID) || !strings.Contains(string(body), other.ID) {
+		t.Fatalf("admin list = %d %s", response.StatusCode, body)
+	}
+	var adminList clipListResponse
+	if err := json.Unmarshal(body, &adminList); err != nil {
+		t.Fatal(err)
+	}
+	if !adminList.IsAdmin || len(adminList.Clips) != 2 {
+		t.Fatalf("admin capability envelope = %+v", adminList)
+	}
+	for _, listedClip := range adminList.Clips {
+		if !listedClip.CanDelete {
+			t.Fatalf("administrator cannot delete listed clip: %+v", listedClip)
+		}
+	}
+
+	deleteApp := fiber.New()
+	deleteApp.Use(func(ctx fiber.Ctx) error {
+		ctx.SetUserContext(ContextWithUser(context.Background(), User{Uuid: "creator-a", Email: "creator@example.test"}))
+		return ctx.Next()
+	})
+	deleteApp.Delete("/clips/:id", api.deleteClip)
+	response, err = deleteApp.Test(httptest.NewRequest(http.MethodDelete, "/clips/"+other.ID, nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	response.Body.Close()
+	if response.StatusCode != http.StatusNotFound {
+		t.Fatalf("unauthorized delete status = %d", response.StatusCode)
+	}
+	response, err = deleteApp.Test(httptest.NewRequest(http.MethodDelete, "/clips/"+owned.ID, nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	response.Body.Close()
+	if response.StatusCode != http.StatusNoContent {
+		t.Fatalf("creator delete status = %d", response.StatusCode)
+	}
+	if _, err := os.Stat(owned.FilePath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("deleted clip bytes still exist: %v", err)
+	}
+	if _, err := store.get(owned.ID); !errors.Is(err, errClipNotFound) {
+		t.Fatalf("deleted clip metadata lookup = %v", err)
+	}
+	adminDeleteApp := fiber.New()
+	adminDeleteApp.Use(func(ctx fiber.Ctx) error {
+		ctx.SetUserContext(ContextWithUser(context.Background(), User{Uuid: "admin", Email: "OWNER@example.test"}))
+		return ctx.Next()
+	})
+	adminDeleteApp.Delete("/clips/:id", api.deleteClip)
+	response, err = adminDeleteApp.Test(httptest.NewRequest(http.MethodDelete, "/clips/"+other.ID, nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	response.Body.Close()
+	if response.StatusCode != http.StatusNoContent {
+		t.Fatalf("administrator delete status = %d", response.StatusCode)
+	}
+	if _, err := os.Stat(other.FilePath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("administrator-deleted bytes still exist: %v", err)
+	}
+}
+
+func TestClipStoreUsesConfiguredDurableRoot(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "durable")
+	config := Config{}
+	config.Storage.Root = root
+	store, err := newClipStore(durableStorageRoot(config), config.Storage.Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "clips.sqlite3")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "clips")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := parseClipTime(time.Now().UTC().Format(time.RFC3339Nano)); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -13,3 +13,11 @@ ffmpeg:
   # h264_nvenc requires Nvidia drivers, Docker GPU access, and the Nvidia
   # Container Toolkit. See README.md for the Docker GPU setup.
   codec: libx264
+storage:
+  # Durable clips, clips.sqlite3, and clip-token.key live below this root.
+  # In the supplied Compose setup this is the mounted cutscene-data volume.
+  # If omitted, the backend defaults to ./data relative to its working directory.
+  root: /data
+  # Relative paths are resolved below storage.root. Omit to use clips.sqlite3.
+  # Absolute paths and paths escaping root are rejected.
+  database: clips.sqlite3

--- a/config_test.go
+++ b/config_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/spf13/viper"
@@ -76,6 +77,36 @@ func TestFFmpegConcurrencyConfig(t *testing.T) {
 				t.Fatalf("ffmpeg.concurrency = %d, want %d", got, test.want)
 			}
 		})
+	}
+}
+
+func TestDurableStorageConfig(t *testing.T) {
+	config := loadConfigForTest(t, "plex:\n  host: http://plex\n"+
+		"storage:\n  root: /srv/cutscene\n  database: metadata.sqlite3\n")
+	if config.Storage.Root != "/srv/cutscene" || config.Storage.Database != "metadata.sqlite3" {
+		t.Fatalf("storage config = root %q database %q", config.Storage.Root, config.Storage.Database)
+	}
+}
+
+func TestComposeMountsDurableStorageWithoutTransientRenderRoot(t *testing.T) {
+	compose, err := os.ReadFile("docker-compose.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	composeText := string(compose)
+	if !strings.Contains(composeText, "cutscene-data:/data") || !strings.Contains(composeText, "volumes:\n  cutscene-data:") {
+		t.Fatalf("Compose does not declare the durable /data volume:\n%s", composeText)
+	}
+	if strings.Contains(composeText, "      - /tmp") {
+		t.Fatal("Compose must not persist transient /tmp render jobs")
+	}
+
+	sample, err := os.ReadFile("config.example.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(sample), "root: /data") {
+		t.Fatal("config.example.yaml does not document the Compose durable root")
 	}
 }
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,3 +6,9 @@ services:
     volumes:
       - ./config.yaml:/config.yaml
       - ./fiber.sqlite3:/fiber.sqlite3
+      # Durable clip metadata, MP4s, and the token-encryption key. Transient
+      # render jobs intentionally remain under the container's /tmp.
+      - cutscene-data:/data
+
+volumes:
+  cutscene-data:

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -5,6 +5,8 @@ import {
 } from "@mui/material";
 import SessionPicker from "./components/SessionPicker";
 import ClipWorkspace from "./components/ClipWorkspace";
+import ClipLibrary from "./components/ClipLibrary";
+import ClipDetail from "./components/ClipDetail";
 import {stripSubtitleMarkup} from "./components/subtitle-markup";
 import {
   buildRenderJobRequest, buildRenderJobRequestFromSpec, isTerminal, isActive, JOB_STATES, snapshotJobSpec, AUDIO_MODES,
@@ -19,6 +21,14 @@ const MAX_NETWORK_RETRIES = 5
 const EXPIRY_TICK_MS = 1000
 
 function App() {
+  // --- Navigation view ---
+  // Smallest suitable routing: an in-app view state instead of a router
+  // dependency. 'home' renders the session picker / active workspace; 'library'
+  // renders the saved-clip library; 'clip' renders a single clip detail. The
+  // workspace state (selectedSession, render job, etc.) is retained across
+  // navigation so the render workflow is never disrupted.
+  const [view, setView] = useState({name: 'home'})
+
   // --- Session list ---
   const [sessions, setSessions] = useState(null)
   const [sessionsError, setSessionsError] = useState(null)
@@ -63,7 +73,7 @@ function App() {
   const [subtitleSelectionEnd, setSubtitleSelectionEnd] = useState(-1)
 
   // --- Render job ---
-  const [renderState, setRenderState] = useState({status: null, error: null, downloadUrl: null, expiresAt: null, retryAfter: null})
+  const [renderState, setRenderState] = useState({status: null, error: null, downloadUrl: null, expiresAt: null, retryAfter: null, clipId: null, shareUrl: null})
   const [jobSpec, setJobSpec] = useState(null)
   const [downloadCompleted, setDownloadCompleted] = useState(false)
   const [controlsChangedSinceJob, setControlsChangedSinceJob] = useState(false)
@@ -104,7 +114,7 @@ function App() {
 
   const resetRenderState = useCallback(() => {
     stopPolling()
-    setRenderState({status: null, error: null, downloadUrl: null, expiresAt: null, retryAfter: null})
+    setRenderState({status: null, error: null, downloadUrl: null, expiresAt: null, retryAfter: null, clipId: null, shareUrl: null})
     setJobSpec(null)
     jobIdRef.current = null
     setDownloadCompleted(false)
@@ -209,7 +219,10 @@ function App() {
   }, [])
 
   useEffect(() => {
-    const pickerVisible = !selectedSession && !needsAuth && documentVisible
+    // Session polling is gated to the home view: the library and clip detail
+    // views don't need live session data, and polling in the background
+    // would compete for the network and surface stale workspace alerts.
+    const pickerVisible = view.name === 'home' && !selectedSession && !needsAuth && documentVisible
     if (!pickerVisible) {
       stopSessionRefresh()
       return undefined
@@ -218,7 +231,7 @@ function App() {
     sessionRefreshActiveRef.current = true
     refreshSessions()
     return stopSessionRefresh
-  }, [documentVisible, needsAuth, refreshSessions, selectedSession, sessionsRetry, stopSessionRefresh])
+  }, [documentVisible, needsAuth, refreshSessions, selectedSession, sessionsRetry, stopSessionRefresh, view.name])
 
   const retrySessions = useCallback(() => {
     stopSessionRefresh()
@@ -576,14 +589,14 @@ function App() {
       setRenderState({
         status: JOB_STATES.FAILED,
         error: {code: 'validation_error', message: error?.message || 'The selected media part has an invalid media ID.', retryable: false},
-        downloadUrl: null, expiresAt: null, retryAfter: null,
+        downloadUrl: null, expiresAt: null, retryAfter: null, clipId: null, shareUrl: null,
       })
       return
     }
 
     setJobSpec(spec)
     setControlsChangedSinceJob(false)
-    setRenderState({status: JOB_STATES.QUEUED, error: null, downloadUrl: null, expiresAt: null, retryAfter: null})
+    setRenderState({status: JOB_STATES.QUEUED, error: null, downloadUrl: null, expiresAt: null, retryAfter: null, clipId: null, shareUrl: null})
 
     const controller = new AbortController()
     pollControllerRef.current = controller
@@ -617,6 +630,8 @@ function App() {
           downloadUrl: job.downloadUrl || null,
           expiresAt: job.expiresAt || null,
           retryAfter: null,
+          clipId: job.clipId || null,
+          shareUrl: job.shareUrl || null,
         })
         pollForJobRef.current(job.id, controller)
       })
@@ -625,7 +640,7 @@ function App() {
         setRenderState({
           status: JOB_STATES.FAILED,
           error: {code: 'request_error', message: err?.message || 'Could not start rendering.', retryable: err?.retryable || false},
-          downloadUrl: null, expiresAt: null, retryAfter: err?.retryAfter || null,
+          downloadUrl: null, expiresAt: null, retryAfter: err?.retryAfter || null, clipId: null, shareUrl: null,
         })
       })
   }, [selectedSession, startPosition, endPosition, selectedSubtitle, subtitleStreams, audioMode, subtitleOffsetMs, stopPolling])
@@ -664,6 +679,8 @@ function App() {
               downloadUrl: job.downloadUrl || null,
               expiresAt: job.expiresAt || null,
               retryAfter: null,
+              clipId: job.clipId || null,
+              shareUrl: job.shareUrl || null,
             })
             if (!isTerminal(job.status)) {
               pollTimeoutRef.current = setTimeout(poll, POLL_INTERVAL_MS)
@@ -672,14 +689,14 @@ function App() {
           .catch(err => {
             if (controller.signal.aborted || isAbortError(err)) return
             if (err?.message === '__gone__') {
-              setRenderState({status: JOB_STATES.EXPIRED, error: null, downloadUrl: null, expiresAt: null, retryAfter: null})
+              setRenderState(prev => ({...prev, status: JOB_STATES.EXPIRED, error: null, downloadUrl: null, expiresAt: null, retryAfter: null}))
               return
             }
             if (err?.message === '__auth__') {
               setRenderState({
                 status: JOB_STATES.FAILED,
                 error: {code: 'auth_error', message: 'Authentication expired. Reload the page and sign in again.', retryable: false},
-                downloadUrl: null, expiresAt: null, retryAfter: null,
+                downloadUrl: null, expiresAt: null, retryAfter: null, clipId: null, shareUrl: null,
               })
               return
             }
@@ -690,7 +707,7 @@ function App() {
                 setRenderState({
                   status: JOB_STATES.FAILED,
                   error: {code: 'service_unavailable', message: 'The server is temporarily unavailable. Try again later.', retryable: true},
-                  downloadUrl: null, expiresAt: null, retryAfter: null,
+                  downloadUrl: null, expiresAt: null, retryAfter: null, clipId: null, shareUrl: null,
                 })
                 return
               }
@@ -704,7 +721,7 @@ function App() {
               setRenderState({
                 status: JOB_STATES.FAILED,
                 error: {code: 'network_error', message: 'Lost connection to the server. Check your network and try again.', retryable: true},
-                downloadUrl: null, expiresAt: null, retryAfter: null,
+                downloadUrl: null, expiresAt: null, retryAfter: null, clipId: null, shareUrl: null,
               })
               return
             }
@@ -761,8 +778,10 @@ function App() {
     const tick = () => {
       setExpiryTick(t => t + 1)
       if (Date.now() >= expiresDate.getTime()) {
-        // Transition to expired — clear the download URL so it can't be used.
+        // The transient download expires; the durable saved clip (clipId)
+        // persists in the library and remains discoverable.
         setRenderState(prev => ({
+          ...prev,
           status: JOB_STATES.EXPIRED,
           error: null,
           downloadUrl: null,
@@ -801,7 +820,7 @@ function App() {
     setStreamsLoading(false)
     setStreamsError(null)
     setSubtitlesError(null)
-    setRenderState({status: null, error: null, downloadUrl: null, expiresAt: null, retryAfter: null})
+    setRenderState({status: null, error: null, downloadUrl: null, expiresAt: null, retryAfter: null, clipId: null, shareUrl: null})
     setJobSpec(null)
     jobIdRef.current = null
     setDownloadCompleted(false)
@@ -818,6 +837,16 @@ function App() {
     stopSessionRefresh()
     setSelectedSession(session)
   }, [stopSessionRefresh])
+
+  // ---------------------------------------------------------------- clip library navigation
+  const openLibrary = useCallback(() => setView({name: 'library'}), [])
+  const openClip = useCallback((clipId) => setView({name: 'clip', clipId}), [])
+  const goHome = useCallback(() => setView({name: 'home'}), [])
+  const handleClipDeleted = useCallback(() => {
+    // After deleting from the detail view, return to the library (which
+    // re-fetches and reconciles).
+    setView({name: 'library'})
+  }, [])
 
   // ---------------------------------------------------------------- cleanup on unmount
   useEffect(() => {
@@ -839,7 +868,18 @@ function App() {
       <Box className="cs-shell-bar" component="header">
         <Container maxWidth="lg">
           <Toolbar disableGutters sx={{gap: 2, minHeight: 64}}>
-            <Box sx={{display: 'flex', alignItems: 'baseline', gap: 0}}>
+            <Box
+              component="button"
+              type="button"
+              onClick={goHome}
+              aria-label="CutScene home"
+              sx={{
+                display: 'flex', alignItems: 'baseline', gap: 0,
+                background: 'none', border: 0, padding: 0, cursor: 'pointer',
+                color: 'inherit', fontFamily: 'inherit',
+                '&:focus-visible': {outline: '2px solid #ff7300', outlineOffset: 4, borderRadius: 2},
+              }}
+            >
               <Typography variant="h5" component="h1" sx={{fontWeight: 700, letterSpacing: '-0.02em'}}>
                 Cut
               </Typography>
@@ -848,12 +888,25 @@ function App() {
               </Typography>
             </Box>
             <Box sx={{flex: 1}}/>
+            {!needsAuth && (
+              <Button
+                variant={view.name === 'library' || view.name === 'clip' ? 'contained' : 'text'}
+                color="primary"
+                onClick={openLibrary}
+                sx={view.name === 'library' || view.name === 'clip'
+                  ? {px: 2, py: 0.5}
+                  : {color: 'text.secondary', '&:hover': {color: '#ffd9b0'}}}
+                aria-current={view.name === 'library' || view.name === 'clip' ? 'page' : undefined}
+              >
+                Clips
+              </Button>
+            )}
           </Toolbar>
         </Container>
       </Box>
 
       <Box component="main" sx={{flex: 1, py: {xs: 2, md: 3}, position: 'relative', zIndex: 2}}>
-        <Container className="cs-main-container" maxWidth={selectedSession && theaterMode ? 'xl' : 'lg'}>
+        <Container className="cs-main-container" maxWidth={selectedSession && theaterMode && view.name === 'home' ? 'xl' : 'lg'}>
           {needsAuth ? (
             <Stack spacing={2} alignItems="center" className="cs-rise" sx={{py: 5, textAlign: 'center'}}>
               <Typography variant="h4">Connect CutScene to Plex</Typography>
@@ -864,6 +917,18 @@ function App() {
                 Log in with Plex
               </Button>
             </Stack>
+          ) : view.name === 'library' ? (
+            <ClipLibrary
+              onOpenClip={openClip}
+              onBack={goHome}
+              hasActiveWorkspace={Boolean(selectedSession)}
+            />
+          ) : view.name === 'clip' ? (
+            <ClipDetail
+              clipId={view.clipId}
+              onBack={openLibrary}
+              onDeleted={handleClipDeleted}
+            />
           ) : !selectedSession ? (
             <Stack spacing={2.5} className="cs-rise">
               <Box>
@@ -909,6 +974,7 @@ function App() {
               onRetryJob={retryRenderJob}
               onRetryPoll={retryPollJob}
               onCreateNewJob={() => createRenderJob()}
+              onOpenClip={openClip}
               audioMode={audioMode}
               onAudioModeChange={setAudioMode}
               theaterMode={theaterMode}
@@ -938,7 +1004,7 @@ function App() {
         </Container>
       </Box>
 
-      {playerError && selectedSession && (
+      {playerError && selectedSession && view.name === 'home' && (
         <Container maxWidth="lg" sx={{pb: 2, position: 'relative', zIndex: 2}}>
           <Typography variant="caption" sx={{color: '#ffb4a8'}} role="alert">
             Preview failed to load. Adjust the trim or change the session to retry.
@@ -946,7 +1012,7 @@ function App() {
         </Container>
       )}
 
-      {downloadCompleted && (
+      {downloadCompleted && view.name === 'home' && (
         <Container maxWidth="lg" sx={{pb: 2, position: 'relative', zIndex: 2}}>
           <Typography variant="caption" sx={{color: '#7fd391'}} role="status">
             Download started — check your browser downloads.

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -1615,3 +1615,105 @@ test('theater toggle is not rendered before a session is selected', async () => 
 
   expect(screen.queryByRole('button', {name: 'Theater mode'})).not.toBeInTheDocument();
 });
+
+// ---------------------------------------------------------------------------
+// Clip library navigation + saved-clip discoverability
+// ---------------------------------------------------------------------------
+
+test('the Clips header button opens the library and Back returns to sessions', async () => {
+  const pending = installFetch();
+  render(<App/>);
+  await flush();
+
+  // Header exposes a Clips navigation affordance once authenticated.
+  const clipsBtn = screen.getByRole('button', {name: 'Clips'});
+  fireEvent.click(clipsBtn);
+  await flush();
+
+  // The library fetches /clips; resolve with the authenticated list shape
+  // {clips, isAdmin} to confirm the view switched.
+  const clipsReq = requestFor(pending, url => url === '/clips');
+  await resolveRequest(clipsReq, {clips: [], isAdmin: false});
+  expect(screen.getByText('No saved clips yet.')).toBeInTheDocument();
+  // The session picker is no longer rendered.
+  expect(screen.queryByText('Pick something to clip')).not.toBeInTheDocument();
+
+  // Back returns to the session picker.
+  fireEvent.click(screen.getByRole('button', {name: 'Back to sessions'}));
+  await flush();
+  expect(screen.getByText('Pick something to clip')).toBeInTheDocument();
+});
+
+test('navigating to the clip library pauses session polling (no /sessions fetches while away)', async () => {
+  jest.useFakeTimers();
+  const {sessionRequests, pending} = installTrackedSessionsFetch();
+  render(<App/>);
+  await resolveRequest(sessionRequests[0], sessions);
+
+  // Navigate to the library view.
+  fireEvent.click(screen.getByRole('button', {name: 'Clips'}));
+  await flush();
+  // Resolve the clips list so the library view settles.
+  const clipsReq = requestFor(pending, url => url === '/clips');
+  await resolveRequest(clipsReq, {clips: [], isAdmin: false});
+
+  // Advance well past the 10s refresh cadence; no new /sessions fetch fires.
+  const sessionsBefore = sessionRequests.length;
+  await advancePolling(20000);
+  expect(sessionRequests.length).toBe(sessionsBefore);
+
+  // Returning home resumes the refresh cadence immediately.
+  fireEvent.click(screen.getByRole('button', {name: 'Back to sessions'}));
+  await flush();
+  expect(sessionRequests.length).toBe(sessionsBefore + 1);
+});
+
+test('a successful render surfaces the saved clip via Open in library without losing the transient download', async () => {
+  jest.useFakeTimers();
+  const pending = installFetch();
+  render(<App/>);
+  await flush();
+  await selectSession('Alpha');
+  fireEvent.click(screen.getByRole('button', {name: 'Render clip'}));
+  const createRequest = requestFor(pending, url => url === '/render-jobs');
+  await resolveRequestWith(createRequest, {id: 'job-saved', status: 'queued'}, {status: 202});
+
+  let poll = requestFor(pending, url => url === '/render-jobs/job-saved');
+  await resolveRequest(poll, {id: 'job-saved', status: 'running'});
+  await advancePolling();
+  poll = pending.filter(r => r.url === '/render-jobs/job-saved').slice(-1)[0];
+
+  // A successful render is promoted to a durable clip; the terminal response
+  // carries clipId alongside the transient downloadUrl.
+  const expiresAt = new Date(Date.now() + 1500).toISOString();
+  await resolveRequest(poll, {
+    id: 'job-saved', status: 'succeeded',
+    downloadUrl: '/render-jobs/job-saved/download', expiresAt,
+    clipId: 'clip-saved', shareUrl: 'https://clips.example.test/shared/clips/tok/download',
+  });
+
+  // The transient download remains the primary quick-grab action.
+  expect(screen.getByRole('link', {name: 'Download clip'})).toHaveAttribute('href', '/render-jobs/job-saved/download');
+  // The durable saved clip is surfaced distinctly.
+  expect(screen.getByText('Saved to your clip library.')).toBeInTheDocument();
+  expect(screen.getByText(/Render job status: Ready\. Download ready\. Saved to your clip library\./))
+    .toHaveAttribute('aria-live', 'polite');
+
+  // Opening the saved clip navigates to the detail view, which fetches the
+  // clip metadata. The workspace state is retained (returning is possible).
+  fireEvent.click(screen.getByRole('button', {name: 'Open in library'}));
+  await flush();
+  const detailReq = requestFor(pending, url => url === '/clips/clip-saved');
+  await resolveRequest(detailReq, {
+    id: 'clip-saved', title: 'Alpha scene', ratingKey: 'A', mediaId: 101,
+    fromMs: 0, toMs: 60000, createdAt: '2026-08-01T12:00:00.000Z',
+    shareUrl: 'https://clips.example.test/shared/clips/tok/download',
+    downloadUrl: '/clips/clip-saved/download',
+    publicDownloadUrl: 'https://clips.example.test/shared/clips/tok/download',
+    canDelete: true,
+    isAdmin: false,
+  });
+  expect(screen.getByText('Alpha scene')).toBeInTheDocument();
+  // Browser playback uses the inline public download URL (shareUrl === publicDownloadUrl).
+  expect(document.querySelector('video').getAttribute('src')).toBe('https://clips.example.test/shared/clips/tok/download');
+});

--- a/frontend/src/components/ClipDeleteDialog.js
+++ b/frontend/src/components/ClipDeleteDialog.js
@@ -1,0 +1,93 @@
+import {Button, CircularProgress, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, Typography} from "@mui/material";
+
+// Delete confirmation flow. The API permits delete only for the clip owner or
+// a server administrator (`canDelete` is explicit per clip). The dialog
+// confirms intent rather than gating on permission.
+//
+// Error recovery:
+//   - `network` (5xx): keep the dialog open with a retryable alert so the
+//     user does not lose context.
+//   - `auth` (401/403): close the retry path and show a sign-in/reload
+//     action. Retrying would be futile — the session is gone.
+//   - `not_found` (404): treated as success by the caller before reaching
+//     the dialog.
+export function ClipDeleteDialog({open, clip, deleting, error, onConfirm, onClose}) {
+  const title = clip?.title || 'this clip'
+  const isAuthError = error?.code === 'auth'
+
+  return (
+    <Dialog
+      open={open}
+      onClose={deleting ? undefined : onClose}
+      aria-labelledby="clip-delete-title"
+      aria-describedby="clip-delete-desc"
+      maxWidth="xs"
+      fullWidth
+    >
+      <DialogTitle id="clip-delete-title" sx={{fontWeight: 700}}>
+        Delete {title}?
+      </DialogTitle>
+      <DialogContent>
+        <DialogContentText id="clip-delete-desc" sx={{color: 'text.secondary'}}>
+          This permanently removes the clip and its video file. This cannot be undone.
+        </DialogContentText>
+        {error && (
+          <Typography role="alert" sx={{color: '#ffb4a8', mt: 1.5, fontSize: '0.85rem'}}>
+            {isAuthError
+              ? 'Your session has expired. Reload the page and sign in again to delete clips.'
+              : (error.message || 'Could not delete this clip right now.')}
+            {!isAuthError && error.code === 'network' ? ' Try again.' : ''}
+          </Typography>
+        )}
+      </DialogContent>
+      <DialogActions sx={{px: 3, pb: 2.5, gap: 1}}>
+        {isAuthError ? (
+          <>
+            <Button
+              onClick={onClose}
+              disabled={deleting}
+              variant="outlined"
+              color="primary"
+              sx={{borderColor: 'rgba(255,255,255,0.2)'}}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="contained"
+              color="primary"
+              href="/authUrl"
+              sx={{px: 3, py: 1}}
+            >
+              Reload and sign in
+            </Button>
+          </>
+        ) : (
+          <>
+            <Button
+              onClick={onClose}
+              disabled={deleting}
+              variant="outlined"
+              color="primary"
+              sx={{borderColor: 'rgba(255,255,255,0.2)'}}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={onConfirm}
+              disabled={deleting}
+              variant="contained"
+              color="error"
+              startIcon={deleting ? <CircularProgress size={16} thickness={3} sx={{color: 'currentColor'}}/> : null}
+              sx={{
+                backgroundColor: '#c0392b', color: '#fff',
+                '&:hover': {backgroundColor: '#a93226'},
+              }}
+            >
+              {deleting ? 'Deleting…' : 'Delete clip'}
+            </Button>
+          </>
+        )}
+      </DialogActions>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/ClipDetail.js
+++ b/frontend/src/components/ClipDetail.js
@@ -1,0 +1,332 @@
+import {Box, Button, Chip, CircularProgress, Paper, Tooltip, Typography} from "@mui/material";
+import {useCallback, useEffect, useRef, useState} from "react";
+import StateMessage from "./StateMessage";
+import {
+  creatorLabel, deleteClip, fetchClip, formatClipCreated, formatClipDuration,
+  mediaContext, mediaLabel,
+} from "./clips";
+import {CopyShareLinkButton} from "./ClipShareCopy";
+import {ClipDeleteDialog} from "./ClipDeleteDialog";
+
+// Single-clip detail view. Browser playback uses the public inline download
+// URL (shareUrl === publicDownloadUrl, Content-Disposition: inline) so the
+// <video> element plays without depending on cookie behaviour; the
+// authenticated attachment download URL is offered as the explicit "Download"
+// action. A public share link can be copied for handing to anyone.
+//
+// If the browser cannot load the video (network issue, codec problem, or the
+// durable bytes are temporarily unavailable), a visible error fallback offers
+// the authenticated download and a retry control.
+export default function ClipDetail({clipId, onBack, onDeleted}) {
+  const [clip, setClip] = useState(null)
+  const [error, setError] = useState(null)
+  const [needsAuth, setNeedsAuth] = useState(false)
+  const [retryCount, setRetryCount] = useState(0)
+  const [videoError, setVideoError] = useState(false)
+  const [videoRetryKey, setVideoRetryKey] = useState(0)
+
+  const [deleteOpen, setDeleteOpen] = useState(false)
+  const [deleting, setDeleting] = useState(false)
+  const [deleteError, setDeleteError] = useState(null)
+
+  const abortRef = useRef(null)
+  const mountedRef = useRef(true)
+
+  useEffect(() => {
+    mountedRef.current = true
+    if (abortRef.current) abortRef.current.abort()
+    const controller = new AbortController()
+    abortRef.current = controller
+    setClip(null)
+    setError(null)
+    setNeedsAuth(false)
+    setVideoError(false)
+    fetchClip(clipId, {signal: controller.signal})
+      .then(data => {
+        if (!mountedRef.current || controller.signal.aborted) return
+        setClip(data)
+      })
+      .catch(err => {
+        if (!mountedRef.current || controller.signal.aborted) return
+        if (err?.code === 'auth') { setNeedsAuth(true); return }
+        setError(err)
+      })
+    return () => {
+      mountedRef.current = false
+      if (abortRef.current) abortRef.current.abort()
+    }
+  }, [clipId, retryCount])
+
+  const confirmDelete = useCallback(async () => {
+    if (!clip) return
+    setDeleting(true)
+    setDeleteError(null)
+    try {
+      await deleteClip(clip.id)
+      if (!mountedRef.current) return
+      setDeleteOpen(false)
+      setDeleting(false)
+      onDeleted?.(clip.id)
+    } catch (err) {
+      if (!mountedRef.current) return
+      setDeleting(false)
+      if (err?.code === 'not_found') {
+        setDeleteOpen(false)
+        onDeleted?.(clip.id)
+        return
+      }
+      // Auth and network errors both stay in the dialog; the dialog itself
+      // renders the appropriate recovery action (reload vs. retry).
+      setDeleteError(err)
+    }
+  }, [clip, onDeleted])
+
+  const cancelDelete = useCallback(() => {
+    if (deleting) return
+    setDeleteOpen(false)
+    setDeleteError(null)
+  }, [deleting])
+
+  const loading = clip === null && !error && !needsAuth
+  // The backend detail response carries an explicit `isAdmin` boolean (only
+  // present for the authenticated caller). Use it instead of inferring admin
+  // from ownerUuid presence — a regular creator also has ownerUuid on their
+  // own clip and must not see an admin-style creator chip.
+  const admin = clip?.isAdmin === true
+  const canDelete = clip?.canDelete === true
+  const creator = admin ? creatorLabel(clip) : ''
+  const {primary: mediaPrimary, secondary: mediaSecondary} = mediaLabel(clip)
+  const displayTitle = clip?.title || 'Untitled clip'
+  // shareUrl and publicDownloadUrl are the same stable public inline MP4 URL.
+  const playbackSrc = clip?.publicDownloadUrl || clip?.shareUrl || ''
+  const downloadUrl = clip?.downloadUrl || ''
+  const artworkUrl = clip?.artworkUrl || ''
+
+  return (
+    <Box className="cs-rise" sx={{display: 'flex', flexDirection: 'column', gap: 2.5}}>
+      <Box sx={{display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap'}}>
+        {onBack && (
+          <Button
+            variant="outlined"
+            color="primary"
+            onClick={onBack}
+            sx={{borderColor: 'rgba(255,255,255,0.2)', px: 2, py: 0.75}}
+          >
+            Back to library
+          </Button>
+        )}
+      </Box>
+
+      {loading && (
+        <Box role="status" aria-live="polite" aria-busy="true" sx={{py: 4, display: 'flex', justifyContent: 'center'}}>
+          <CircularProgress thickness={3}/>
+          <Typography variant="caption" sx={visuallyHidden}>Loading clip…</Typography>
+        </Box>
+      )}
+
+      {needsAuth && (
+        <StateMessage
+          variant="error"
+          title="Sign in to view this clip."
+          hint="Reload the page and connect CutScene to Plex."
+          live
+        />
+      )}
+
+      {error && !needsAuth && (
+        <StateMessage
+          variant={error?.code === 'not_found' ? 'empty' : 'error'}
+          title={error?.code === 'not_found' ? 'This clip is no longer available.' : 'Couldn’t load this clip.'}
+          hint={error?.code === 'not_found'
+            ? 'It may have been deleted by its creator or an administrator.'
+            : (error?.message || 'Try again in a moment.')}
+          live
+          action={error?.code !== 'not_found' && (
+            <Button variant="outlined" color="primary" size="small"
+              onClick={() => setRetryCount(n => n + 1)}
+              sx={{mt: 1, borderColor: 'rgba(255,255,255,0.2)'}}
+            >
+              Try again
+            </Button>
+          )}
+        />
+      )}
+
+      {clip && (
+        <Box sx={{display: 'flex', flexDirection: 'column', gap: 2.5}}>
+          <Box sx={{minWidth: 0}}>
+            <Typography variant="overline" className="cs-section-label" sx={{color: '#ff7300'}}>
+              Clip
+            </Typography>
+            <Typography variant="h4" sx={{mt: 0.5, wordBreak: 'break-word'}}>
+              {displayTitle}
+            </Typography>
+            {(mediaPrimary || mediaSecondary) && (
+              <Typography variant="subtitle1" sx={{color: 'text.secondary', mt: 0.5, wordBreak: 'break-word'}}>
+                {mediaContext(clip)}
+              </Typography>
+            )}
+            <Box sx={{display: 'flex', flexWrap: 'wrap', gap: 1, alignItems: 'center', mt: 1}}>
+              {formatClipDuration(clip) && (
+                <Typography variant="caption" sx={{fontFamily: 'var(--cs-mono-font)', color: '#ff7300'}}>
+                  {formatClipDuration(clip)}
+                </Typography>
+              )}
+              {formatClipCreated(clip) && (
+                <Typography variant="caption" sx={{color: 'text.secondary'}}>
+                  Created {formatClipCreated(clip)}
+                </Typography>
+              )}
+              {admin && (
+                <Tooltip title={creator === 'Unknown creator' ? 'Creator name unavailable for this clip' : `Creator ${creator}`} arrow>
+                  <Chip
+                    size="small"
+                    label={`by ${creator}`}
+                    sx={{
+                      height: 20, fontSize: '0.7rem',
+                      backgroundColor: 'rgba(255,115,0,0.10)', color: '#ffd9b0',
+                      border: '1px solid rgba(255,115,0,0.28)', fontWeight: 600,
+                    }}
+                  />
+                </Tooltip>
+              )}
+            </Box>
+          </Box>
+
+          {/* Browser playback. The inline public download URL plays in-page.
+              If the browser cannot load the video, a visible error fallback
+              offers the authenticated download and a retry control. */}
+          <Paper
+            variant="outlined"
+            sx={{
+              p: 0, overflow: 'hidden', borderRadius: 2,
+              borderColor: 'rgba(255,255,255,0.08)',
+              backgroundColor: '#000',
+              boxShadow: '0 24px 60px -28px rgba(0,0,0,0.8)',
+            }}
+          >
+            {playbackSrc && !videoError ? (
+              <Box
+                key={videoRetryKey}
+                component="video"
+                src={playbackSrc}
+                controls
+                preload="metadata"
+                poster={artworkUrl || undefined}
+                aria-label={`Video player for ${displayTitle}`}
+                onError={() => setVideoError(true)}
+                sx={{width: '100%', maxHeight: '70vh', display: 'block', background: '#000'}}
+              />
+            ) : videoError ? (
+              <Box sx={{p: 4, textAlign: 'center', display: 'flex', flexDirection: 'column', gap: 1.5, alignItems: 'center'}}>
+                <Typography variant="body2" sx={{color: '#ffb4a8'}} role="alert">
+                  Couldn’t play this clip in the browser.
+                </Typography>
+                <Typography variant="caption" sx={{color: 'text.secondary', maxWidth: 420}}>
+                  The video may be temporarily unavailable or your browser can’t decode it. You can still download the file and play it locally.
+                </Typography>
+                <Box sx={{display: 'flex', gap: 1.5, mt: 0.5, flexWrap: 'wrap', justifyContent: 'center'}}>
+                  {downloadUrl && (
+                    <Button variant="contained" color="primary" href={downloadUrl} download sx={{px: 3, py: 1}}>
+                      Download clip
+                    </Button>
+                  )}
+                  <Button
+                    variant="outlined"
+                    color="primary"
+                    onClick={() => { setVideoError(false); setVideoRetryKey(k => k + 1) }}
+                    sx={{borderColor: 'rgba(255,255,255,0.2)', px: 2.5, py: 1}}
+                  >
+                    Try again
+                  </Button>
+                </Box>
+              </Box>
+            ) : (
+              <Box sx={{p: 4, textAlign: 'center'}}>
+                <Typography variant="body2" sx={{color: 'text.secondary'}}>
+                  Playback is unavailable for this clip.
+                </Typography>
+              </Box>
+            )}
+          </Paper>
+
+          <Box sx={{display: 'flex', flexWrap: 'wrap', gap: 1.5, alignItems: 'center'}}>
+            {downloadUrl && (
+              <Button
+                variant="contained"
+                color="primary"
+                href={downloadUrl}
+                download
+                sx={{px: 3, py: 1}}
+              >
+                Download clip
+              </Button>
+            )}
+            <CopyShareLinkButton shareUrl={clip.shareUrl} />
+            <Box sx={{flex: 1}}/>
+            {canDelete ? (
+              <Tooltip title="Delete this clip permanently">
+                <Button
+                  variant="outlined"
+                  onClick={() => setDeleteOpen(true)}
+                  sx={{
+                    px: 2.5, py: 1, color: '#ffb4a8',
+                    borderColor: 'rgba(255,90,90,0.4)',
+                    '&:hover': {borderColor: 'rgba(255,90,90,0.7)', backgroundColor: 'rgba(255,90,90,0.08)'},
+                  }}
+                  aria-label={`Delete clip ${displayTitle}`}
+                >
+                  Delete clip
+                </Button>
+              </Tooltip>
+            ) : clip && (
+              <Tooltip title="You don’t have permission to delete this clip." arrow>
+                <span>
+                  <Button
+                    variant="outlined"
+                    disabled
+                    sx={{
+                      px: 2.5, py: 1, color: 'text.disabled',
+                      borderColor: 'rgba(255,255,255,0.12)',
+                    }}
+                    aria-label="Delete unavailable"
+                  >
+                    Delete clip
+                  </Button>
+                </span>
+              </Tooltip>
+            )}
+          </Box>
+
+          {clip.shareUrl && (
+            <Paper variant="outlined" sx={{p: 1.5, borderColor: 'rgba(255,255,255,0.08)', backgroundColor: 'rgba(0,0,0,0.16)'}}>
+              <Typography variant="caption" sx={{color: 'text.secondary', display: 'block', mb: 0.5}}>
+                Public share link
+              </Typography>
+              <Typography sx={{fontFamily: 'var(--cs-mono-font)', fontSize: '0.82rem', wordBreak: 'break-all', color: 'text.primary'}}>
+                {clip.shareUrl}
+              </Typography>
+              <Typography variant="caption" sx={{color: 'text.disabled', display: 'block', mt: 0.5}}>
+                Anyone with this link can play and download the clip.
+              </Typography>
+            </Paper>
+          )}
+        </Box>
+      )}
+
+      <ClipDeleteDialog
+        open={deleteOpen}
+        clip={clip}
+        deleting={deleting}
+        error={deleteError}
+        onConfirm={confirmDelete}
+        onClose={cancelDelete}
+      />
+    </Box>
+  )
+}
+
+const visuallyHidden = {
+  position: 'absolute', width: 1, height: 1, padding: 0, margin: -1,
+  overflow: 'hidden', clip: 'rect(0, 0, 0, 0)', whiteSpace: 'nowrap', border: 0,
+}

--- a/frontend/src/components/ClipLibrary.js
+++ b/frontend/src/components/ClipLibrary.js
@@ -1,0 +1,428 @@
+import {Box, Button, Chip, CircularProgress, IconButton, Paper, Stack, Tooltip, Typography} from "@mui/material";
+import {useCallback, useEffect, useRef, useState} from "react";
+import StateMessage from "./StateMessage";
+import {
+  creatorLabel, deleteClip, fetchClips, formatClipCreated, formatClipDuration,
+  mediaContext,
+} from "./clips";
+import {CopyShareLinkButton} from "./ClipShareCopy";
+import {ClipDeleteDialog} from "./ClipDeleteDialog";
+
+// Authenticated clip library. Lists the caller's saved clips (or, for a
+// server administrator, every clip on the server with creator differentiation).
+//
+// `isAdmin` is an explicit boolean on the list response. `canDelete` is an
+// explicit boolean per clip — the delete affordance is gated on it so a
+// viewer who cannot delete never sees the control. `creatorDisplayName` is the
+// friendly creator identity (never a UUID) shown only in admin scope.
+export default function ClipLibrary({onOpenClip, onBack, hasActiveWorkspace}) {
+  const [clips, setClips] = useState(null)
+  const [isAdmin, setIsAdmin] = useState(false)
+  const [error, setError] = useState(null)
+  const [needsAuth, setNeedsAuth] = useState(false)
+  const [retryCount, setRetryCount] = useState(0)
+
+  const [pendingDelete, setPendingDelete] = useState(null)
+  const [deleteError, setDeleteError] = useState(null)
+  const [deleting, setDeleting] = useState(false)
+  const [toast, setToast] = useState(null)
+
+  const abortRef = useRef(null)
+  const mountedRef = useRef(true)
+
+  const load = useCallback(() => {
+    if (abortRef.current) abortRef.current.abort()
+    const controller = new AbortController()
+    abortRef.current = controller
+    setClips(null)
+    setError(null)
+    setNeedsAuth(false)
+    fetchClips({signal: controller.signal})
+      .then(({clips: data, isAdmin: admin}) => {
+        if (!mountedRef.current || controller.signal.aborted) return
+        setClips(data)
+        setIsAdmin(admin)
+      })
+      .catch(err => {
+        if (!mountedRef.current || controller.signal.aborted) return
+        if (err?.code === 'auth') {
+          setNeedsAuth(true)
+          return
+        }
+        setError(err)
+      })
+  }, [])
+
+  useEffect(() => {
+    mountedRef.current = true
+    load()
+    return () => {
+      mountedRef.current = false
+      if (abortRef.current) abortRef.current.abort()
+    }
+  }, [load, retryCount])
+
+  const requestDelete = useCallback((clip) => {
+    setDeleteError(null)
+    setPendingDelete(clip)
+  }, [])
+
+  const confirmDelete = useCallback(async () => {
+    const clip = pendingDelete
+    if (!clip) return
+    setDeleting(true)
+    setDeleteError(null)
+    try {
+      await deleteClip(clip.id)
+      if (!mountedRef.current) return
+      setPendingDelete(null)
+      setDeleting(false)
+      setClips(prev => prev ? prev.filter(c => c.id !== clip.id) : prev)
+      setToast({kind: 'success', message: 'Clip deleted.'})
+    } catch (err) {
+      if (!mountedRef.current) return
+      setDeleting(false)
+      if (err?.code === 'not_found') {
+        // Already gone — close the dialog and reconcile the list.
+        setPendingDelete(null)
+        setClips(prev => prev ? prev.filter(c => c.id !== clip.id) : prev)
+        setToast({kind: 'success', message: 'Clip already removed.'})
+        return
+      }
+      // Auth and network errors both stay in the dialog; the dialog itself
+      // renders the appropriate recovery action (reload vs. retry).
+      setDeleteError(err)
+    }
+  }, [pendingDelete])
+
+  const cancelDelete = useCallback(() => {
+    if (deleting) return
+    setPendingDelete(null)
+    setDeleteError(null)
+  }, [deleting])
+
+  const dismissToast = useCallback(() => setToast(null), [])
+
+  const loading = clips === null && !error && !needsAuth
+
+  return (
+    <Box className="cs-rise" sx={{display: 'flex', flexDirection: 'column', gap: 2.5}}>
+      <Box sx={{display: 'flex', alignItems: 'flex-end', justifyContent: 'space-between', gap: 2, flexWrap: 'wrap'}}>
+        <Box sx={{minWidth: 0}}>
+          <Typography variant="overline" className="cs-section-label" sx={{color: '#ff7300'}}>
+            Library
+          </Typography>
+          <Typography variant="h4" sx={{mt: 0.5}}>
+            {isAdmin ? 'All clips' : 'Your clips'}
+          </Typography>
+          <Typography variant="body2" sx={{color: 'text.secondary', mt: 0.5, maxWidth: 560}}>
+            {clips && clips.length > 0
+              ? (isAdmin
+                  ? 'Every saved clip on this server. You can play, share, or delete any clip.'
+                  : 'Saved renders stay here until you delete them. Play, copy a public share link, or remove a clip.')
+              : 'Saved renders are kept here so you can replay, share, or download them later.'}
+          </Typography>
+        </Box>
+        {onBack && (
+          <Button
+            variant="outlined"
+            color="primary"
+            onClick={onBack}
+            sx={{borderColor: 'rgba(255,255,255,0.2)', px: 2, py: 0.75}}
+          >
+            {hasActiveWorkspace ? 'Back to editing' : 'Back to sessions'}
+          </Button>
+        )}
+      </Box>
+
+      {loading && (
+        <Box role="status" aria-live="polite" aria-busy="true" sx={{py: 4}}>
+          <Stack spacing={2}>
+            {[0, 1, 2].map(i => (
+              <Paper key={i} variant="outlined" sx={{p: 2, borderColor: 'rgba(255,255,255,0.06)', display: 'flex', gap: 2, alignItems: 'center'}}>
+                <Box sx={{width: 96, height: 54, borderRadius: 1, background: 'linear-gradient(110deg,#222633,#1b1e26)'}}/>
+                <Box sx={{flex: 1, display: 'flex', flexDirection: 'column', gap: 1}}>
+                  <Box sx={{height: 18, width: '46%', borderRadius: 1, background: '#2a2f3a'}}/>
+                  <Box sx={{height: 12, width: '28%', borderRadius: 1, background: '#232733'}}/>
+                </Box>
+                <CircularProgress size={20} thickness={3} sx={{color: 'text.disabled'}}/>
+              </Paper>
+            ))}
+          </Stack>
+          <Typography variant="caption" sx={visuallyHidden}>Loading clips…</Typography>
+        </Box>
+      )}
+
+      {needsAuth && (
+        <StateMessage
+          variant="error"
+          title="Sign in to view your clips."
+          hint="Reload the page and connect CutScene to Plex to see your clip library."
+          live
+        />
+      )}
+
+      {error && !needsAuth && (
+        <StateMessage
+          variant="error"
+          title="Couldn’t load the clip library."
+          hint={error?.message || 'Check that the CutScene server is reachable and try again.'}
+          live
+          action={
+            <Button variant="outlined" color="primary" size="small"
+              onClick={() => setRetryCount(n => n + 1)}
+              sx={{mt: 1, borderColor: 'rgba(255,255,255,0.2)'}}
+            >
+              Try again
+            </Button>
+          }
+        />
+      )}
+
+      {clips && clips.length === 0 && !needsAuth && (
+        <StateMessage
+          variant="empty"
+          title="No saved clips yet."
+          hint="Render a clip from an active session and it will appear here automatically."
+          live
+        />
+      )}
+
+      {clips && clips.length > 0 && (
+        <Stack spacing={1.5} aria-label="Saved clips">
+          {clips.map(clip => (
+            <ClipRow
+              key={clip.id}
+              clip={clip}
+              admin={isAdmin}
+              onOpen={() => onOpenClip?.(clip.id)}
+              onDelete={() => requestDelete(clip)}
+            />
+          ))}
+        </Stack>
+      )}
+
+      <ClipDeleteDialog
+        open={Boolean(pendingDelete)}
+        clip={pendingDelete}
+        deleting={deleting}
+        error={deleteError}
+        onConfirm={confirmDelete}
+        onClose={cancelDelete}
+      />
+
+      {toast && (
+        <Box
+          role="status"
+          aria-live="polite"
+          sx={{
+            position: 'fixed', left: '50%', bottom: 24, transform: 'translateX(-50%)',
+            zIndex: 60, px: 2.5, py: 1.25, borderRadius: 999,
+            backgroundColor: toast.kind === 'error' ? 'rgba(120,30,30,0.92)' : 'rgba(46,90,60,0.92)',
+            color: toast.kind === 'error' ? '#ffd9d2' : '#d6f5dd',
+            fontSize: '0.85rem', fontWeight: 600,
+            boxShadow: '0 12px 30px -12px rgba(0,0,0,0.7)',
+            display: 'flex', alignItems: 'center', gap: 1.5,
+          }}
+        >
+          {toast.message}
+          <Button size="small" onClick={dismissToast} sx={{color: 'inherit', minWidth: 0, padding: 0, fontWeight: 700}}>
+            Dismiss
+          </Button>
+        </Box>
+      )}
+    </Box>
+  )
+}
+
+function ClipRow({clip, admin, onOpen, onDelete}) {
+  const created = formatClipCreated(clip)
+  const duration = formatClipDuration(clip)
+  const creator = admin ? creatorLabel(clip) : ''
+  const shareUrl = clip.shareUrl || ''
+  const canDelete = clip.canDelete === true
+  const context = mediaContext(clip)
+  const artworkUrl = clip.artworkUrl || ''
+  const title = clip.title || 'Untitled clip'
+
+  // The row is a non-interactive container. The clickable area (thumbnail +
+  // title + metadata) is a dedicated button; the action controls are siblings,
+  // not children. This eliminates nested interactive elements and keyboard
+  // event bubbling while preserving the visual layout.
+  const openLabel = `Open clip ${title}${context ? `, ${context}` : ''}${duration ? `, ${duration}` : ''}${created ? `, created ${created}` : ''}`
+
+  return (
+    <Paper
+      variant="outlined"
+      sx={{
+        p: 0, overflow: 'hidden', borderColor: 'rgba(255,255,255,0.08)',
+        transition: 'border-color 180ms ease, box-shadow 180ms ease, transform 180ms ease',
+        '&:hover': {borderColor: 'rgba(255,115,0,0.4)', transform: 'translateY(-1px)'},
+      }}
+    >
+      <Box sx={{display: 'flex', alignItems: 'stretch', width: '100%'}}>
+        {/* Clickable area — a single button, no interactive children. */}
+        <Box
+          component="button"
+          type="button"
+          onClick={onOpen}
+          aria-label={openLabel}
+          sx={{
+            display: 'flex', alignItems: 'center', gap: {xs: 1.5, sm: 2}, flex: 1, minWidth: 0,
+            p: 1.5, border: 0, background: 'transparent', color: 'inherit',
+            cursor: 'pointer', textAlign: 'left', fontFamily: 'inherit', fontSize: 'inherit',
+            '&:focus-visible': {outline: '2px solid #ff7300', outlineOffset: '-2px', borderRadius: 1},
+          }}
+        >
+          <ClipThumbnail artworkUrl={artworkUrl} />
+
+          <Box sx={{flex: 1, minWidth: 0}}>
+            <Typography noWrap sx={{fontWeight: 700, fontSize: {xs: '0.95rem', sm: '1.02rem'}, lineHeight: 1.3}}>
+              {title}
+            </Typography>
+            {context && (
+              <Typography noWrap variant="body2" sx={{color: 'text.secondary', mt: -0.25}}>
+                {context}
+              </Typography>
+            )}
+            <Box sx={{display: 'flex', flexWrap: 'wrap', gap: 1, alignItems: 'center', mt: 0.5}}>
+              {duration && (
+                <Typography component="span" variant="caption" sx={{fontFamily: 'var(--cs-mono-font)', color: 'text.secondary'}}>
+                  {duration}
+                </Typography>
+              )}
+              {created && (
+                <Typography component="span" variant="caption" sx={{color: 'text.disabled'}}>
+                  {created}
+                </Typography>
+              )}
+              {admin && (
+                <Tooltip title={creator === 'Unknown creator' ? 'Creator name unavailable for this clip' : `Creator ${creator}`} arrow>
+                  <Chip
+                    size="small"
+                    label={`by ${creator}`}
+                    sx={{
+                      height: 20, fontSize: '0.7rem',
+                      backgroundColor: 'rgba(255,115,0,0.10)', color: '#ffd9b0',
+                      border: '1px solid rgba(255,115,0,0.28)', fontWeight: 600,
+                      maxWidth: {xs: 120, sm: 200},
+                    }}
+                  />
+                </Tooltip>
+              )}
+            </Box>
+          </Box>
+        </Box>
+      </Box>
+      <ClipRowActions
+        shareUrl={shareUrl}
+        canDelete={canDelete}
+        clipTitle={title}
+        onDelete={onDelete}
+      />
+    </Paper>
+  )
+}
+
+// Action controls rendered as a sibling row beneath the open button. This
+// avoids any outer clipped affordance: on narrow widths the actions wrap to
+// their own line with adequate space, and the delete icon is never clipped
+// by the row's horizontal bounds.
+function ClipRowActions({shareUrl, canDelete, clipTitle, onDelete}) {
+  return (
+    <Box
+      sx={{
+        display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap',
+        px: 1.5, pb: 1.5, pt: 0.25,
+        borderTop: '1px solid rgba(255,255,255,0.04)',
+      }}
+    >
+      <CopyShareLinkButton shareUrl={shareUrl} size="small" />
+      <Box sx={{flex: 1}}/>
+      {canDelete ? (
+        <Tooltip title="Delete clip">
+          <IconButton
+            aria-label={`Delete clip ${clipTitle}`}
+            onClick={onDelete}
+            size="small"
+            sx={{color: 'text.secondary', '&:hover': {color: '#ffb4a8', backgroundColor: 'rgba(255,90,90,0.10)'}}}
+          >
+            <DeleteIcon/>
+          </IconButton>
+        </Tooltip>
+      ) : (
+        <Tooltip title="You don’t have permission to delete this clip." arrow>
+          <span>
+            <IconButton
+              disabled
+              aria-label="Delete unavailable"
+              size="small"
+              sx={{color: 'text.disabled', opacity: 0.4}}
+            >
+              <DeleteIcon/>
+            </IconButton>
+          </span>
+        </Tooltip>
+      )}
+    </Box>
+  )
+}
+
+// Durable thumbnail with graceful placeholder and image-error fallback.
+// The artwork is a snapshot captured at render-promotion time and served from
+// the authenticated /clips/:id/artwork endpoint. If the image fails to load
+// (network, missing file, decode error), the placeholder reappears.
+//
+// The thumbnail renders inside the row's native open button, so the placeholder
+// is purely decorative (no nested interactive element). Artwork retries happen
+// naturally on URL change (row reuse) or row re-render; a nested retry control
+// would be both invalid HTML and redundant with the opener.
+function ClipThumbnail({artworkUrl}) {
+  const [failed, setFailed] = useState(false)
+
+  // Reset the failed state if the artwork URL changes (e.g. row reuse).
+  useEffect(() => { setFailed(false) }, [artworkUrl])
+
+  const showImage = artworkUrl && !failed
+
+  return (
+    <Box sx={{
+      width: {xs: 80, sm: 96}, height: {xs: 45, sm: 54}, flexShrink: 0,
+      borderRadius: 1, overflow: 'hidden', position: 'relative',
+      background: 'linear-gradient(135deg,#222633,#11141a)',
+      display: 'grid', placeItems: 'center',
+    }}>
+      {showImage ? (
+        // Decorative image: the enclosing open button carries the full
+        // aria-label, so the thumbnail alt is empty to avoid redundancy.
+        // eslint-disable-next-line jsx-a11y/alt-text
+        <Box
+          component="img"
+          src={artworkUrl}
+          alt=""
+          onError={() => setFailed(true)}
+          sx={{width: '100%', height: '100%', objectFit: 'cover', display: 'block'}}
+        />
+      ) : (
+        <svg viewBox="0 0 24 24" width="26" height="26" fill="none" stroke="rgba(255,255,255,0.22)"
+          strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+          <polygon points="6 4 20 12 6 20 6 4"/>
+        </svg>
+      )}
+    </Box>
+  )
+}
+
+function DeleteIcon() {
+  return (
+    <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor"
+      strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+      <path d="M3 6h18M8 6V4h8v2M19 6l-1 14H6L5 6M10 11v6M14 11v6"/>
+    </svg>
+  )
+}
+
+const visuallyHidden = {
+  position: 'absolute', width: 1, height: 1, padding: 0, margin: -1,
+  overflow: 'hidden', clip: 'rect(0, 0, 0, 0)', whiteSpace: 'nowrap', border: 0,
+}

--- a/frontend/src/components/ClipLibrary.test.js
+++ b/frontend/src/components/ClipLibrary.test.js
@@ -1,0 +1,911 @@
+import React from 'react';
+import {act, fireEvent, render, screen, waitFor} from '@testing-library/react';
+import ClipLibrary from './ClipLibrary';
+import ClipDetail from './ClipDetail';
+import {creatorLabel, mediaContext, mediaLabel, millisToHMS} from './clips';
+
+// Deferred-promise helpers so tests can drive fetch responses deterministically.
+function deferred() {
+  let resolve, reject;
+  const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+  return {promise, resolve, reject};
+}
+
+function jsonResponse(data, overrides = {}) {
+  return {
+    ok: true, status: 200, statusText: 'OK',
+    json: () => Promise.resolve(data),
+    ...overrides,
+  };
+}
+
+function installFetch(handler) {
+  const requests = [];
+  global.fetch = jest.fn((url, options = {}) => {
+    const entry = deferred();
+    requests.push({url, options, ...entry});
+    const handled = handler ? handler(url, entry, options) : null;
+    if (handled) return handled;
+    return entry.promise;
+  });
+  return requests;
+}
+
+function byUrl(requests, predicate, occurrence = 0) {
+  const matches = requests.filter(r => predicate(r.url));
+  return matches[occurrence];
+}
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+async function resolveReq(req, data, overrides = {}) {
+  await act(async () => {
+    req.resolve(jsonResponse(data, overrides));
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+// The backend list response is {clips: [...], isAdmin: bool}. Each clip
+// includes canDelete, shareUrl, and publicDownloadUrl. shareUrl and
+// publicDownloadUrl are the same stable public inline MP4 URL.
+const listResponse = (clips, isAdmin = false) => ({clips, isAdmin});
+
+const sampleClip = (overrides = {}) => ({
+  id: 'clip-1',
+  title: 'Alpha scene',
+  ratingKey: 'rk-1',
+  mediaId: 101,
+  fromMs: 5000,
+  toMs: 65000,
+  createdAt: '2026-08-01T12:00:00.000Z',
+  shareUrl: 'https://clips.example.test/shared/clips/abc123token/download',
+  downloadUrl: '/clips/clip-1/download',
+  publicDownloadUrl: 'https://clips.example.test/shared/clips/abc123token/download',
+  canDelete: true,
+  mediaKind: 'movie',
+  movieTitle: 'Alpha',
+  movieYear: 2024,
+  creatorDisplayName: 'plexuser',
+  artworkUrl: '/clips/clip-1/artwork',
+  ...overrides,
+});
+
+// jsdom does not implement clipboard / execCommand. Each test that needs
+// clipboard behaviour installs its own stub so jest.restoreAllMocks() cannot
+// reset it mid-suite.
+function installCopyStub() {
+  document.execCommand = jest.fn(() => true);
+  return document.execCommand;
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers / unit-level
+// ---------------------------------------------------------------------------
+
+describe('clip helpers', () => {
+  test('millisToHMS formats hours, minutes, seconds', () => {
+    expect(millisToHMS(0)).toBe('00:00:00');
+    expect(millisToHMS(1500)).toBe('00:00:01');
+    expect(millisToHMS(60000)).toBe('00:01:00');
+    expect(millisToHMS(3661000)).toBe('01:01:01');
+  });
+
+  test('creatorLabel uses creatorDisplayName, falling back to a neutral "Unknown creator" (never UUID/email)', () => {
+    expect(creatorLabel({creatorDisplayName: 'plexuser'})).toBe('plexuser');
+    expect(creatorLabel({creatorDisplayName: '  spaced  '})).toBe('spaced');
+    // Old clips without creatorDisplayName get a neutral label — never UUID-derived.
+    expect(creatorLabel({ownerUuid: 'abcdef12-3456'})).toBe('Unknown creator');
+    expect(creatorLabel({})).toBe('Unknown creator');
+    expect(creatorLabel(null)).toBe('Unknown creator');
+  });
+
+  test('mediaLabel renders movie title and year', () => {
+    const label = mediaLabel({mediaKind: 'movie', movieTitle: 'Inception', movieYear: 2010});
+    expect(label.primary).toBe('Inception');
+    expect(label.secondary).toBe('(2010)');
+  });
+
+  test('mediaLabel renders show title + SxxExx + episode title', () => {
+    const label = mediaLabel({
+      mediaKind: 'episode', showTitle: 'The Show',
+      seasonNumber: 2, episodeNumber: 7, episodeTitle: 'Pilot',
+    });
+    expect(label.primary).toBe('The Show');
+    expect(label.secondary).toBe('S02E07 Pilot');
+  });
+
+  test('mediaLabel degrades gracefully with missing fields', () => {
+    expect(mediaLabel({mediaKind: 'movie', movieTitle: 'No Year'})).toEqual({primary: 'No Year', secondary: ''});
+    expect(mediaLabel({mediaKind: 'episode', showTitle: 'Show Only'})).toEqual({primary: 'Show Only', secondary: ''});
+    // No media metadata → empty label (clip.title is shown separately as the headline).
+    expect(mediaLabel({title: 'Fallback'})).toEqual({primary: '', secondary: ''});
+    expect(mediaLabel(null)).toEqual({primary: '', secondary: ''});
+  });
+
+  test('mediaContext joins primary and secondary with a middle dot', () => {
+    expect(mediaContext({mediaKind: 'movie', movieTitle: 'Inception', movieYear: 2010})).toBe('Inception · (2010)');
+    expect(mediaContext({mediaKind: 'episode', showTitle: 'The Show', seasonNumber: 2, episodeNumber: 7, episodeTitle: 'Pilot'})).toBe('The Show · S02E07 Pilot');
+    expect(mediaContext({title: 'No media'})).toBe('');
+    expect(mediaContext(null)).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ClipLibrary list states
+// ---------------------------------------------------------------------------
+
+describe('ClipLibrary list states', () => {
+  test('loading shows a live busy region, then clips render with title, duration, and created date', async () => {
+    const requests = installFetch();
+    render(<ClipLibrary onOpenClip={() => {}} onBack={() => {}}/>);
+
+    // Loading affordance is announced to assistive tech.
+    expect(screen.getByRole('status')).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getByText('Loading clips…')).toBeInTheDocument();
+
+    const req = byUrl(requests, u => u === '/clips');
+    await resolveReq(req, listResponse([sampleClip()]));
+
+    expect(screen.queryByText('Loading clips…')).not.toBeInTheDocument();
+    expect(screen.getByText('Alpha scene')).toBeInTheDocument();
+    // 60000ms duration → 00:01:00.
+    expect(screen.getByText('00:01:00')).toBeInTheDocument();
+    // The open affordance is an accessible button with a descriptive label.
+    const openBtn = screen.getByRole('button', {name: /Open clip Alpha scene/});
+    expect(openBtn).toBeInTheDocument();
+  });
+
+  test('a non-admin list (isAdmin=false) reads as "Your clips" with no creator chip', async () => {
+    const requests = installFetch();
+    render(<ClipLibrary onOpenClip={() => {}} onBack={() => {}}/>);
+    await resolveReq(byUrl(requests, u => u === '/clips'),
+      listResponse([
+        sampleClip({id: 'a', ownerUuid: 'user-own-uuid'}),
+        sampleClip({id: 'b', title: 'Beta scene', ownerUuid: 'user-own-uuid'}),
+      ], false));
+
+    expect(screen.getByText('Your clips')).toBeInTheDocument();
+    expect(screen.queryByText('All clips')).not.toBeInTheDocument();
+    // No creator chip is rendered for personal scope.
+    expect(screen.queryByText(/^by /)).not.toBeInTheDocument();
+  });
+
+  test('an admin list (isAdmin=true) reads as "All clips" and differentiates creators by display name', async () => {
+    const requests = installFetch();
+    render(<ClipLibrary onOpenClip={() => {}} onBack={() => {}}/>);
+    await resolveReq(byUrl(requests, u => u === '/clips'),
+      listResponse([
+        sampleClip({id: 'a', ownerUuid: 'aaaaaaaa-1111', creatorDisplayName: 'alice', title: 'Alpha scene'}),
+        sampleClip({id: 'b', ownerUuid: 'bbbbbbbb-2222', creatorDisplayName: 'bob', title: 'Beta scene'}),
+      ], true));
+
+    expect(screen.getByText('All clips')).toBeInTheDocument();
+    // Two distinct creator chips differentiate the rows by display name.
+    expect(screen.getByText('by alice')).toBeInTheDocument();
+    expect(screen.getByText('by bob')).toBeInTheDocument();
+    expect(screen.getAllByText(/^by /)).toHaveLength(2);
+  });
+
+  test('an admin list with old clips (no creatorDisplayName) shows a neutral "Unknown creator" chip, never UUID/email', async () => {
+    const requests = installFetch();
+    render(<ClipLibrary onOpenClip={() => {}} onBack={() => {}}/>);
+    await resolveReq(byUrl(requests, u => u === '/clips'),
+      listResponse([
+        sampleClip({id: 'a', creatorDisplayName: 'alice', title: 'Alpha scene'}),
+        // Old clip: backend no longer serializes ownerUuid and creatorDisplayName
+        // is absent. The row must fall back to "Unknown creator", not a UUID.
+        sampleClip({id: 'b', title: 'Old clip', creatorDisplayName: '', ownerUuid: ''}),
+      ], true));
+
+    expect(screen.getByText('by alice')).toBeInTheDocument();
+    expect(screen.getByText('by Unknown creator')).toBeInTheDocument();
+    // No UUID-derived text or email appears anywhere.
+    expect(document.body.textContent).not.toMatch(/creator [0-9a-f]{8}/);
+    expect(document.body.textContent).not.toMatch(/@/);
+  });
+
+  test('an admin with an empty library still reads as "All clips" (explicit isAdmin, not ownerUuid inference)', async () => {
+    const requests = installFetch();
+    render(<ClipLibrary onOpenClip={() => {}} onBack={() => {}}/>);
+    await resolveReq(byUrl(requests, u => u === '/clips'), listResponse([], true));
+
+    // The heading reflects the explicit isAdmin flag, not inferred from clips.
+    expect(screen.getByText('All clips')).toBeInTheDocument();
+    expect(screen.queryByText('Your clips')).not.toBeInTheDocument();
+  });
+
+  test('empty state is announced and explains how clips get saved', async () => {
+    const requests = installFetch();
+    render(<ClipLibrary onOpenClip={() => {}} onBack={() => {}}/>);
+    await resolveReq(byUrl(requests, u => u === '/clips'), listResponse([]));
+
+    expect(screen.getByText('No saved clips yet.')).toBeInTheDocument();
+    expect(screen.getByText(/Render a clip from an active session/)).toBeInTheDocument();
+  });
+
+  test('network error shows an alert and a retry that re-fetches the list', async () => {
+    const requests = installFetch();
+    render(<ClipLibrary onOpenClip={() => {}} onBack={() => {}}/>);
+    const req = byUrl(requests, u => u === '/clips');
+    await act(async () => {
+      req.resolve({ok: false, status: 503, statusText: 'Service Unavailable', json: () => Promise.resolve({})});
+      await Promise.resolve(); await Promise.resolve(); await Promise.resolve();
+    });
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/Couldn’t load the clip library/);
+    expect(screen.getByRole('button', {name: 'Try again'})).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', {name: 'Try again'}));
+    await flush();
+    const retryReq = byUrl(requests, u => u === '/clips', 1);
+    expect(retryReq).toBeDefined();
+    await resolveReq(retryReq, listResponse([sampleClip()]));
+    expect(screen.getByText('Alpha scene')).toBeInTheDocument();
+  });
+
+  test('auth failure surfaces a sign-in message as an alert', async () => {
+    const requests = installFetch();
+    render(<ClipLibrary onOpenClip={() => {}} onBack={() => {}}/>);
+    const req = byUrl(requests, u => u === '/clips');
+    await act(async () => {
+      req.resolve({ok: false, status: 401, statusText: 'Unauthorized', type: 'basic', json: () => Promise.resolve({})});
+      await Promise.resolve(); await Promise.resolve(); await Promise.resolve();
+    });
+
+    // The sign-in prompt is announced as an alert (variant=error in StateMessage).
+    expect(screen.getByRole('alert')).toHaveTextContent('Sign in to view your clips.');
+    // No separate "Couldn't load" network error is shown.
+    expect(screen.queryByText(/Couldn’t load the clip library/)).not.toBeInTheDocument();
+  });
+
+  test('clicking the open area opens the clip detail via onOpenClip', async () => {
+    const requests = installFetch();
+    const onOpenClip = jest.fn();
+    render(<ClipLibrary onOpenClip={onOpenClip} onBack={() => {}}/>);
+    await resolveReq(byUrl(requests, u => u === '/clips'), listResponse([sampleClip()]));
+
+    fireEvent.click(screen.getByRole('button', {name: /Open clip Alpha scene/}));
+    expect(onOpenClip).toHaveBeenCalledWith('clip-1');
+  });
+
+  test('keyboard activation and action-button clicks do not bubble to the open handler (no nested interactive elements)', async () => {
+    const requests = installFetch();
+    const onOpenClip = jest.fn();
+    render(<ClipLibrary onOpenClip={onOpenClip} onBack={() => {}}/>);
+    await resolveReq(byUrl(requests, u => u === '/clips'), listResponse([sampleClip({canDelete: true})]));
+
+    // The open area is a native <button> — keyboard activation is handled
+    // by the browser, not a custom onKeyDown. Clicking it opens the clip.
+    const openBtn = screen.getByRole('button', {name: /Open clip Alpha scene/});
+    fireEvent.click(openBtn);
+    expect(onOpenClip).toHaveBeenCalledWith('clip-1');
+
+    // The delete and copy buttons are siblings (not children) of the open
+    // button, so their clicks do not bubble to the open handler.
+    onOpenClip.mockClear();
+    fireEvent.click(screen.getByRole('button', {name: /Delete clip Alpha scene/}));
+    expect(onOpenClip).not.toHaveBeenCalled();
+    // Clean up the dialog so it doesn't interfere with other assertions.
+    fireEvent.click(screen.getByRole('button', {name: 'Cancel'}));
+    await waitFor(() => expect(screen.queryByRole('heading', {name: /Delete/})).not.toBeInTheDocument());
+  });
+
+  test('the Back button reflects an active workspace when present', async () => {
+    const requests = installFetch();
+    const onBack = jest.fn();
+    render(<ClipLibrary onOpenClip={() => {}} onBack={onBack} hasActiveWorkspace/>);
+    await resolveReq(byUrl(requests, u => u === '/clips'), listResponse([sampleClip()]));
+
+    const back = screen.getByRole('button', {name: 'Back to editing'});
+    fireEvent.click(back);
+    expect(onBack).toHaveBeenCalled();
+  });
+
+  test('canDelete=false hides the delete control and shows a disabled placeholder', async () => {
+    const requests = installFetch();
+    render(<ClipLibrary onOpenClip={() => {}} onBack={() => {}}/>);
+    await resolveReq(byUrl(requests, u => u === '/clips'),
+      listResponse([sampleClip({canDelete: false})]));
+
+    // No enabled delete button; a disabled placeholder communicates the lack of permission.
+    expect(screen.queryByRole('button', {name: /Delete clip Alpha scene/})).not.toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Delete unavailable'})).toBeDisabled();
+  });
+
+  test('canDelete=true shows the enabled delete control', async () => {
+    const requests = installFetch();
+    render(<ClipLibrary onOpenClip={() => {}} onBack={() => {}}/>);
+    await resolveReq(byUrl(requests, u => u === '/clips'),
+      listResponse([sampleClip({canDelete: true})]));
+
+    expect(screen.getByRole('button', {name: /Delete clip Alpha scene/})).toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'Delete unavailable'})).not.toBeInTheDocument();
+  });
+
+  test('renders durable artwork thumbnail from artworkUrl with decorative alt (opener carries the aria label)', async () => {
+    const requests = installFetch();
+    render(<ClipLibrary onOpenClip={() => {}} onBack={() => {}}/>);
+    await resolveReq(byUrl(requests, u => u === '/clips'),
+      listResponse([sampleClip({artworkUrl: '/clips/clip-1/artwork'})]));
+
+    // The thumbnail is decorative (alt="") because the enclosing open button
+    // has the full aria-label. The image is still present with the right src.
+    const img = document.querySelector('img');
+    expect(img).not.toBeNull();
+    expect(img).toHaveAttribute('src', '/clips/clip-1/artwork');
+    expect(img).toHaveAttribute('alt', '');
+    // The open button carries the accessible name, not the image.
+    expect(screen.getByRole('button', {name: /Open clip Alpha scene/})).toBeInTheDocument();
+  });
+
+  test('a missing artworkUrl renders the placeholder film icon, not a broken image', async () => {
+    const requests = installFetch();
+    render(<ClipLibrary onOpenClip={() => {}} onBack={() => {}}/>);
+    await resolveReq(byUrl(requests, u => u === '/clips'),
+      listResponse([sampleClip({artworkUrl: ''})]));
+
+    expect(screen.queryByRole('img')).not.toBeInTheDocument();
+  });
+
+  test('a missing-artwork placeholder is decorative, not a nested button inside the opener (no validateDOMNesting warning)', async () => {
+    const requests = installFetch();
+    render(<ClipLibrary onOpenClip={() => {}} onBack={() => {}}/>);
+    await resolveReq(byUrl(requests, u => u === '/clips'),
+      listResponse([sampleClip({artworkUrl: ''})]));
+
+    // The open area is a single native button. The decorative placeholder
+    // must not be a nested <button> — it's an inline <svg> only.
+    const openBtn = screen.getByRole('button', {name: /Open clip Alpha scene/});
+    expect(openBtn.tagName).toBe('BUTTON');
+    expect(openBtn.querySelector('button')).toBeNull();
+    // The placeholder svg is present and marked decorative.
+    expect(openBtn.querySelector('svg[aria-hidden="true"]')).not.toBeNull();
+  });
+
+  test('an artwork image onError falls back to the placeholder', async () => {
+    const requests = installFetch();
+    render(<ClipLibrary onOpenClip={() => {}} onBack={() => {}}/>);
+    await resolveReq(byUrl(requests, u => u === '/clips'),
+      listResponse([sampleClip({artworkUrl: '/clips/clip-1/artwork'})]));
+
+    // The decorative image is present initially.
+    const img = document.querySelector('img');
+    expect(img).not.toBeNull();
+    fireEvent.error(img);
+    // After the error, the image is replaced by the placeholder svg (no img).
+    expect(document.querySelector('img')).toBeNull();
+  });
+
+  test('the row shows the media context line (movie title · year) under the clip title', async () => {
+    const requests = installFetch();
+    render(<ClipLibrary onOpenClip={() => {}} onBack={() => {}}/>);
+    await resolveReq(byUrl(requests, u => u === '/clips'),
+      listResponse([sampleClip({
+        mediaKind: 'movie', movieTitle: 'Inception', movieYear: 2010,
+      })]));
+
+    expect(screen.getByText('Alpha scene')).toBeInTheDocument();
+    expect(screen.getByText('Inception · (2010)')).toBeInTheDocument();
+  });
+
+  test('the row shows episode context (show · SxxExx episodeTitle) under the clip title', async () => {
+    const requests = installFetch();
+    render(<ClipLibrary onOpenClip={() => {}} onBack={() => {}}/>);
+    await resolveReq(byUrl(requests, u => u === '/clips'),
+      listResponse([sampleClip({
+        mediaKind: 'episode', showTitle: 'The Show',
+        seasonNumber: 2, episodeNumber: 7, episodeTitle: 'Pilot',
+        movieTitle: '', movieYear: null,
+      })]));
+
+    expect(screen.getByText('The Show · S02E07 Pilot')).toBeInTheDocument();
+  });
+
+  test('the row shows partial media context (movie title without year) as just the title', async () => {
+    const requests = installFetch();
+    render(<ClipLibrary onOpenClip={() => {}} onBack={() => {}}/>);
+    await resolveReq(byUrl(requests, u => u === '/clips'),
+      listResponse([sampleClip({
+        mediaKind: 'movie', movieTitle: 'No Year Movie', movieYear: null,
+      })]));
+
+    // Primary present, secondary absent → context is just the primary.
+    expect(screen.getByText('No Year Movie')).toBeInTheDocument();
+    // No dangling separator.
+    expect(screen.queryByText(/·$/)).not.toBeInTheDocument();
+  });
+
+  test('the row shows partial episode context (show + code, no episode title)', async () => {
+    const requests = installFetch();
+    render(<ClipLibrary onOpenClip={() => {}} onBack={() => {}}/>);
+    await resolveReq(byUrl(requests, u => u === '/clips'),
+      listResponse([sampleClip({
+        mediaKind: 'episode', showTitle: 'The Show',
+        seasonNumber: 3, episodeNumber: 1, episodeTitle: '',
+        movieTitle: '', movieYear: null,
+      })]));
+
+    expect(screen.getByText('The Show · S03E01')).toBeInTheDocument();
+  });
+
+  test('a row with no media metadata shows no context line', async () => {
+    const requests = installFetch();
+    render(<ClipLibrary onOpenClip={() => {}} onBack={() => {}}/>);
+    await resolveReq(byUrl(requests, u => u === '/clips'),
+      listResponse([sampleClip({
+        mediaKind: '', movieTitle: '', movieYear: null,
+        showTitle: '', seasonNumber: null, episodeNumber: null, episodeTitle: '',
+      })]));
+
+    expect(screen.getByText('Alpha scene')).toBeInTheDocument();
+    // No media context line is rendered (no "·" separator, no stray label).
+    expect(screen.queryByText(/·/)).not.toBeInTheDocument();
+  });
+
+  test('action controls are rendered as a sibling row, never clipped by the open button', async () => {
+    const requests = installFetch();
+    render(<ClipLibrary onOpenClip={() => {}} onBack={() => {}}/>);
+    await resolveReq(byUrl(requests, u => u === '/clips'),
+      listResponse([sampleClip({canDelete: true})]));
+
+    // The copy and delete controls are present and not children of the open
+    // button — they live in their own sibling action row below the content.
+    expect(screen.getByRole('button', {name: 'Copy share link'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: /Delete clip Alpha scene/})).toBeInTheDocument();
+    // The open button does not contain the action controls.
+    const openBtn = screen.getByRole('button', {name: /Open clip Alpha scene/});
+    expect(openBtn).not.toContainElement(screen.getByRole('button', {name: 'Copy share link'}));
+    expect(openBtn).not.toContainElement(screen.getByRole('button', {name: /Delete clip Alpha scene/}));
+  });
+
+  test('admin row with a long creatorDisplayName truncates but remains visible', async () => {
+    const requests = installFetch();
+    render(<ClipLibrary onOpenClip={() => {}} onBack={() => {}}/>);
+    await resolveReq(byUrl(requests, u => u === '/clips'),
+      listResponse([sampleClip({
+        ownerUuid: 'aaaaaaaa-1111', creatorDisplayName: 'a-very-long-plex-username',
+      })], true));
+
+    expect(screen.getByText('by a-very-long-plex-username')).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Copy share link
+// ---------------------------------------------------------------------------
+
+describe('copy share link', () => {
+  test('copies shareUrl (direct public inline MP4) to the clipboard and confirms with an updated accessible label', async () => {
+    const execStub = installCopyStub();
+    const requests = installFetch();
+    render(<ClipLibrary onOpenClip={() => {}} onBack={() => {}}/>);
+    await resolveReq(byUrl(requests, u => u === '/clips'), listResponse([sampleClip()]));
+
+    const copyBtn = screen.getByRole('button', {name: 'Copy share link'});
+    fireEvent.click(copyBtn);
+
+    // The legacy copy path was invoked with the full share URL.
+    await waitFor(() => expect(execStub).toHaveBeenCalledWith('copy'));
+    // The button announces the copied state for screen readers.
+    await waitFor(() => expect(screen.getByRole('button', {name: 'Copy share link copied'})).toBeInTheDocument());
+  });
+
+  test('a clip without a share token renders a disabled, unavailable share control', async () => {
+    const requests = installFetch();
+    render(<ClipLibrary onOpenClip={() => {}} onBack={() => {}}/>);
+    await resolveReq(byUrl(requests, u => u === '/clips'),
+      listResponse([sampleClip({shareUrl: '', publicDownloadUrl: ''})]));
+
+    expect(screen.getByRole('button', {name: 'Share link unavailable'})).toBeDisabled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Delete confirmation / success / error / auth recovery
+// ---------------------------------------------------------------------------
+
+describe('ClipLibrary delete flow', () => {
+  test('delete requires confirmation and removes the clip on success with a status toast', async () => {
+    const requests = installFetch();
+    render(<ClipLibrary onOpenClip={() => {}} onBack={() => {}}/>);
+    await resolveReq(byUrl(requests, u => u === '/clips'), listResponse([sampleClip()]));
+
+    // No clip is removed before confirmation.
+    expect(screen.getByText('Alpha scene')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', {name: /Delete clip Alpha scene/}));
+
+    // Confirmation dialog is labelled for screen readers.
+    expect(screen.getByRole('heading', {name: /Delete Alpha scene\?/})).toBeInTheDocument();
+    expect(screen.getByText(/permanently removes the clip/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', {name: 'Delete clip'}));
+    // DELETE request issued.
+    const deleteReq = byUrl(requests, u => u === '/clips/clip-1');
+    expect(deleteReq).toBeDefined();
+    expect(deleteReq.options.method).toBe('DELETE');
+
+    await act(async () => {
+      deleteReq.resolve({ok: true, status: 204, statusText: 'No Content'});
+      await Promise.resolve(); await Promise.resolve(); await Promise.resolve();
+    });
+
+    // Row removed and success announced.
+    await waitFor(() => expect(screen.queryByText('Alpha scene')).not.toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole('status')).toHaveTextContent('Clip deleted.'));
+  });
+
+  test('cancel closes the dialog without deleting or fetching', async () => {
+    const requests = installFetch();
+    render(<ClipLibrary onOpenClip={() => {}} onBack={() => {}}/>);
+    await resolveReq(byUrl(requests, u => u === '/clips'), listResponse([sampleClip()]));
+
+    fireEvent.click(screen.getByRole('button', {name: /Delete clip Alpha scene/}));
+    fireEvent.click(screen.getByRole('button', {name: 'Cancel'}));
+
+    // The dialog unmounts after its exit transition.
+    await waitFor(() => expect(screen.queryByRole('heading', {name: /Delete/})).not.toBeInTheDocument());
+    expect(screen.getByText('Alpha scene')).toBeInTheDocument();
+    expect(requests.some(r => r.options && r.options.method === 'DELETE')).toBe(false);
+  });
+
+  test('a 503 delete error keeps the dialog open with a retryable alert', async () => {
+    const requests = installFetch();
+    render(<ClipLibrary onOpenClip={() => {}} onBack={() => {}}/>);
+    await resolveReq(byUrl(requests, u => u === '/clips'), listResponse([sampleClip()]));
+
+    fireEvent.click(screen.getByRole('button', {name: /Delete clip Alpha scene/}));
+    fireEvent.click(screen.getByRole('button', {name: 'Delete clip'}));
+    const deleteReq = byUrl(requests, u => u === '/clips/clip-1');
+    await act(async () => {
+      deleteReq.resolve({ok: false, status: 503, statusText: 'Service Unavailable', json: () => Promise.resolve({})});
+      await Promise.resolve(); await Promise.resolve(); await Promise.resolve();
+    });
+
+    // Dialog remains open with an alert; the clip row is still present.
+    expect(screen.getByRole('heading', {name: /Delete Alpha scene\?/})).toBeInTheDocument();
+    expect(screen.getByRole('alert')).toHaveTextContent(/Could not delete this clip/);
+    expect(screen.getByText('Alpha scene')).toBeInTheDocument();
+
+    // Retry: confirm again issues a fresh DELETE.
+    fireEvent.click(screen.getByRole('button', {name: 'Delete clip'}));
+    const retryDelete = byUrl(requests, u => u === '/clips/clip-1', 1);
+    expect(retryDelete).toBeDefined();
+    await act(async () => {
+      retryDelete.resolve({ok: true, status: 204, statusText: 'No Content'});
+      await Promise.resolve(); await Promise.resolve(); await Promise.resolve();
+    });
+    expect(screen.queryByText('Alpha scene')).not.toBeInTheDocument();
+  });
+
+  test('a 404 during delete reconciles the list as already removed', async () => {
+    const requests = installFetch();
+    render(<ClipLibrary onOpenClip={() => {}} onBack={() => {}}/>);
+    await resolveReq(byUrl(requests, u => u === '/clips'), listResponse([sampleClip()]));
+
+    fireEvent.click(screen.getByRole('button', {name: /Delete clip Alpha scene/}));
+    fireEvent.click(screen.getByRole('button', {name: 'Delete clip'}));
+    const deleteReq = byUrl(requests, u => u === '/clips/clip-1');
+    await act(async () => {
+      deleteReq.resolve({ok: false, status: 404, statusText: 'Not Found', json: () => Promise.resolve({})});
+      await Promise.resolve(); await Promise.resolve(); await Promise.resolve();
+    });
+
+    // Treated as success — clip removed, dialog closed, no alert.
+    await waitFor(() => expect(screen.queryByText('Alpha scene')).not.toBeInTheDocument());
+    await waitFor(() => expect(screen.queryByRole('heading', {name: /Delete/})).not.toBeInTheDocument());
+  });
+
+  test('a 401 delete auth failure shows a sign-in/reload action instead of a futile retry', async () => {
+    const requests = installFetch();
+    render(<ClipLibrary onOpenClip={() => {}} onBack={() => {}}/>);
+    await resolveReq(byUrl(requests, u => u === '/clips'), listResponse([sampleClip()]));
+
+    fireEvent.click(screen.getByRole('button', {name: /Delete clip Alpha scene/}));
+    fireEvent.click(screen.getByRole('button', {name: 'Delete clip'}));
+    const deleteReq = byUrl(requests, u => u === '/clips/clip-1');
+    await act(async () => {
+      deleteReq.resolve({ok: false, status: 401, statusText: 'Unauthorized', type: 'basic', json: () => Promise.resolve({})});
+      await Promise.resolve(); await Promise.resolve(); await Promise.resolve();
+    });
+
+    // The dialog stays open, but the retry button is replaced with a reload
+    // action — retrying with an expired session would be futile.
+    expect(screen.getByRole('alert')).toHaveTextContent(/session has expired/i);
+    expect(screen.getByRole('link', {name: 'Reload and sign in'})).toHaveAttribute('href', '/authUrl');
+    // The "Delete clip" retry button is gone.
+    expect(screen.queryByRole('button', {name: 'Delete clip'})).not.toBeInTheDocument();
+    // The clip row is still present — the delete did not succeed.
+    expect(screen.getByText('Alpha scene')).toBeInTheDocument();
+  });
+
+  test('delete is disabled while a delete is in flight', async () => {
+    const requests = installFetch();
+    render(<ClipLibrary onOpenClip={() => {}} onBack={() => {}}/>);
+    await resolveReq(byUrl(requests, u => u === '/clips'), listResponse([sampleClip()]));
+
+    fireEvent.click(screen.getByRole('button', {name: /Delete clip Alpha scene/}));
+    fireEvent.click(screen.getByRole('button', {name: 'Delete clip'}));
+    await flush();
+
+    // While the DELETE is pending, the confirm button shows in-progress state.
+    expect(screen.getByRole('button', {name: 'Deleting…'})).toBeDisabled();
+    expect(screen.getByRole('button', {name: 'Cancel'})).toBeDisabled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ClipDetail
+// ---------------------------------------------------------------------------
+
+describe('ClipDetail', () => {
+  test('renders a browser playback video using the public inline MP4 URL, a download link, and the share URL', async () => {
+    const requests = installFetch();
+    render(<ClipDetail clipId="clip-1" onBack={() => {}} onDeleted={() => {}}/>);
+    const req = byUrl(requests, u => u === '/clips/clip-1');
+    await resolveReq(req, sampleClip());
+
+    // Browser playback uses the inline public download URL (shareUrl === publicDownloadUrl).
+    const video = document.querySelector('video');
+    expect(video).not.toBeNull();
+    expect(video.getAttribute('src')).toBe('https://clips.example.test/shared/clips/abc123token/download');
+    expect(video).toHaveAttribute('controls');
+    expect(video).toHaveAccessibleName(/Video player for/);
+
+    // Download affordance uses the authenticated attachment endpoint.
+    expect(screen.getByRole('link', {name: 'Download clip'})).toHaveAttribute('href', '/clips/clip-1/download');
+
+    // The public share URL is visible for verification.
+    expect(screen.getByText('https://clips.example.test/shared/clips/abc123token/download')).toBeInTheDocument();
+  });
+
+  test('a video onError shows a visible error fallback with download and retry controls', async () => {
+    const requests = installFetch();
+    render(<ClipDetail clipId="clip-1" onBack={() => {}} onDeleted={() => {}}/>);
+    await resolveReq(byUrl(requests, u => u === '/clips/clip-1'), sampleClip());
+
+    // Initially the video element is present.
+    expect(document.querySelector('video')).not.toBeNull();
+
+    // Simulate a browser playback failure.
+    fireEvent.error(document.querySelector('video'));
+
+    // The video is replaced by a visible error fallback with an alert.
+    expect(screen.getByRole('alert')).toHaveTextContent(/Couldn’t play this clip in the browser/);
+    expect(screen.getByText(/download the file and play it locally/i)).toBeInTheDocument();
+    // Download and retry controls are available in the fallback. There are
+    // two "Download clip" links (the fallback and the action bar); both are
+    // valid, so assert at least one points to the authenticated endpoint.
+    const downloadLinks = screen.getAllByRole('link', {name: 'Download clip'});
+    expect(downloadLinks.length).toBeGreaterThanOrEqual(1);
+    expect(downloadLinks.some(l => l.getAttribute('href') === '/clips/clip-1/download')).toBe(true);
+    expect(screen.getByRole('button', {name: 'Try again'})).toBeInTheDocument();
+
+    // Retry restores the video element.
+    fireEvent.click(screen.getByRole('button', {name: 'Try again'}));
+    expect(document.querySelector('video')).not.toBeNull();
+  });
+
+  test('a 404 detail load shows an empty-state message rather than an error alert', async () => {
+    const requests = installFetch();
+    render(<ClipDetail clipId="clip-gone" onBack={() => {}} onDeleted={() => {}}/>);
+    const req = byUrl(requests, u => u === '/clips/clip-gone');
+    await act(async () => {
+      req.resolve({ok: false, status: 404, statusText: 'Not Found', json: () => Promise.resolve({})});
+      await Promise.resolve(); await Promise.resolve(); await Promise.resolve();
+    });
+
+    expect(screen.getByText('This clip is no longer available.')).toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    // No retry is offered for a permanent 404.
+    expect(screen.queryByRole('button', {name: 'Try again'})).not.toBeInTheDocument();
+  });
+
+  test('detail delete confirms, then calls onDeleted and returns to the library', async () => {
+    const requests = installFetch();
+    const onDeleted = jest.fn();
+    render(<ClipDetail clipId="clip-1" onBack={() => {}} onDeleted={onDeleted}/>);
+    await resolveReq(byUrl(requests, u => u === '/clips/clip-1'), sampleClip());
+
+    fireEvent.click(screen.getByRole('button', {name: 'Delete clip Alpha scene'}));
+    fireEvent.click(screen.getByRole('button', {name: 'Delete clip'}));
+    // Both the detail GET and the DELETE hit /clips/clip-1; pick the DELETE
+    // by method so we resolve the right deferred request.
+    const deleteReq = requests.find(r => r.url === '/clips/clip-1' && r.options && r.options.method === 'DELETE');
+    expect(deleteReq).toBeDefined();
+    await act(async () => {
+      deleteReq.resolve({ok: true, status: 204, statusText: 'No Content'});
+      await Promise.resolve(); await Promise.resolve(); await Promise.resolve();
+    });
+
+    await waitFor(() => expect(onDeleted).toHaveBeenCalledWith('clip-1'));
+  });
+
+  test('detail delete auth failure shows a reload action instead of retry', async () => {
+    const requests = installFetch();
+    render(<ClipDetail clipId="clip-1" onBack={() => {}} onDeleted={() => {}}/>);
+    await resolveReq(byUrl(requests, u => u === '/clips/clip-1'), sampleClip());
+
+    fireEvent.click(screen.getByRole('button', {name: 'Delete clip Alpha scene'}));
+    fireEvent.click(screen.getByRole('button', {name: 'Delete clip'}));
+    const deleteReq = requests.find(r => r.url === '/clips/clip-1' && r.options && r.options.method === 'DELETE');
+    await act(async () => {
+      deleteReq.resolve({ok: false, status: 401, statusText: 'Unauthorized', type: 'basic', json: () => Promise.resolve({})});
+      await Promise.resolve(); await Promise.resolve(); await Promise.resolve();
+    });
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/session has expired/i);
+    expect(screen.getByRole('link', {name: 'Reload and sign in'})).toHaveAttribute('href', '/authUrl');
+    expect(screen.queryByRole('button', {name: 'Delete clip'})).not.toBeInTheDocument();
+  });
+
+  test('canDelete=false hides the delete button and shows a disabled placeholder', async () => {
+    const requests = installFetch();
+    render(<ClipDetail clipId="clip-1" onBack={() => {}} onDeleted={() => {}}/>);
+    await resolveReq(byUrl(requests, u => u === '/clips/clip-1'), sampleClip({canDelete: false}));
+
+    expect(screen.queryByRole('button', {name: /Delete clip Alpha scene/})).not.toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Delete unavailable'})).toBeDisabled();
+  });
+
+  test('admin detail (isAdmin=true) shows the creator chip with display name', async () => {
+    const requests = installFetch();
+    render(<ClipDetail clipId="clip-1" onBack={() => {}} onDeleted={() => {}}/>);
+    await resolveReq(byUrl(requests, u => u === '/clips/clip-1'),
+      sampleClip({creatorDisplayName: 'alice', isAdmin: true}));
+    expect(screen.getByText('by alice')).toBeInTheDocument();
+  });
+
+  test('admin detail for an old clip (no creatorDisplayName) shows "Unknown creator", never UUID/email', async () => {
+    const requests = installFetch();
+    render(<ClipDetail clipId="clip-1" onBack={() => {}} onDeleted={() => {}}/>);
+    await resolveReq(byUrl(requests, u => u === '/clips/clip-1'),
+      sampleClip({creatorDisplayName: '', ownerUuid: '', isAdmin: true}));
+    expect(screen.getByText('by Unknown creator')).toBeInTheDocument();
+    // No UUID-derived text or email in the document.
+    expect(document.body.textContent).not.toMatch(/creator [0-9a-f]{8}/);
+    expect(document.body.textContent).not.toMatch(/@/);
+  });
+
+  test('non-admin creator detail (isAdmin=false) does not show an admin-style creator chip', async () => {
+    const requests = installFetch();
+    render(<ClipDetail clipId="clip-1" onBack={() => {}} onDeleted={() => {}}/>);
+    // A regular creator viewing their own clip must not see a creator chip —
+    // only admins get creator differentiation.
+    await resolveReq(byUrl(requests, u => u === '/clips/clip-1'),
+      sampleClip({creatorDisplayName: 'alice', isAdmin: false}));
+    expect(screen.queryByText(/^by /)).not.toBeInTheDocument();
+  });
+
+  test('detail shows the clip title as headline and media context as a subtitle', async () => {
+    const requests = installFetch();
+    render(<ClipDetail clipId="clip-1" onBack={() => {}} onDeleted={() => {}}/>);
+    await resolveReq(byUrl(requests, u => u === '/clips/clip-1'),
+      sampleClip({mediaKind: 'movie', movieTitle: 'Inception', movieYear: 2010}));
+
+    // The user-given clip title is the h4 headline.
+    expect(screen.getByRole('heading', {level: 4, name: 'Alpha scene'})).toBeInTheDocument();
+    // The media context appears as a subtitle below.
+    expect(screen.getByText('Inception · (2010)')).toBeInTheDocument();
+  });
+
+  test('detail shows episode media context (show · SxxExx episodeTitle)', async () => {
+    const requests = installFetch();
+    render(<ClipDetail clipId="clip-1" onBack={() => {}} onDeleted={() => {}}/>);
+    await resolveReq(byUrl(requests, u => u === '/clips/clip-1'),
+      sampleClip({
+        mediaKind: 'episode', showTitle: 'The Show',
+        seasonNumber: 2, episodeNumber: 7, episodeTitle: 'Pilot',
+        movieTitle: '', movieYear: null,
+      }));
+
+    expect(screen.getByText('The Show · S02E07 Pilot')).toBeInTheDocument();
+  });
+
+  test('detail shows partial media context (movie title without year)', async () => {
+    const requests = installFetch();
+    render(<ClipDetail clipId="clip-1" onBack={() => {}} onDeleted={() => {}}/>);
+    await resolveReq(byUrl(requests, u => u === '/clips/clip-1'),
+      sampleClip({mediaKind: 'movie', movieTitle: 'No Year Movie', movieYear: null}));
+
+    // Primary present, secondary absent → context is just the primary.
+    expect(screen.getByText('No Year Movie')).toBeInTheDocument();
+    expect(screen.queryByText(/·/)).not.toBeInTheDocument();
+  });
+
+  test('detail shows partial media context (show + code, no episode title)', async () => {
+    const requests = installFetch();
+    render(<ClipDetail clipId="clip-1" onBack={() => {}} onDeleted={() => {}}/>);
+    await resolveReq(byUrl(requests, u => u === '/clips/clip-1'),
+      sampleClip({
+        mediaKind: 'episode', showTitle: 'The Show',
+        seasonNumber: 3, episodeNumber: 1, episodeTitle: '',
+        movieTitle: '', movieYear: null,
+      }));
+
+    expect(screen.getByText('The Show · S03E01')).toBeInTheDocument();
+  });
+
+  test('detail video uses artworkUrl as the poster attribute', async () => {
+    const requests = installFetch();
+    render(<ClipDetail clipId="clip-1" onBack={() => {}} onDeleted={() => {}}/>);
+    await resolveReq(byUrl(requests, u => u === '/clips/clip-1'),
+      sampleClip({artworkUrl: '/clips/clip-1/artwork'}));
+
+    const video = document.querySelector('video');
+    expect(video).not.toBeNull();
+    expect(video).toHaveAttribute('poster', '/clips/clip-1/artwork');
+  });
+
+  test('detail without artwork renders a video with no poster attribute', async () => {
+    const requests = installFetch();
+    render(<ClipDetail clipId="clip-1" onBack={() => {}} onDeleted={() => {}}/>);
+    await resolveReq(byUrl(requests, u => u === '/clips/clip-1'),
+      sampleClip({artworkUrl: ''}));
+
+    const video = document.querySelector('video');
+    expect(video).not.toBeNull();
+    expect(video).not.toHaveAttribute('poster');
+  });
+
+  test('detail without media metadata shows only the clip title, no media subtitle', async () => {
+    const requests = installFetch();
+    render(<ClipDetail clipId="clip-1" onBack={() => {}} onDeleted={() => {}}/>);
+    await resolveReq(byUrl(requests, u => u === '/clips/clip-1'),
+      sampleClip({mediaKind: '', movieTitle: '', movieYear: null, showTitle: ''}));
+
+    expect(screen.getByRole('heading', {level: 4, name: 'Alpha scene'})).toBeInTheDocument();
+    // No media context subtitle is rendered.
+    expect(screen.queryByText(/·/)).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Async cleanup
+// ---------------------------------------------------------------------------
+
+describe('async cleanup', () => {
+  test('ClipLibrary aborts the in-flight list fetch on unmount', async () => {
+    const requests = installFetch();
+    const view = render(<ClipLibrary onOpenClip={() => {}} onBack={() => {}}/>);
+    const req = byUrl(requests, u => u === '/clips');
+    expect(req).toBeDefined();
+    view.unmount();
+    expect(req.options.signal.aborted).toBe(true);
+  });
+
+  test('ClipDetail aborts the in-flight detail fetch on unmount', async () => {
+    const requests = installFetch();
+    const view = render(<ClipDetail clipId="clip-1" onBack={() => {}} onDeleted={() => {}}/>);
+    const req = byUrl(requests, u => u === '/clips/clip-1');
+    view.unmount();
+    expect(req.options.signal.aborted).toBe(true);
+  });
+
+  test('re-fetching the list aborts the previous in-flight request', async () => {
+    const requests = installFetch();
+    render(<ClipLibrary onOpenClip={() => {}} onBack={() => {}}/>);
+    const first = byUrl(requests, u => u === '/clips');
+    // Trigger a retry which starts a second request before the first resolves.
+    await act(async () => {
+      first.resolve({ok: false, status: 503, statusText: 'Service Unavailable', json: () => Promise.resolve({})});
+      await Promise.resolve(); await Promise.resolve(); await Promise.resolve();
+    });
+    fireEvent.click(screen.getByRole('button', {name: 'Try again'}));
+    await flush();
+    const second = byUrl(requests, u => u === '/clips', 1);
+    expect(second).toBeDefined();
+    expect(second.options.signal.aborted).toBe(false);
+  });
+});

--- a/frontend/src/components/ClipShareCopy.js
+++ b/frontend/src/components/ClipShareCopy.js
@@ -1,0 +1,105 @@
+import {Button, CircularProgress, IconButton, Tooltip, Typography} from "@mui/material";
+import {useCallback, useEffect, useRef, useState} from "react";
+import {copyToClipboard} from "./clips";
+
+// Copy a public share link to the clipboard. The backend mints an unguessable
+// share token per clip; shareUrl is the public `/shared/clips/:token` URL.
+// We show a brief "Copied" confirmation rather than a toast so the affordance
+// sits inline next to the link it copies.
+export function CopyShareLinkButton({shareUrl, size = 'medium', label = 'Copy share link'}) {
+  const [state, setState] = useState('idle') // 'idle' | 'copying' | 'copied' | 'error'
+  const resetTimerRef = useRef(null)
+
+  useEffect(() => () => {
+    if (resetTimerRef.current) clearTimeout(resetTimerRef.current)
+  }, [])
+
+  const handleCopy = useCallback(async () => {
+    if (!shareUrl) return
+    setState('copying')
+    const ok = await copyToClipboard(shareUrl)
+    setState(ok ? 'copied' : 'error')
+    if (resetTimerRef.current) clearTimeout(resetTimerRef.current)
+    resetTimerRef.current = setTimeout(() => setState('idle'), 2500)
+  }, [shareUrl])
+
+  if (!shareUrl) {
+    // No share token available — render a disabled control so the affordance
+    // is discoverable but clearly unavailable.
+    return (
+      <Tooltip title="Sharing is unavailable for this clip." arrow>
+        <span>
+          <IconButton disabled size={size} aria-label="Share link unavailable">
+            <ShareIcon/>
+          </IconButton>
+        </span>
+      </Tooltip>
+    )
+  }
+
+  const ariaLabel = state === 'copied' ? `${label} copied` : label
+
+  if (size === 'small') {
+    return (
+      <Tooltip
+        title={state === 'copied' ? 'Link copied to clipboard' : (state === 'error' ? 'Copy failed — select and copy manually' : 'Copy public share link')}
+        arrow
+      >
+        <IconButton
+          aria-label={ariaLabel}
+          onClick={handleCopy}
+          size="small"
+          disabled={state === 'copying'}
+          sx={{
+            color: state === 'copied' ? '#7fd391' : state === 'error' ? '#ffb4a8' : 'text.secondary',
+            '&:hover': {color: '#ffd9b0', backgroundColor: 'rgba(255,115,0,0.10)'},
+          }}
+        >
+          {state === 'copying' ? <CircularProgress size={16} thickness={3}/> : <ShareIcon checked={state === 'copied'}/>}
+        </IconButton>
+      </Tooltip>
+    )
+  }
+
+  return (
+    <Button
+      variant="outlined"
+      color="primary"
+      onClick={handleCopy}
+      disabled={state === 'copying'}
+      startIcon={state === 'copied' ? <CheckIcon/> : <ShareIcon/>}
+      sx={{borderColor: 'rgba(255,255,255,0.2)', px: 2, py: 0.75}}
+      aria-label={ariaLabel}
+      aria-live="polite"
+    >
+      {state === 'copied' ? 'Link copied' : state === 'error' ? 'Copy failed' : label}
+    </Button>
+  )
+}
+
+function ShareIcon({checked}) {
+  return (
+    <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor"
+      strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+      {checked ? (
+        <path d="M20 6 9 17l-5-5"/>
+      ) : (
+        <>
+          <circle cx="18" cy="5" r="3"/>
+          <circle cx="6" cy="12" r="3"/>
+          <circle cx="18" cy="19" r="3"/>
+          <path d="M8.6 13.5 15.4 17.5M15.4 6.5 8.6 10.5"/>
+        </>
+      )}
+    </svg>
+  )
+}
+
+function CheckIcon() {
+  return (
+    <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor"
+      strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+      <path d="M20 6 9 17l-5-5"/>
+    </svg>
+  )
+}

--- a/frontend/src/components/ClipWorkspace.js
+++ b/frontend/src/components/ClipWorkspace.js
@@ -18,6 +18,7 @@ export default function ClipWorkspace({
   onChangeSession, changeSessionDisabled, changeSessionDisabledReason,
   renderState, jobSpec, controlsChangedSinceJob,
   onCreateJob, onDownloadJob, onRetryJob, onRetryPoll, onCreateNewJob,
+  onOpenClip,
   audioMode, onAudioModeChange,
   theaterMode, onToggleTheater,
               subtitleOffsetMs, onSubtitleOffsetChange,
@@ -68,6 +69,7 @@ export default function ClipWorkspace({
             onRetry={onRetryJob}
             onRetryPoll={onRetryPoll}
             onCreateNew={onCreateNewJob}
+            onOpenClip={onOpenClip}
           />
         </Box>
 

--- a/frontend/src/components/RenderJobBar.js
+++ b/frontend/src/components/RenderJobBar.js
@@ -15,8 +15,15 @@ export default function RenderJobBar({
   audioMode, onAudioModeChange,
   renderState, jobSpec, controlsChangedSinceJob,
   onCreateJob, onDownload, onRetry, onRetryPoll, onCreateNew,
+  onOpenClip,
 }) {
-  const {status, error, downloadUrl, expiresAt, retryAfter} = renderState
+  const {status, error, downloadUrl, expiresAt, retryAfter, clipId} = renderState
+  // A successful render is promoted to a durable saved clip (see clips.go).
+  // The terminal job response carries clipId; we surface a discoverable
+  // "Open in library" affordance that is visually distinct from the transient
+  // download (which expires after one hour). The transient download stays the
+  // primary quick-grab action; the saved clip is the durable artifact.
+  const savedToLibrary = Boolean(clipId) && (status === JOB_STATES.SUCCEEDED || status === JOB_STATES.EXPIRED)
   const spec = formatJobSpec(jobSpec)
   const ready = startPosition != null && endPosition != null && endPosition - startPosition >= 500
   const busy = status === JOB_STATES.QUEUED || status === JOB_STATES.RUNNING
@@ -174,14 +181,18 @@ export default function RenderJobBar({
       </Box>
 
       {/* Live job-state announcement for screen readers */}
-      {status && (
-        <Box aria-live="polite" sx={{position: 'absolute', width: 1, height: 1, overflow: 'hidden', clip: 'rect(0,0,0,0)'}}>
-          Render job status: {jobStatusLabel(status)}
-          {status === JOB_STATES.SUCCEEDED && downloadUrl ? '. Download ready.' : ''}
-          {status === JOB_STATES.FAILED && error ? `. ${jobErrorMessage(error)}` : ''}
-          {status === JOB_STATES.EXPIRED ? '. The clip has expired.' : ''}
-        </Box>
-      )}
+      {status && (() => {
+        const parts = [`Render job status: ${jobStatusLabel(status)}.`]
+        if (status === JOB_STATES.SUCCEEDED && downloadUrl) parts.push('Download ready.')
+        if (savedToLibrary) parts.push('Saved to your clip library.')
+        if (status === JOB_STATES.FAILED && error) parts.push(jobErrorMessage(error))
+        if (status === JOB_STATES.EXPIRED) parts.push('The transient download has expired.')
+        return (
+          <Box aria-live="polite" sx={{position: 'absolute', width: 1, height: 1, overflow: 'hidden', clip: 'rect(0,0,0,0)'}}>
+            {parts.join(' ')}
+          </Box>
+        )
+      })()}
 
       {/* Render failure message */}
       {isRenderFailure && error && (
@@ -235,6 +246,27 @@ export default function RenderJobBar({
           </Typography>
           <Button variant="outlined" size="small" color="primary" onClick={onCreateNew} sx={{px: 2, py: 0.5}}>
             Render new clip
+          </Button>
+        </Box>
+      )}
+
+      {/* Saved-clip discoverability. A successful render is promoted to a
+          durable clip; surface it here without displacing the transient
+          download above. The transient download expires after one hour, the
+          saved clip does not. */}
+      {savedToLibrary && onOpenClip && (
+        <Box sx={{mt: 1.5, pt: 1.5, borderTop: '1px solid rgba(255,255,255,0.06)'}}>
+          <Typography variant="caption" sx={{color: '#7fd391', display: 'block', mb: 0.75}}>
+            Saved to your clip library.
+          </Typography>
+          <Button
+            variant="outlined"
+            size="small"
+            color="primary"
+            onClick={() => onOpenClip(clipId)}
+            sx={{px: 2, py: 0.5, borderColor: 'rgba(255,115,0,0.4)'}}
+          >
+            Open in library
           </Button>
         </Box>
       )}

--- a/frontend/src/components/clips.js
+++ b/frontend/src/components/clips.js
@@ -1,0 +1,224 @@
+// Clip library API helpers and small presentation utilities.
+//
+// The backend clip API (see clips.go / api.go) exposes:
+//   GET    /clips            -> {clips: [clipAPIResponse], isAdmin: bool}
+//   GET    /clips/:id        ->  clipAPIResponse
+//   GET    /clips/:id/download -> mp4 (attachment; auth required)
+//   GET    /clips/:id/artwork  -> artwork image (auth required)
+//   DELETE /clips/:id        -> 204 (owner or admin only; 404 otherwise)
+//   GET    /shared/clips/:token        -> public clipAPIResponse (no ownerUuid)
+//   GET    /shared/clips/:token/download -> mp4 (inline; public capability)
+//
+// clipAPIResponse fields: id, creatorDisplayName (optional on old clips),
+// mediaKind, movieTitle, movieYear, showTitle, seasonNumber, episodeNumber,
+// episodeTitle, artworkUrl, title, ratingKey, mediaId, fromMs, toMs,
+// createdAt, shareUrl, downloadUrl, publicDownloadUrl, canDelete, isAdmin.
+//
+// `isAdmin` is an explicit boolean on the list response and a *bool on detail.
+// `canDelete` is an explicit boolean per clip. `creatorDisplayName` is the
+// friendly creator identity for admin differentiation; the backend no longer
+// serializes ownerUuid, so the UI never derives a label from a UUID or email.
+// `artworkUrl` is the authenticated durable artwork endpoint (/clips/:id/artwork).
+// `shareUrl` and `publicDownloadUrl` are the same stable public inline MP4 URL.
+
+// Authenticated list response: {clips: [...], isAdmin: bool}.
+export async function fetchClips({signal} = {}) {
+  const resp = await fetch('/clips', {redirect: 'manual', signal})
+  if (resp.status === 401 || resp.status === 403 || resp.type === 'opaqueredirect') {
+    const err = new Error('authentication required')
+    err.code = 'auth'
+    throw err
+  }
+  if (!resp.ok) {
+    const err = new Error(`Could not load clips (${resp.status})`)
+    err.code = 'network'
+    throw err
+  }
+  const data = await resp.json()
+  return {
+    clips: Array.isArray(data?.clips) ? data.clips : [],
+    isAdmin: Boolean(data?.isAdmin),
+  }
+}
+
+export async function fetchClip(id, {signal} = {}) {
+  const resp = await fetch(`/clips/${encodeURIComponent(id)}`, {redirect: 'manual', signal})
+  if (resp.status === 401 || resp.status === 403 || resp.type === 'opaqueredirect') {
+    const err = new Error('authentication required')
+    err.code = 'auth'
+    throw err
+  }
+  if (resp.status === 404) {
+    const err = new Error('clip not found')
+    err.code = 'not_found'
+    throw err
+  }
+  if (!resp.ok) {
+    const err = new Error(`Could not load this clip (${resp.status})`)
+    err.code = 'network'
+    throw err
+  }
+  return resp.json()
+}
+
+export async function deleteClip(id, {signal} = {}) {
+  const resp = await fetch(`/clips/${encodeURIComponent(id)}`, {
+    method: 'DELETE',
+    redirect: 'manual',
+    signal,
+  })
+  if (resp.status === 204) return true
+  if (resp.status === 401 || resp.status === 403 || resp.type === 'opaqueredirect') {
+    const err = new Error('authentication required')
+    err.code = 'auth'
+    throw err
+  }
+  if (resp.status === 404) {
+    const err = new Error('clip not found')
+    err.code = 'not_found'
+    throw err
+  }
+  // 503 / 5xx and anything else: treat as a transient server error so the
+  // confirmation flow can offer a retry without closing the dialog.
+  const err = new Error('Could not delete this clip right now.')
+  err.code = 'network'
+  throw err
+}
+
+// Copy text to the clipboard with a graceful fallback for non-secure contexts
+// (jsdom / older browsers). Returns true on success.
+export async function copyToClipboard(text) {
+  if (navigator.clipboard && window.isSecureContext) {
+    try {
+      await navigator.clipboard.writeText(text)
+      return true
+    } catch {
+      // fall through to the legacy path
+    }
+  }
+  try {
+    const ta = document.createElement('textarea')
+    ta.value = text
+    ta.setAttribute('readonly', '')
+    ta.style.position = 'fixed'
+    ta.style.top = '0'
+    ta.style.left = '0'
+    ta.style.opacity = '0'
+    document.body.appendChild(ta)
+    ta.select()
+    let ok = false
+    try { ok = document.execCommand('copy') } catch { ok = false }
+    document.body.removeChild(ta)
+    return ok
+  } catch {
+    return false
+  }
+}
+
+export function clipDurationMs(clip) {
+  if (!clip) return 0
+  const from = Number(clip.fromMs) || 0
+  const to = Number(clip.toMs) || 0
+  return Math.max(0, to - from)
+}
+
+export function formatClipDuration(clip) {
+  return millisToHMS(clipDurationMs(clip))
+}
+
+export function millisToHMS(millis) {
+  const total = Math.max(0, Math.floor(millis))
+  const hours = Math.floor(total / 3600000)
+  const minutes = Math.floor((total % 3600000) / 60000)
+  const seconds = Math.floor((total % 60000) / 1000)
+  return [hours, minutes, seconds]
+    .map(n => String(n).padStart(2, '0'))
+    .join(':')
+}
+
+export function formatClipCreated(clip) {
+  const raw = clip && clip.createdAt
+  if (!raw) return ''
+  const date = new Date(raw)
+  if (isNaN(date.getTime())) return ''
+  // Locale-aware date with a short relative hint. Keep it compact for rows.
+  const now = new Date()
+  const sameDay = date.toDateString() === now.toDateString()
+  if (sameDay) {
+    return `Today, ${date.toLocaleTimeString([], {hour: '2-digit', minute: '2-digit'})}`
+  }
+  const yest = new Date(now)
+  yest.setDate(now.getDate() - 1)
+  if (date.toDateString() === yest.toDateString()) {
+    return `Yesterday, ${date.toLocaleTimeString([], {hour: '2-digit', minute: '2-digit'})}`
+  }
+  return date.toLocaleDateString([], {year: 'numeric', month: 'short', day: 'numeric'})
+}
+
+// Creator display name for admin differentiation. The API exposes a friendly
+// creatorDisplayName (Plex username/title) when available; old clips may not
+// carry one. The backend no longer serializes ownerUuid, so never derive a
+// label from a UUID or email — use a neutral "Unknown creator" when absent.
+export function creatorLabel(clip) {
+  const name = clip && clip.creatorDisplayName
+  if (name && String(name).trim()) return String(name).trim()
+  return 'Unknown creator'
+}
+
+// Build a structured media label from the durable clip metadata fields. The
+// backend captures movie vs episode kind at promotion time so the label is
+// stable across restarts and doesn't depend on live Plex metadata. Old clips
+// may have partial or absent metadata.
+//
+// Returns {primary, secondary} where primary is the movie title or show name,
+// and secondary is "(year)" for movies or "S##E## episodeTitle" for episodes.
+// Either or both may be empty — the UI renders the context line whenever
+// either part exists. Does NOT fall back to clip.title (the user-given clip
+// name shown elsewhere as the headline); the media context line only appears
+// when real media metadata is present.
+export function mediaLabel(clip) {
+  if (!clip) return {primary: '', secondary: ''}
+  const kind = String(clip.mediaKind || '').toLowerCase()
+  if (kind === 'episode') {
+    return episodeLabel(clip)
+  }
+  if (kind === 'movie') {
+    return movieLabel(clip)
+  }
+  // Unknown/absent kind: prefer movie fields, then episode fields.
+  if (clip.movieTitle) return movieLabel(clip)
+  if (clip.showTitle) return episodeLabel(clip)
+  return {primary: '', secondary: ''}
+}
+
+// A single-line media context string for compact layouts (rows). Joins the
+// primary and secondary with a middle dot, e.g. "Inception · (2010)" or
+// "The Show · S02E07 Pilot". Returns '' only when BOTH parts are empty.
+export function mediaContext(clip) {
+  const {primary, secondary} = mediaLabel(clip)
+  return [primary, secondary].filter(Boolean).join(' · ')
+}
+
+function movieLabel(clip) {
+  const primary = clip.movieTitle || ''
+  const year = clip.movieYear != null ? Number(clip.movieYear) : null
+  const secondary = (Number.isFinite(year) && year > 0) ? `(${year})` : ''
+  return {primary, secondary}
+}
+
+function episodeLabel(clip) {
+  const primary = clip.showTitle || ''
+  const season = clip.seasonNumber != null ? Number(clip.seasonNumber) : null
+  const episode = clip.episodeNumber != null ? Number(clip.episodeNumber) : null
+  const parts = []
+  if (Number.isFinite(season) && season >= 0) {
+    parts.push(`S${String(season).padStart(2, '0')}`)
+  }
+  if (Number.isFinite(episode) && episode >= 0) {
+    parts.push(`E${String(episode).padStart(2, '0')}`)
+  }
+  const code = parts.join('')
+  const epTitle = clip.episodeTitle || ''
+  const secondary = [code, epTitle].filter(Boolean).join(' ')
+  return {primary, secondary}
+}

--- a/main.go
+++ b/main.go
@@ -23,6 +23,13 @@ type Config struct {
 		Codec       Codec `mapstructure:"codec"`
 		Concurrency int   `mapstructure:"concurrency"`
 	} `mapstructure:"ffmpeg"`
+	Storage struct {
+		// Root contains durable application data, including saved clips and the
+		// clip metadata database. It is deliberately separate from the transient
+		// render-job directory.
+		Root     string `mapstructure:"root"`
+		Database string `mapstructure:"database"`
+	} `mapstructure:"storage"`
 }
 
 func loadConfig() (*Config, error) {

--- a/render_jobs.go
+++ b/render_jobs.go
@@ -85,6 +85,15 @@ type renderJobSpec struct {
 	Height                int
 	QP                    int
 	AudioMode             AudioMode
+	CreatorDisplayName    string
+	MediaKind             string
+	MovieTitle            string
+	MovieYear             *int
+	ShowTitle             string
+	SeasonNumber          *int
+	EpisodeNumber         *int
+	EpisodeTitle          string
+	ThumbnailURL          string
 }
 
 type renderJobError struct {
@@ -100,6 +109,8 @@ type renderJobResponse struct {
 	UpdatedAt   time.Time       `json:"updatedAt"`
 	ExpiresAt   *time.Time      `json:"expiresAt,omitempty"`
 	DownloadURL string          `json:"downloadUrl,omitempty"`
+	ClipID      string          `json:"clipId,omitempty"`
+	ShareURL    string          `json:"shareUrl,omitempty"`
 	Error       *renderJobError `json:"error,omitempty"`
 }
 
@@ -260,6 +271,8 @@ type renderJob struct {
 	cleanupWait  bool
 	sizeBytes    int64
 	bytesCounted bool
+	clipID       string
+	shareURL     string
 }
 
 type renderJobExecutor func(context.Context, renderJobSpec, string) error
@@ -304,25 +317,27 @@ func (a *Application) acquireFFmpeg(ctx context.Context) (func(), error) {
 }
 
 type renderJobManager struct {
-	mu               sync.Mutex
-	jobs             map[string]*renderJob
-	ownerOutstanding map[string]int
-	queue            chan *renderJob
-	store            *renderStorage
-	execute          renderJobExecutor
-	now              func() time.Time
-	lifetime         context.Context
-	cancel           context.CancelFunc
-	stop             chan struct{}
-	done             chan struct{}
-	cleanupDone      chan struct{}
-	stopOnce         sync.Once
-	stopped          bool
-	maxBytes         int64
-	bytesUsed        int64
-	maxTerminal      int
-	maxFailed        int
-	timeout          time.Duration
+	mu                 sync.Mutex
+	jobs               map[string]*renderJob
+	ownerOutstanding   map[string]int
+	queue              chan *renderJob
+	store              *renderStorage
+	execute            renderJobExecutor
+	now                func() time.Time
+	lifetime           context.Context
+	cancel             context.CancelFunc
+	stop               chan struct{}
+	done               chan struct{}
+	cleanupDone        chan struct{}
+	stopOnce           sync.Once
+	stopped            bool
+	maxBytes           int64
+	bytesUsed          int64
+	maxTerminal        int
+	maxFailed          int
+	timeout            time.Duration
+	promote            func(*renderJob, string) error
+	terminalDeleteHook func() // test synchronization point; called under both locks
 }
 
 var errRenderQueueFull = errors.New("render queue is full")
@@ -336,6 +351,10 @@ func newRenderJobManager(root string, execute renderJobExecutor) (*renderJobMana
 }
 
 func newRenderJobManagerWithContext(parent context.Context, root string, execute renderJobExecutor) (*renderJobManager, error) {
+	return newRenderJobManagerWithContextAndPromotion(parent, root, execute, nil)
+}
+
+func newRenderJobManagerWithContextAndPromotion(parent context.Context, root string, execute renderJobExecutor, promote func(*renderJob, string) error) (*renderJobManager, error) {
 	store, err := newRenderStorage(root)
 	if err != nil {
 		return nil, err
@@ -360,6 +379,7 @@ func newRenderJobManagerWithContext(parent context.Context, root string, execute
 		maxTerminal:      renderMaxTerminal,
 		maxFailed:        renderMaxFailedRecords,
 		timeout:          renderTimeout,
+		promote:          promote,
 	}
 	go m.worker()
 	go m.cleanupLoop()
@@ -506,12 +526,18 @@ func (m *renderJobManager) run(job *renderJob) {
 	if err == nil {
 		err = m.finalizeOutput(job)
 	}
+	if err == nil && m.promote != nil {
+		err = m.promote(job, filepath.Join(job.dir, "output.mp4"))
+	}
 	if err != nil {
 		failure := classifyRenderError(err)
 		public := publicRenderFailure(failure)
 		log.Printf("render job %s failed category=%s diagnostic=%s", job.id, public.Code, redactedDiagnostic(failure))
 		_ = os.Remove(filepath.Join(job.dir, "output.partial"))
-		_ = m.store.removeJobDir(job.dir)
+		// Promotion can fail after finalizeOutput has charged the transient
+		// byte budget. Use the normal storage cleanup path so that failed
+		// promotion does not leak that budget.
+		m.deleteJobStorage(job)
 		job.mu.Lock()
 		job.state = renderFailed
 		job.failure = &public
@@ -619,22 +645,38 @@ func (m *renderJobManager) enforceTerminalBudget() {
 }
 
 func (m *renderJobManager) removeTerminalJob(job *renderJob) {
+	// Map removal and the lease check share the manager lock with download
+	// acquisition. Once removed, a new downloader cannot obtain this job.
+	m.mu.Lock()
 	job.mu.Lock()
 	if job.leaseCount > 0 {
 		job.mu.Unlock()
+		m.mu.Unlock()
 		return
 	}
-	job.mu.Unlock()
-	m.deleteJobStorage(job)
-	m.mu.Lock()
+	if m.terminalDeleteHook != nil {
+		m.terminalDeleteHook()
+	}
 	delete(m.jobs, job.id)
+	m.deleteJobStorageLocked(job)
+	job.mu.Unlock()
 	m.mu.Unlock()
 }
 
 func (m *renderJobManager) deleteJobStorage(job *renderJob) {
+	m.mu.Lock()
 	job.mu.Lock()
+	m.deleteJobStorageLocked(job)
+	job.mu.Unlock()
+	m.mu.Unlock()
+}
+
+// deleteJobStorageLocked requires m.mu and job.mu. Keeping the byte-budget
+// accounting, lease check, and filesystem removal in the same critical
+// section prevents eviction from deleting a file between lease acquisition
+// and its first stat/open.
+func (m *renderJobManager) deleteJobStorageLocked(job *renderJob) {
 	if job.leaseCount > 0 {
-		job.mu.Unlock()
 		return
 	}
 	dir := job.dir
@@ -642,14 +684,11 @@ func (m *renderJobManager) deleteJobStorage(job *renderJob) {
 	counted := job.bytesCounted
 	job.sizeBytes = 0
 	job.bytesCounted = false
-	job.mu.Unlock()
 	if counted {
-		m.mu.Lock()
 		m.bytesUsed -= size
 		if m.bytesUsed < 0 {
 			m.bytesUsed = 0
 		}
-		m.mu.Unlock()
 	}
 	_ = m.store.removeJobDir(dir)
 }
@@ -672,6 +711,8 @@ func (m *renderJobManager) status(id, owner string) (renderJobResponse, error) {
 	job.mu.Lock()
 	defer job.mu.Unlock()
 	response := renderJobResponse{ID: job.id, Status: job.state, CreatedAt: job.createdAt, UpdatedAt: job.updatedAt}
+	response.ClipID = job.clipID
+	response.ShareURL = job.shareURL
 	if !job.expiresAt.IsZero() {
 		expiresAt := job.expiresAt
 		response.ExpiresAt = &expiresAt
@@ -692,11 +733,16 @@ func (m *renderJobManager) acquireDownload(id, owner string) (string, func(), er
 }
 
 func (m *renderJobManager) acquireDownloadWithSpec(id, owner string) (string, renderJobSpec, func(), error) {
-	job, err := m.ownedJob(id, owner)
-	if err != nil {
-		return "", renderJobSpec{}, nil, err
+	// Hold the manager lock while taking the job lock. Terminal eviction uses
+	// the same order, making map membership and lease acquisition atomic.
+	m.mu.Lock()
+	job := m.jobs[id]
+	if job == nil || job.ownerUUID != owner {
+		m.mu.Unlock()
+		return "", renderJobSpec{}, nil, errRenderNotFound
 	}
 	job.mu.Lock()
+	m.mu.Unlock()
 	state := job.state
 	if state != renderSucceeded {
 		job.mu.Unlock()
@@ -903,7 +949,7 @@ func (a *API) createRenderJob(ctx fiber.Ctx) error {
 	if len(metadataList) == 0 {
 		return renderAPIErrorCode(ctx, http.StatusUnprocessableEntity, "validation_error", "requested media is unavailable")
 	}
-	spec, err := validateRenderJobRequestWithMetadata(request, *user, sessions, metadataList[0].Media, selection)
+	spec, err := validateRenderJobRequestWithMetadataAndItem(request, *user, sessions, metadataList[0].Media, selection, &metadataList[0])
 	if err != nil {
 		return renderAPIErrorCode(ctx, http.StatusUnprocessableEntity, "validation_error", err.Error())
 	}
@@ -919,6 +965,7 @@ func (a *API) createRenderJob(ctx fiber.Ctx) error {
 	result, _ := a.app.renderJobs.status(job.id, user.Uuid)
 	ctx.Status(http.StatusAccepted)
 	ctx.Set("Cache-Control", "no-store")
+	ctx.Set("Referrer-Policy", "no-referrer")
 	ctx.Set("Location", "/render-jobs/"+job.id)
 	return ctx.JSON(result)
 }
@@ -943,6 +990,7 @@ func (a *API) getRenderJob(ctx fiber.Ctx) error {
 		return renderAPIError(ctx, http.StatusUnauthorized, "authentication required")
 	}
 	ctx.Set("Cache-Control", "no-store")
+	ctx.Set("Referrer-Policy", "no-referrer")
 	result, err := a.app.renderJobs.status(ctx.Params("id"), user.Uuid)
 	if err != nil {
 		return renderAPIError(ctx, http.StatusNotFound, "render job not found")
@@ -981,6 +1029,7 @@ func (a *API) downloadRenderJob(ctx fiber.Ctx) error {
 	}
 	ctx.Type(".mp4")
 	ctx.Set("Cache-Control", "no-store")
+	ctx.Set("Referrer-Policy", "no-referrer")
 	ctx.Set(fiber.HeaderContentDisposition, renderDownloadContentDisposition(spec))
 	ctx.Set("Content-Length", strconv.FormatInt(info.Size(), 10))
 	ctx.Response().SetBodyStreamWriter(func(writer *bufio.Writer) {
@@ -1018,6 +1067,127 @@ func validateRenderJobRequest(request RenderJobCreateRequest, user User, session
 }
 
 func validateRenderJobRequestWithMetadata(request RenderJobCreateRequest, user User, sessions []sessionMetadata, metadata []components.Media, selection previewSessionSelection) (renderJobSpec, error) {
+	return validateRenderJobRequestWithMetadataAndItem(request, user, sessions, metadata, selection, nil)
+}
+
+type renderPresentation struct {
+	CreatorDisplayName string
+	MediaKind          string
+	MovieTitle         string
+	MovieYear          *int
+	ShowTitle          string
+	SeasonNumber       *int
+	EpisodeNumber      *int
+	EpisodeTitle       string
+	ThumbnailURL       string
+}
+
+func creatorDisplayName(user User) string {
+	if strings.TrimSpace(user.Username) != "" {
+		return strings.TrimSpace(user.Username)
+	}
+	return strings.TrimSpace(user.Title)
+}
+
+func presentationFromSession(user User, sessions []sessionMetadata, ratingKey string) renderPresentation {
+	presentation := renderPresentation{CreatorDisplayName: creatorDisplayName(user)}
+	for _, session := range sessions {
+		key := session.Key
+		if session.RatingKey != nil {
+			key = *session.RatingKey
+		}
+		if key != ratingKey {
+			continue
+		}
+		presentation.MediaKind = session.Type
+		if session.Thumb != nil && strings.TrimSpace(*session.Thumb) != "" {
+			presentation.ThumbnailURL = *session.Thumb
+		} else if session.GrandparentThumb != nil {
+			presentation.ThumbnailURL = *session.GrandparentThumb
+		}
+		if session.Type == "episode" || session.GrandparentTitle != nil || session.ParentIndex != nil || session.Index != nil {
+			presentation.ShowTitle = stringValue(session.GrandparentTitle)
+			presentation.SeasonNumber = intValue(session.ParentIndex)
+			presentation.EpisodeNumber = intValue(session.Index)
+			presentation.EpisodeTitle = session.Title
+		}
+		break
+	}
+	return presentation
+}
+
+func presentationFromMetadata(user User, sessions []sessionMetadata, ratingKey string, metadata *components.Metadata) renderPresentation {
+	presentation := presentationFromSession(user, sessions, ratingKey)
+	if metadata == nil {
+		return presentation
+	}
+	if metadata.Type != "" {
+		presentation.MediaKind = metadata.Type
+	}
+	if presentation.ThumbnailURL == "" && metadata.Thumb != nil && strings.TrimSpace(*metadata.Thumb) != "" {
+		presentation.ThumbnailURL = *metadata.Thumb
+	} else if presentation.ThumbnailURL == "" && metadata.GrandparentThumb != nil {
+		presentation.ThumbnailURL = *metadata.GrandparentThumb
+	}
+	switch metadata.Type {
+	case "movie":
+		if metadata.Title != "" {
+			presentation.MovieTitle = metadata.Title
+		}
+		if metadata.Year != nil {
+			presentation.MovieYear = intValue(metadata.Year)
+		}
+	case "episode":
+		if value := stringValue(metadata.GrandparentTitle); value != "" {
+			presentation.ShowTitle = value
+		} else if presentation.ShowTitle == "" {
+			// ParentTitle is only a fallback when the selected session did not
+			// provide a show title; it must never replace a valid session title.
+			if value := stringValue(metadata.ParentTitle); value != "" {
+				presentation.ShowTitle = value
+			}
+		}
+		if metadata.ParentIndex != nil {
+			presentation.SeasonNumber = intValue(metadata.ParentIndex)
+		}
+		if metadata.Index != nil {
+			presentation.EpisodeNumber = intValue(metadata.Index)
+		}
+		if metadata.Title != "" {
+			presentation.EpisodeTitle = metadata.Title
+		}
+	}
+	return presentation
+}
+
+func stringValue(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}
+
+func intValue(value *int) *int {
+	if value == nil {
+		return nil
+	}
+	copy := *value
+	return &copy
+}
+
+func (p renderPresentation) apply(spec *renderJobSpec) {
+	spec.CreatorDisplayName = p.CreatorDisplayName
+	spec.MediaKind = p.MediaKind
+	spec.MovieTitle = p.MovieTitle
+	spec.MovieYear = p.MovieYear
+	spec.ShowTitle = p.ShowTitle
+	spec.SeasonNumber = p.SeasonNumber
+	spec.EpisodeNumber = p.EpisodeNumber
+	spec.EpisodeTitle = p.EpisodeTitle
+	spec.ThumbnailURL = p.ThumbnailURL
+}
+
+func validateRenderJobRequestWithMetadataAndItem(request RenderJobCreateRequest, user User, sessions []sessionMetadata, metadata []components.Media, selection previewSessionSelection, metadataItem *components.Metadata) (renderJobSpec, error) {
 	audioMode, err := parseAudioMode(string(request.AudioMode))
 	if err != nil {
 		return renderJobSpec{}, errors.New("audioMode is invalid")
@@ -1081,7 +1251,7 @@ func validateRenderJobRequestWithMetadata(request RenderJobCreateRequest, user U
 				return renderJobSpec{}, errors.New("subtitle codec is not supported")
 			}
 		}
-		return renderJobSpec{
+		spec := renderJobSpec{
 			OwnerUUID:             user.Uuid,
 			RatingKey:             request.RatingKey,
 			MediaID:               request.MediaID,
@@ -1100,7 +1270,9 @@ func validateRenderJobRequestWithMetadata(request RenderJobCreateRequest, user U
 			Height:                request.Height,
 			QP:                    request.QP,
 			AudioMode:             audioMode,
-		}, nil
+		}
+		presentationFromMetadata(user, sessions, request.RatingKey, metadataItem).apply(&spec)
+		return spec, nil
 	}
 
 	for _, session := range sessions {
@@ -1147,7 +1319,7 @@ func validateRenderJobRequestWithMetadata(request RenderJobCreateRequest, user U
 				if request.SubtitleIndex >= 0 && subtitleEmbeddedIndex < 0 {
 					return renderJobSpec{}, errors.New("subtitle codec is not supported")
 				}
-				return renderJobSpec{
+				spec := renderJobSpec{
 					OwnerUUID:             user.Uuid,
 					RatingKey:             request.RatingKey,
 					MediaID:               request.MediaID,
@@ -1162,7 +1334,9 @@ func validateRenderJobRequestWithMetadata(request RenderJobCreateRequest, user U
 					Height:                request.Height,
 					QP:                    request.QP,
 					AudioMode:             audioMode,
-				}, nil
+				}
+				presentationFromSession(user, sessions, request.RatingKey).apply(&spec)
+				return spec, nil
 			}
 		}
 	}

--- a/render_jobs_test.go
+++ b/render_jobs_test.go
@@ -163,6 +163,35 @@ func TestRenderValidationSnapshotsExternalSubtitleSource(t *testing.T) {
 	}
 }
 
+func TestIncompleteEpisodeMetadataPreservesSessionShowAndEpisodeFields(t *testing.T) {
+	show := "Session Show"
+	season, episode := 4, 9
+	sessions := []sessionMetadata{{
+		Key: "episode-1", Type: "episode", Title: "Session Episode",
+		GrandparentTitle: &show, ParentIndex: &season, Index: &episode,
+	}}
+	parentTitle := "Season 4"
+	presentation := presentationFromMetadata(User{Username: "plex-user"}, sessions, "episode-1", &components.Metadata{
+		Type: "episode", ParentTitle: &parentTitle,
+	})
+	if presentation.ShowTitle != show {
+		t.Fatalf("metadata fallback replaced session show title: %q", presentation.ShowTitle)
+	}
+	if presentation.SeasonNumber == nil || *presentation.SeasonNumber != season || presentation.EpisodeNumber == nil || *presentation.EpisodeNumber != episode || presentation.EpisodeTitle != "Session Episode" {
+		t.Fatalf("session episode fields were not preserved: %+v", presentation)
+	}
+}
+
+func TestEpisodeMetadataUsesParentTitleOnlyWithoutSessionShowTitle(t *testing.T) {
+	parentTitle := "Season 4"
+	presentation := presentationFromMetadata(User{}, []sessionMetadata{{Key: "episode-1", Type: "episode", Title: "Episode"}}, "episode-1", &components.Metadata{
+		Type: "episode", ParentTitle: &parentTitle,
+	})
+	if presentation.ShowTitle != parentTitle {
+		t.Fatalf("explicit parent-title fallback = %q, want %q", presentation.ShowTitle, parentTitle)
+	}
+}
+
 func TestFFmpegLimiterReleaseIsIdempotent(t *testing.T) {
 	limiter := newFFmpegLimiter(1)
 	release, err := limiter.acquire(context.Background())
@@ -215,6 +244,67 @@ func TestRenderJobOwnershipTerminalStateAndDownload(t *testing.T) {
 		t.Fatalf("partial output still exists: %v", err)
 	}
 	release()
+}
+
+func TestTerminalEvictionCannotRaceDownloadLeaseAcquisition(t *testing.T) {
+	manager, err := newRenderJobManager(t.TempDir(), writeRenderOutput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer manager.stopAndWait()
+	job, err := manager.enqueue("owner-a", renderTestSpec("owner-a"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	waitRenderStatus(t, manager, job.id, "owner-a", renderSucceeded)
+
+	evictionEntered := make(chan struct{})
+	allowEviction := make(chan struct{})
+	manager.terminalDeleteHook = func() {
+		close(evictionEntered)
+		<-allowEviction
+	}
+	evictionDone := make(chan struct{})
+	go func() {
+		manager.removeTerminalJob(job)
+		close(evictionDone)
+	}()
+	select {
+	case <-evictionEntered:
+	case <-time.After(time.Second):
+		t.Fatal("terminal eviction did not reach synchronization point")
+	}
+
+	downloadDone := make(chan struct {
+		path    string
+		release func()
+		err     error
+	}, 1)
+	go func() {
+		path, release, err := manager.acquireDownload(job.id, "owner-a")
+		downloadDone <- struct {
+			path    string
+			release func()
+			err     error
+		}{path: path, release: release, err: err}
+	}()
+	select {
+	case result := <-downloadDone:
+		t.Fatalf("download acquired while eviction held its locks: %+v", result.err)
+	case <-time.After(25 * time.Millisecond):
+	}
+	close(allowEviction)
+	<-evictionDone
+	result := <-downloadDone
+	if !errors.Is(result.err, errRenderNotFound) {
+		if result.release != nil {
+			result.release()
+		}
+		t.Fatalf("download/eviction interleaving error = %v, want not found", result.err)
+	}
+	if _, err := os.Stat(filepath.Join(job.dir, "output.mp4")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("evicted render output remains: %v", err)
+	}
 }
 
 func TestRenderJobExpirationRespectsDownloadLease(t *testing.T) {


### PR DESCRIPTION
## Summary\n- persist completed renders as durable clips with secure share links and creator/admin deletion\n- add a responsive clip library with playback, thumbnails, media metadata, and creator display names\n- add durable Docker storage, recovery safeguards, migrations, and operational documentation\n\n## Validation\n- go test -count=1 ./...\n- go test -race -count=1 ./...\n- CI=true npm test -- --watchAll=false\n- docker compose -f docker-compose.yaml config --quiet