### PR TITLE
Add Plex library search and show selection

### DIFF
--- a/api.go
+++ b/api.go
@@ -719,6 +719,35 @@ func selectLibraryMetadataSource(metadata *components.Metadata, requestedID int6
 	return resolveLibraryMetadataSource(metadata, 0, 0)
 }
 
+// selectLibraryMetadataSourceForDiscovery is intentionally separate from the
+// explicit selector. Search and hierarchy discovery may try later Plex
+// versions when the first otherwise-playable candidate cannot satisfy the
+// exact-duration safety rule. Explicit mediaId/partId requests continue to
+// resolve one requested source and fail when its duration is unsafe.
+func selectLibraryMetadataSourceForDiscovery(metadata *components.Metadata) (*components.Media, *components.Part, error) {
+	if metadata == nil || (metadata.Type != "movie" && metadata.Type != "episode") || strings.TrimSpace(metadata.Title) == "" {
+		return nil, nil, &sourceValidationError{message: "requested media is not clip-capable"}
+	}
+	for i := range metadata.Media {
+		media := &metadata.Media[i]
+		if media.ID <= 0 || media.VideoProfile != nil && *media.VideoProfile == "main 10" {
+			continue
+		}
+		for j := range media.Part {
+			part := &media.Part[j]
+			if part.Key == "" || part.ID <= 0 || part.Accessible != nil && !*part.Accessible || part.Exists != nil && !*part.Exists {
+				continue
+			}
+			duration, err := selectedDiscoverySourceDuration(metadata, media, part)
+			if err != nil || duration <= 0 {
+				continue
+			}
+			return media, part, nil
+		}
+	}
+	return nil, nil, &sourceValidationError{message: "requested media has no playable part"}
+}
+
 // resolveLibraryMetadataSource is the canonical explicit-library resolver.
 // mediaID identifies a Media and partID identifies its playable Part. A
 // missing partID selects the first playable part of the requested Media.
@@ -770,6 +799,25 @@ func selectedSourceDuration(media *components.Media, part *components.Part) (int
 	}
 	if media != nil && media.Duration != nil && *media.Duration > 0 {
 		return int64(*media.Duration), nil
+	}
+	return 0, nil
+}
+
+// selectedDiscoverySourceDuration is the discovery-only duration policy. A
+// title duration is safe only for a single-part source; multipart clipping
+// requires the selected Part's own exact duration.
+func selectedDiscoverySourceDuration(item *components.Metadata, media *components.Media, part *components.Part) (int64, error) {
+	if part != nil && part.Duration != nil && *part.Duration > 0 {
+		return int64(*part.Duration), nil
+	}
+	if media != nil && len(media.Part) > 1 {
+		return 0, &sourceValidationError{message: "multipart media requires a part duration"}
+	}
+	if media != nil && media.Duration != nil && *media.Duration > 0 {
+		return int64(*media.Duration), nil
+	}
+	if item != nil && item.Duration != nil && *item.Duration > 0 {
+		return int64(*item.Duration), nil
 	}
 	return 0, nil
 }

--- a/api.go
+++ b/api.go
@@ -17,7 +17,7 @@ import (
 	"time"
 
 	"github.com/LukeHagar/plexgo/models/components"
-	"github.com/LukeHagar/plexgo/models/operations"
+	"github.com/LukeHagar/plexgo/models/sdkerrors"
 	"github.com/gofiber/fiber/v3"
 	"github.com/gofiber/fiber/v3/middleware/session"
 	"github.com/gofiber/fiber/v3/middleware/static"
@@ -75,6 +75,8 @@ func NewAPI(config Config, app *Application) (*API, error) {
 	}
 
 	api.http.Get("/sessions", api.getSessions, api.authMiddleware)
+	api.http.Get("/library/search", api.searchLibrary, api.authMiddlewareJSON)
+	api.http.Get("/library/metadata/:ratingKey/children", api.getLibraryMetadataChildren, api.authMiddlewareJSON)
 	api.http.Get("/thumb", api.thumb, api.authMiddleware)
 	api.http.Get("/streams/:ratingKey", api.getStreams, api.authMiddleware)
 	api.http.Get("/subtitles/:ratingKey", api.getSubtitleEntries, api.authMiddleware)
@@ -306,27 +308,143 @@ func (a *API) getSessions(ctx fiber.Ctx) error {
 	return ctx.JSON(sessions)
 }
 
+func (a *API) searchLibrary(ctx fiber.Ctx) error {
+	token := AuthTokenFromContext(ctx.UserContext())
+	if UserFromContext(ctx.UserContext()) == nil || token == nil || strings.TrimSpace(*token) == "" {
+		return renderAPIError(ctx, http.StatusUnauthorized, "authentication required")
+	}
+	query := ctx.Query("query")
+	if query == "" {
+		// Accept the conventional short spelling without changing the stable
+		// response contract.
+		query = ctx.Query("q")
+	}
+	if _, err := validateLibrarySearchQuery(query); err != nil {
+		return renderAPIErrorCode(ctx, http.StatusUnprocessableEntity, "validation_error", err.Error())
+	}
+	results, err := a.app.SearchLibrary(ctx.UserContext(), query)
+	if err != nil {
+		log.Printf("library search failed: %s", redactedDiagnostic(err))
+		ctx.Set("Retry-After", "5")
+		return renderAPIErrorCode(ctx, http.StatusServiceUnavailable, "search_unavailable", "could not search the Plex library")
+	}
+	ctx.Set("Cache-Control", "no-store")
+	return ctx.JSON(results)
+}
+
+func (a *API) getLibraryMetadataChildren(ctx fiber.Ctx) error {
+	ratingKey, err := validateLibraryRatingKey(ctx.Params("ratingKey"))
+	if err != nil {
+		return renderAPIErrorCode(ctx, http.StatusUnprocessableEntity, "validation_error", "ratingKey is invalid")
+	}
+	token := AuthTokenFromContext(ctx.UserContext())
+	if UserFromContext(ctx.UserContext()) == nil || token == nil || strings.TrimSpace(*token) == "" {
+		return renderAPIError(ctx, http.StatusUnauthorized, "authentication required")
+	}
+	results, err := a.app.GetLibraryMetadataChildren(ctx.UserContext(), ratingKey)
+	if err != nil {
+		log.Printf("library hierarchy failed: %s", redactedDiagnostic(err))
+		return renderLibraryHierarchyAPIError(ctx, err)
+	}
+	ctx.Set("Cache-Control", "no-store")
+	return ctx.JSON(results)
+}
+
 func (a *API) getStreams(ctx fiber.Ctx) error {
 	ratingKeyStr := ctx.Params("ratingKey")
-	if ratingKeyStr == "" {
+	if ratingKeyStr == "" || len(ratingKeyStr) > 512 {
 		return fmt.Errorf("ratingKey not specified")
 	}
 
-	streams, err := a.app.GetSubtitleStreams(ctx.UserContext(), ratingKeyStr, ctx.Query("mediaId"))
+	mediaID, partID, err := parseSourceQuery(ctx)
 	if err != nil {
-		return err
+		return renderAPIErrorCode(ctx, http.StatusUnprocessableEntity, "validation_error", err.Error())
+	}
+	streams, err := a.app.GetSubtitleStreamsForSource(ctx.UserContext(), ratingKeyStr, mediaID, partID)
+	if err != nil {
+		return renderSourceAPIError(ctx, err)
 	}
 
 	return ctx.JSON(streams)
 }
 
+func parseSourceQuery(ctx fiber.Ctx) (string, string, error) {
+	mediaID := ctx.Query("mediaId")
+	partID := ctx.Query("partId")
+	if mediaID != "" {
+		value, err := strconv.ParseInt(mediaID, 10, 64)
+		if err != nil || value <= 0 {
+			return "", "", errors.New("mediaId is invalid")
+		}
+	}
+	if partID != "" {
+		value, err := strconv.ParseInt(partID, 10, 64)
+		if err != nil || value <= 0 {
+			return "", "", errors.New("partId is invalid")
+		}
+	}
+	return mediaID, partID, nil
+}
+
+func plexMetadataStatus(err error) int {
+	var sdkErr *sdkerrors.SDKError
+	if errors.As(err, &sdkErr) {
+		return sdkErr.StatusCode
+	}
+	var libraryErr *libraryHTTPError
+	if errors.As(err, &libraryErr) {
+		return libraryErr.status
+	}
+	return 0
+}
+
+func renderLibraryHierarchyAPIError(ctx fiber.Ctx, err error) error {
+	var validationErr *sourceValidationError
+	if errors.As(err, &validationErr) {
+		return renderAPIErrorCode(ctx, http.StatusUnprocessableEntity, "validation_error", validationErr.Error())
+	}
+	status := plexMetadataStatus(err)
+	if status == http.StatusUnauthorized || status == http.StatusForbidden || status == http.StatusNotFound {
+		return renderAPIErrorCode(ctx, http.StatusNotFound, "not_found", "requested library item is unavailable")
+	}
+	return renderAPIErrorCode(ctx, http.StatusServiceUnavailable, "metadata_unavailable", "could not load the library hierarchy")
+}
+
+func normalizeSourceError(err error) error {
+	var validationErr *sourceValidationError
+	if errors.As(err, &validationErr) {
+		return err
+	}
+	status := plexMetadataStatus(err)
+	if status == http.StatusUnauthorized || status == http.StatusForbidden || status == http.StatusNotFound {
+		return errors.New("requested media is unavailable")
+	}
+	return newPreviewUpstreamFailure("could not get library metadata", errors.New("Plex metadata service unavailable"))
+}
+
+func renderSourceAPIError(ctx fiber.Ctx, err error) error {
+	var validationErr *sourceValidationError
+	if errors.As(err, &validationErr) {
+		return renderAPIErrorCode(ctx, http.StatusUnprocessableEntity, "validation_error", validationErr.Error())
+	}
+	status := plexMetadataStatus(err)
+	if status == 0 || status >= 500 {
+		return renderAPIErrorCode(ctx, http.StatusServiceUnavailable, "metadata_unavailable", "could not validate the requested media")
+	}
+	return renderAPIErrorCode(ctx, http.StatusUnprocessableEntity, "validation_error", "requested media is unavailable")
+}
+
 func (a *API) getSubtitleEntries(ctx fiber.Ctx) error {
 	ratingKeyStr := ctx.Params("ratingKey")
-	if ratingKeyStr == "" {
+	if ratingKeyStr == "" || len(ratingKeyStr) > 512 {
 		return fmt.Errorf("ratingKey not specified")
 	}
 
 	mediaIdStr := ctx.Query("mediaId")
+	partIdStr := ctx.Query("partId")
+	if _, _, err := parseSourceQuery(ctx); err != nil {
+		return renderAPIErrorCode(ctx, http.StatusUnprocessableEntity, "validation_error", err.Error())
+	}
 
 	subtitleIndexStr := ctx.Query("subtitle", "-1")
 	subtitleIndex, err := strconv.Atoi(subtitleIndexStr)
@@ -338,9 +456,9 @@ func (a *API) getSubtitleEntries(ctx fiber.Ctx) error {
 		return ctx.JSON([]SubtitleEntry{})
 	}
 
-	entries, err := a.app.GetSubtitleEntries(ctx.UserContext(), ratingKeyStr, mediaIdStr, subtitleIndex)
+	entries, err := a.app.GetSubtitleEntriesForSource(ctx.UserContext(), ratingKeyStr, mediaIdStr, partIdStr, subtitleIndex)
 	if err != nil {
-		return err
+		return renderSourceAPIError(ctx, err)
 	}
 
 	return ctx.JSON(entries)
@@ -348,7 +466,7 @@ func (a *API) getSubtitleEntries(ctx fiber.Ctx) error {
 
 func (a *API) clip(ctx fiber.Ctx) error {
 	ratingKeyStr := ctx.Params("ratingKey")
-	if ratingKeyStr == "" {
+	if ratingKeyStr == "" || len(ratingKeyStr) > 512 {
 		return fmt.Errorf("ratingKey not specified")
 	}
 
@@ -481,6 +599,10 @@ type previewSessionSelection struct {
 	selected int64
 }
 
+type sourceValidationError struct{ message string }
+
+func (e *sourceValidationError) Error() string { return e.message }
+
 // selectPreviewSessionSource authorizes a preview against the caller-visible
 // session list. Active-session responses do not reliably include the part key
 // (or file), so this deliberately checks IDs only. The playable key is taken
@@ -577,6 +699,81 @@ func resolvePreviewMetadataSource(metadata []components.Media, selection preview
 	return nil, nil, errors.New("requested preview source is unavailable")
 }
 
+// selectLibraryMetadataSource applies the one source policy used by search,
+// preview, subtitles, and render: movie/episode metadata must resolve to a
+// real, accessible Part with a Plex stream key. Media are considered in PMS
+// order, with main-10 encodes skipped as they are by the existing renderer.
+// A supplied ID may identify either the parent Media or one of its Parts.
+func selectLibraryMetadataSource(metadata *components.Metadata, requestedID int64, supplied bool) (*components.Media, *components.Part, error) {
+	if metadata == nil {
+		return nil, nil, &sourceValidationError{message: "requested media is not clip-capable"}
+	}
+	if supplied {
+		for _, media := range metadata.Media {
+			if media.ID == requestedID {
+				return resolveLibraryMetadataSource(metadata, requestedID, 0)
+			}
+		}
+		return resolveLibraryMetadataSource(metadata, 0, requestedID)
+	}
+	return resolveLibraryMetadataSource(metadata, 0, 0)
+}
+
+// resolveLibraryMetadataSource is the canonical explicit-library resolver.
+// mediaID identifies a Media and partID identifies its playable Part. A
+// missing partID selects the first playable part of the requested Media.
+func resolveLibraryMetadataSource(metadata *components.Metadata, mediaID, partID int64) (*components.Media, *components.Part, error) {
+	if metadata == nil || (metadata.Type != "movie" && metadata.Type != "episode") || strings.TrimSpace(metadata.Title) == "" {
+		return nil, nil, &sourceValidationError{message: "requested media is not clip-capable"}
+	}
+	for i := range metadata.Media {
+		media := &metadata.Media[i]
+		if media.ID <= 0 || mediaID > 0 && media.ID != mediaID {
+			continue
+		}
+		if media.VideoProfile != nil && *media.VideoProfile == "main 10" {
+			continue
+		}
+		for j := range media.Part {
+			part := &media.Part[j]
+			if partID > 0 && part.ID != partID {
+				continue
+			}
+			if part.Key == "" || part.ID <= 0 || part.Accessible != nil && !*part.Accessible || part.Exists != nil && !*part.Exists {
+				continue
+			}
+			return media, part, nil
+		}
+	}
+	return nil, nil, &sourceValidationError{message: "requested media has no playable part"}
+}
+
+func mediaDurationFromSource(media *components.Media, part *components.Part) int64 {
+	if part != nil && part.Duration != nil && *part.Duration > 0 {
+		return int64(*part.Duration)
+	}
+	if media != nil && len(media.Part) > 1 {
+		return 0
+	}
+	if media != nil && media.Duration != nil && *media.Duration > 0 {
+		return int64(*media.Duration)
+	}
+	return 0
+}
+
+func selectedSourceDuration(media *components.Media, part *components.Part) (int64, error) {
+	if part != nil && part.Duration != nil && *part.Duration > 0 {
+		return int64(*part.Duration), nil
+	}
+	if media != nil && len(media.Part) > 1 {
+		return 0, &sourceValidationError{message: "multipart media requires a part duration"}
+	}
+	if media != nil && media.Duration != nil && *media.Duration > 0 {
+		return int64(*media.Duration), nil
+	}
+	return 0, nil
+}
+
 func findVisiblePartKey(sessions []sessionMetadata, ratingKey string, requestedID int64) string {
 	for _, session := range sessions {
 		key := session.Key
@@ -644,7 +841,7 @@ func (a *API) previewStream(ctx fiber.Ctx) error {
 	}()
 
 	ratingKeyStr := ctx.Params("ratingKey")
-	if ratingKeyStr == "" {
+	if ratingKeyStr == "" || len(ratingKeyStr) > 512 {
 		return fmt.Errorf("ratingKey not specified")
 	}
 
@@ -680,11 +877,19 @@ func (a *API) previewStream(ctx fiber.Ctx) error {
 	}
 
 	previewMediaIdStr := ctx.Query("mediaId")
+	previewPartIdStr := ctx.Query("partId")
 	var previewMediaId int64
 	if previewMediaIdStr != "" {
 		previewMediaId, err = strconv.ParseInt(previewMediaIdStr, 10, 64)
 		if err != nil || previewMediaId <= 0 {
 			return errors.New("could not parse media id")
+		}
+	}
+	var previewPartId int64
+	if previewPartIdStr != "" {
+		previewPartId, err = strconv.ParseInt(previewPartIdStr, 10, 64)
+		if err != nil || previewPartId <= 0 {
+			return errors.New("could not parse part id")
 		}
 	}
 	if subtitleIndex < -1 {
@@ -695,44 +900,56 @@ func (a *API) previewStream(ctx fiber.Ctx) error {
 		return errors.New("subtitleOffsetMs is invalid")
 	}
 
-	// Validate the caller-visible source before asking the configured Plex
-	// administrator token for metadata. This prevents a valid session from
-	// being used to probe arbitrary library items.
-	sessions, err := a.app.GetSessions(operationCtx)
-	if err != nil {
-		return newPreviewUpstreamFailure("could not validate caller-visible preview source", err)
-	}
-	selection, err := selectPreviewSessionSource(sessions, ratingKeyStr, previewMediaId, previewMediaIdStr != "")
-	if err != nil {
-		return err
+	var sessions []sessionMetadata
+	var selection previewSessionSelection
+	userScoped := previewPartIdStr != ""
+	var metadataItem *components.Metadata
+	if userScoped {
+		metadataItem, err = a.app.getMetadataItem(operationCtx, ratingKeyStr, true)
+		if err != nil {
+			return normalizeSourceError(err)
+		}
+		media, part, sourceErr := resolveLibraryMetadataSource(metadataItem, previewMediaId, previewPartId)
+		if sourceErr != nil {
+			return sourceErr
+		}
+		duration := mediaDurationFromSource(media, part)
+		if _, durationErr := selectedSourceDuration(media, part); durationErr != nil {
+			return durationErr
+		}
+		selection = previewSessionSelection{mediaID: media.ID, partID: part.ID, duration: duration, selected: part.ID}
+	} else {
+		// No partId is the legacy active-session path. Explicit library sources
+		// must never depend on /status/sessions being available.
+		sessions, err = a.app.GetSessions(operationCtx)
+		if err != nil {
+			return newPreviewUpstreamFailure("could not validate caller-visible preview source", err)
+		}
+		selection, err = selectPreviewSessionSource(sessions, ratingKeyStr, previewMediaId, previewMediaIdStr != "")
+		if err != nil {
+			return err
+		}
 	}
 	if selection.duration > 0 && toMs > selection.duration {
 		return errors.New("requested range exceeds the selected media duration")
 	}
 
-	libraryMetadata, err := a.app.plexAdmin.Content.GetMetadataItem(operationCtx, operations.GetMetadataItemRequest{
-		Ids: []string{ratingKeyStr},
-	})
+	if metadataItem == nil {
+		metadataItem, err = a.app.getMetadataItem(operationCtx, ratingKeyStr, userScoped)
+	}
 	if err != nil {
 		return newPreviewUpstreamFailure("could not get library metadata", err)
 	}
-
-	metadataList := libraryMetadata.MediaContainerWithMetadata.MediaContainer.Metadata
-	if len(metadataList) == 0 {
-		return errors.New("requested preview source is unavailable")
-	}
-	metadata := metadataList[0]
+	metadata := *metadataItem
 
 	previewMedia, previewPart, err := resolvePreviewMetadataSource(metadata.Media, selection)
 	if err != nil {
 		return err
 	}
-	visibleMediaID := selection.selected
-	mediaDuration := int64(0)
-	if previewMedia.Duration != nil && *previewMedia.Duration > 0 {
-		mediaDuration = int64(*previewMedia.Duration)
-	} else if previewPart.Duration != nil && *previewPart.Duration > 0 {
-		mediaDuration = int64(*previewPart.Duration)
+	visibleMediaID := previewMedia.ID
+	mediaDuration, durationErr := selectedSourceDuration(previewMedia, previewPart)
+	if durationErr != nil {
+		return durationErr
 	}
 	if mediaDuration > 0 && toMs > mediaDuration {
 		return errors.New("requested range exceeds the selected media duration")
@@ -741,7 +958,7 @@ func (a *API) previewStream(ctx fiber.Ctx) error {
 	fileURL := fmt.Sprintf("%s%s?X-Plex-Token=%s",
 		a.config.Plex.Host,
 		previewPart.Key,
-		a.config.Plex.Token,
+		a.app.plexSourceToken(operationCtx, userScoped),
 	)
 
 	// Extract subtitle to temp file if requested. For text subtitles, either use
@@ -767,7 +984,8 @@ func (a *API) previewStream(ctx fiber.Ctx) error {
 			subtitleIdxForFFmpeg = source.EmbeddedIndex
 		} else {
 			cacheMediaID := strconv.FormatInt(visibleMediaID, 10)
-			if entries, ok := a.app.GetCachedSubtitleEntries(ratingKeyStr, cacheMediaID, subtitleIndex); ok {
+			cachePartID := strconv.FormatInt(previewPart.ID, 10)
+			if entries, ok := a.app.GetCachedSubtitleEntries(operationCtx, ratingKeyStr, cacheMediaID, cachePartID, subtitleIndex); ok {
 				subtitleFile, err = WriteClipSRT(entries, fromMs, toMs, subtitleOffsetMs)
 				if err != nil {
 					return fmt.Errorf("could not write clip subtitle: %w", err)
@@ -776,7 +994,7 @@ func (a *API) previewStream(ctx fiber.Ctx) error {
 				if !isSupportedTextSubtitle(source) {
 					return errors.New("subtitle codec is not supported")
 				}
-				subtitleFile, err = a.app.prepareExternalSubtitle(operationCtx, source, fromMs, toMs, subtitleOffsetMs)
+				subtitleFile, err = a.app.prepareExternalSubtitleWithToken(operationCtx, source, fromMs, toMs, []int64{subtitleOffsetMs}, a.app.plexSourceToken(operationCtx, userScoped))
 				if err != nil {
 					return newPreviewUpstreamFailure("preview subtitle source unavailable", err)
 				}

--- a/api.go
+++ b/api.go
@@ -702,7 +702,7 @@ func resolvePreviewMetadataSource(metadata []components.Media, selection preview
 // selectLibraryMetadataSource applies the one source policy used by search,
 // preview, subtitles, and render: movie/episode metadata must resolve to a
 // real, accessible Part with a Plex stream key. Media are considered in PMS
-// order, with main-10 encodes skipped as they are by the existing renderer.
+// order; source codec/profile is left to the FFmpeg render pipeline.
 // A supplied ID may identify either the parent Media or one of its Parts.
 func selectLibraryMetadataSource(metadata *components.Metadata, requestedID int64, supplied bool) (*components.Media, *components.Part, error) {
 	if metadata == nil {
@@ -730,7 +730,7 @@ func selectLibraryMetadataSourceForDiscovery(metadata *components.Metadata) (*co
 	}
 	for i := range metadata.Media {
 		media := &metadata.Media[i]
-		if media.ID <= 0 || media.VideoProfile != nil && *media.VideoProfile == "main 10" {
+		if media.ID <= 0 {
 			continue
 		}
 		for j := range media.Part {
@@ -758,9 +758,6 @@ func resolveLibraryMetadataSource(metadata *components.Metadata, mediaID, partID
 	for i := range metadata.Media {
 		media := &metadata.Media[i]
 		if media.ID <= 0 || mediaID > 0 && media.ID != mediaID {
-			continue
-		}
-		if media.VideoProfile != nil && *media.VideoProfile == "main 10" {
 			continue
 		}
 		for j := range media.Part {

--- a/api_render_jobs_test.go
+++ b/api_render_jobs_test.go
@@ -34,6 +34,8 @@ func TestProtectedRoutesRunAuthBeforeHandlers(t *testing.T) {
 		json   bool
 	}{
 		{http.MethodGet, "/sessions", false},
+		{http.MethodGet, "/library/search?query=movie", true},
+		{http.MethodGet, "/library/metadata/show-1/children", true},
 		{http.MethodGet, "/thumb?path=/thumb", false},
 		{http.MethodGet, "/streams/movie", false},
 		{http.MethodGet, "/subtitles/movie", false},
@@ -478,7 +480,7 @@ func TestGetStreamsSelectsSubtitleBearingPartAndUsesSubtitleOrdinal(t *testing.T
 			http.NotFound(w, r)
 			return
 		}
-		_, _ = io.WriteString(w, `{"MediaContainer":{"Metadata":[{"Media":[{"id":10,"Part":[{"id":100,"key":"/library/parts/100/file.mp4","Stream":[{"streamType":1,"index":0},{"streamType":2,"index":1}]},{"id":200,"key":"/library/parts/200/file.mp4","Stream":[{"streamType":1,"index":4},{"streamType":3,"index":9,"codec":"subrip","language":"English","displayTitle":"English"}]}]}]}]}}`)
+		_, _ = io.WriteString(w, `{"MediaContainer":{"Metadata":[{"ratingKey":"movie-1","type":"movie","title":"Movie","Media":[{"id":10,"Part":[{"id":100,"key":"/library/parts/100/file.mp4","Stream":[{"streamType":1,"index":0},{"streamType":2,"index":1}]},{"id":200,"key":"/library/parts/200/file.mp4","Stream":[{"streamType":1,"index":4},{"streamType":3,"index":9,"codec":"subrip","language":"English","displayTitle":"English"}]}]}]}]}}`)
 	}))
 	defer plex.Close()
 
@@ -515,7 +517,7 @@ func TestGetSubtitleEntriesUsesSelectedPartForNativeExtractionAndCache(t *testin
 	plex := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/library/metadata/movie-1" {
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = io.WriteString(w, `{"MediaContainer":{"Metadata":[{"Media":[{"id":10,"Part":[{"id":100,"key":"/library/parts/100/file.mp4"},{"id":200,"key":"/library/parts/200/file.mp4","Stream":[{"streamType":3,"codec":"subrip","key":"/library/streams/200"}]}]}]}]}}`)
+			_, _ = io.WriteString(w, `{"MediaContainer":{"Metadata":[{"ratingKey":"movie-1","type":"movie","title":"Movie","Media":[{"id":10,"Part":[{"id":100,"key":"/library/parts/100/file.mp4"},{"id":200,"key":"/library/parts/200/file.mp4","Stream":[{"streamType":3,"codec":"subrip","key":"/library/streams/200"}]}]}]}]}}`)
 			return
 		}
 		if r.URL.Path == "/library/streams/200" {
@@ -545,7 +547,7 @@ func TestGetSubtitleEntriesUsesSelectedPartForNativeExtractionAndCache(t *testin
 	if subtitleRequests != 1 {
 		t.Fatalf("native subtitle requests = %d, want 1", subtitleRequests)
 	}
-	if _, ok := app.GetCachedSubtitleEntries("movie-1", "200", 0); !ok {
+	if _, ok := app.GetCachedSubtitleEntries(context.Background(), "movie-1", "10", "200", 0); !ok {
 		t.Fatal("selected subtitle entries were not cached")
 	}
 }

--- a/application.go
+++ b/application.go
@@ -169,6 +169,7 @@ type sessionMedia struct {
 	AudioCodec      *string       `json:"audioCodec,omitempty"`
 	AudioChannels   *int          `json:"audioChannels,omitempty"`
 	VideoCodec      *string       `json:"videoCodec,omitempty"`
+	VideoProfile    *string       `json:"videoProfile,omitempty"`
 	VideoResolution *string       `json:"videoResolution,omitempty"`
 	Container       *string       `json:"container,omitempty"`
 	Part            []sessionPart `json:"Part,omitempty"`

--- a/application.go
+++ b/application.go
@@ -30,21 +30,30 @@ import (
 type subtitleCache struct {
 	mu    sync.RWMutex
 	max   int
-	m     map[subtitleCacheKey][]SubtitleEntry
-	order []subtitleCacheKey
+	m     map[subtitleCacheEntryKey][]SubtitleEntry
+	order []subtitleCacheEntryKey
+}
+
+type subtitleCacheEntryKey struct {
+	key      subtitleCacheKey
+	callerID string
 }
 
 func newSubtitleCache(max int) *subtitleCache {
 	return &subtitleCache{
 		max: max,
-		m:   make(map[subtitleCacheKey][]SubtitleEntry),
+		m:   make(map[subtitleCacheEntryKey][]SubtitleEntry),
 	}
 }
 
 func (c *subtitleCache) get(key subtitleCacheKey) ([]SubtitleEntry, bool) {
+	return c.getForCaller(key, "legacy")
+}
+
+func (c *subtitleCache) getForCaller(key subtitleCacheKey, callerID string) ([]SubtitleEntry, bool) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	entries, ok := c.m[key]
+	entries, ok := c.m[subtitleCacheEntryKey{key: key, callerID: callerID}]
 	if !ok {
 		return nil, false
 	}
@@ -55,22 +64,27 @@ func (c *subtitleCache) get(key subtitleCacheKey) ([]SubtitleEntry, bool) {
 }
 
 func (c *subtitleCache) set(key subtitleCacheKey, entries []SubtitleEntry) {
+	c.setForCaller(key, entries, "legacy")
+}
+
+func (c *subtitleCache) setForCaller(key subtitleCacheKey, entries []SubtitleEntry, callerID string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	// defensive copy
 	entriesCopy := make([]SubtitleEntry, len(entries))
 	copy(entriesCopy, entries)
 
-	if _, exists := c.m[key]; !exists && len(c.m) >= c.max && c.max > 0 {
+	entryKey := subtitleCacheEntryKey{key: key, callerID: callerID}
+	if _, exists := c.m[entryKey]; !exists && len(c.m) >= c.max && c.max > 0 {
 		// FIFO eviction: remove oldest entry
 		oldest := c.order[0]
 		delete(c.m, oldest)
 		c.order = c.order[1:]
 	}
-	if _, exists := c.m[key]; !exists {
-		c.order = append(c.order, key)
+	if _, exists := c.m[entryKey]; !exists {
+		c.order = append(c.order, entryKey)
 	}
-	c.m[key] = entriesCopy
+	c.m[entryKey] = entriesCopy
 }
 
 func (c *subtitleCache) len() int {
@@ -234,6 +248,7 @@ func NewApplication(config Config) (*Application, error) {
 	app.plexUser = plexgo.New(
 		plexgo.WithServerURL(config.Plex.Host),
 		plexgo.WithSecuritySource(app.plexSecurityUserToken),
+		plexgo.WithClient(callerPlexHTTPClient),
 	)
 
 	app.clipStore, err = newClipStore(durableStorageRoot(config), config.Storage.Database)
@@ -243,7 +258,11 @@ func NewApplication(config Config) (*Application, error) {
 	app.renderJobs, err = newRenderJobManagerWithContextAndPromotion(app.lifetime, renderRoot, app.executeRenderSpec, func(job *renderJob, outputPath string) error {
 		artworkContext, cancelArtwork := context.WithTimeout(app.lifetime, 30*time.Second)
 		defer cancelArtwork()
-		artworkPath, artworkMIME, artworkErr := app.fetchClipArtwork(artworkContext, job.spec.ThumbnailURL)
+		artworkToken := job.spec.SourceToken
+		if artworkToken == "" {
+			artworkToken = app.config.Plex.Token
+		}
+		artworkPath, artworkMIME, artworkErr := app.fetchClipArtworkWithToken(artworkContext, job.spec.ThumbnailURL, artworkToken)
 		if artworkErr != nil {
 			log.Printf("clip artwork snapshot unavailable: %s", redactedDiagnostic(artworkErr))
 		}
@@ -289,6 +308,10 @@ func (a *Application) Close() error {
 const maxClipArtworkBytes int64 = 8 << 20
 
 func (a *Application) fetchClipArtwork(ctx context.Context, artworkPath string) (string, string, error) {
+	return a.fetchClipArtworkWithToken(ctx, artworkPath, a.config.Plex.Token)
+}
+
+func (a *Application) fetchClipArtworkWithToken(ctx context.Context, artworkPath, token string) (string, string, error) {
 	if strings.TrimSpace(artworkPath) == "" {
 		return "", "", nil
 	}
@@ -322,7 +345,7 @@ func (a *Application) fetchClipArtwork(ctx context.Context, artworkPath string) 
 		return "", "", errors.New("clip artwork origin is not the configured Plex origin")
 	}
 	query := parsed.Query()
-	query.Set("X-Plex-Token", a.config.Plex.Token)
+	query.Set("X-Plex-Token", token)
 	parsed.RawQuery = query.Encode()
 	request, err := http.NewRequestWithContext(ctx, http.MethodGet, parsed.String(), nil)
 	if err != nil {
@@ -456,6 +479,47 @@ func (a *Application) plexSecurityUserToken(ctx context.Context) (components.Sec
 	return components.Security{
 		Token: authToken,
 	}, nil
+}
+
+// getMetadataItem keeps the access decision explicit. Library requests must
+// use the token belonging to the caller; the configured administrator client
+// is retained for the existing active-session path.
+func (a *Application) getMetadataItem(ctx context.Context, ratingKey string, userScoped bool) (*components.Metadata, error) {
+	var response *operations.GetMetadataItemResponse
+	var err error
+	request := operations.GetMetadataItemRequest{Ids: []string{ratingKey}}
+	if userScoped {
+		if token := AuthTokenFromContext(ctx); token == nil || strings.TrimSpace(*token) == "" {
+			return nil, errors.New("caller-scoped Plex client is unavailable")
+		} else {
+			return a.getCallerMetadataItem(ctx, ratingKey, *token)
+		}
+	} else {
+		if a.plexAdmin == nil {
+			return nil, errors.New("Plex client is unavailable")
+		}
+		response, err = a.plexAdmin.Content.GetMetadataItem(ctx, request)
+	}
+	if err != nil {
+		return nil, err
+	}
+	if response == nil || response.MediaContainerWithMetadata == nil || response.MediaContainerWithMetadata.MediaContainer == nil || len(response.MediaContainerWithMetadata.MediaContainer.Metadata) == 0 {
+		return nil, &sourceValidationError{message: "requested media is unavailable"}
+	}
+	metadata := response.MediaContainerWithMetadata.MediaContainer.Metadata[0]
+	if metadata.RatingKey != nil && *metadata.RatingKey != "" && *metadata.RatingKey != ratingKey {
+		return nil, &sourceValidationError{message: "requested media is unavailable"}
+	}
+	return &metadata, nil
+}
+
+func (a *Application) plexSourceToken(ctx context.Context, userScoped bool) string {
+	if userScoped {
+		if token := AuthTokenFromContext(ctx); token != nil && strings.TrimSpace(*token) != "" {
+			return *token
+		}
+	}
+	return a.config.Plex.Token
 }
 
 func (a *Application) GetValidatedUser(ctx context.Context) (*User, error) {
@@ -772,42 +836,62 @@ type subtitleCacheKey struct {
 	subtitleIndex int
 }
 
+func subtitleCallerID(ctx context.Context) (string, error) {
+	if user := UserFromContext(ctx); user != nil && strings.TrimSpace(user.Uuid) != "" {
+		return "plex-user:" + normalizeOwnerIdentity(user.Uuid), nil
+	}
+	if AuthTokenFromContext(ctx) != nil {
+		return "", errors.New("authenticated user is missing a stable id")
+	}
+	// Direct unauthenticated unit callers retain the old in-process namespace;
+	// HTTP callers cannot reach subtitle handlers without validated auth.
+	return "legacy", nil
+}
+
+func resolveRequestedSource(metadata *components.Metadata, mediaIDStr, partIDStr string) (*components.Media, *components.Part, error) {
+	var mediaID, partID int64
+	var err error
+	if mediaIDStr != "" {
+		mediaID, err = strconv.ParseInt(mediaIDStr, 10, 64)
+		if err != nil || mediaID <= 0 {
+			return nil, nil, errors.New("mediaId is invalid")
+		}
+	}
+	if partIDStr != "" {
+		partID, err = strconv.ParseInt(partIDStr, 10, 64)
+		if err != nil || partID <= 0 {
+			return nil, nil, errors.New("partId is invalid")
+		}
+	}
+	if partID > 0 {
+		return resolveLibraryMetadataSource(metadata, mediaID, partID)
+	}
+	if mediaID > 0 {
+		return selectLibraryMetadataSource(metadata, mediaID, true)
+	}
+	return selectLibraryMetadataSource(metadata, 0, false)
+}
+
 func (a *Application) GetSubtitleStreams(ctx context.Context, ratingKeyStr string, mediaIdStr ...string) ([]SubtitleStream, error) {
-	libraryMetadata, err := a.plexAdmin.Content.GetMetadataItem(ctx, operations.GetMetadataItemRequest{
-		Ids: []string{ratingKeyStr},
-	})
+	mediaID := ""
+	if len(mediaIdStr) > 0 {
+		mediaID = mediaIdStr[0]
+	}
+	return a.GetSubtitleStreamsForSource(ctx, ratingKeyStr, mediaID, "")
+}
+
+func (a *Application) GetSubtitleStreamsForSource(ctx context.Context, ratingKeyStr, mediaIdStr, partIdStr string) ([]SubtitleStream, error) {
+	metadata, err := a.getMetadataItem(ctx, ratingKeyStr, AuthTokenFromContext(ctx) != nil)
 	if err != nil {
 		return nil, err
 	}
-
-	metadata := libraryMetadata.MediaContainerWithMetadata.MediaContainer.Metadata[0]
 	if len(metadata.Media) == 0 {
 		return nil, nil
 	}
 
-	var selectedPart *components.Part
-	if len(metadata.Media[0].Part) > 0 {
-		selectedPart = &metadata.Media[0].Part[0]
-	}
-	if len(mediaIdStr) > 0 && mediaIdStr[0] != "" {
-		mediaId, err := strconv.ParseInt(mediaIdStr[0], 10, 64)
-		if err != nil {
-			return nil, fmt.Errorf("could not parse media id: %w", err)
-		}
-		media, err := resolveMedia(metadata.Media, mediaId, true)
-		if err != nil {
-			return nil, err
-		}
-		selectedPart, err = resolvePart(media, mediaId, true)
-		if err != nil {
-			return nil, err
-		}
-		if selectedPart == nil {
-			return nil, nil
-		}
-	}
-	if selectedPart == nil {
-		return nil, nil
+	_, selectedPart, err := resolveRequestedSource(metadata, mediaIdStr, partIdStr)
+	if err != nil {
+		return nil, err
 	}
 
 	var result []SubtitleStream
@@ -852,47 +936,35 @@ func (a *Application) GetSubtitleStreams(ctx context.Context, ratingKeyStr strin
 }
 
 func (a *Application) GetSubtitleEntries(ctx context.Context, ratingKeyStr, mediaIdStr string, subtitleIndex int) ([]SubtitleEntry, error) {
+	return a.GetSubtitleEntriesForSource(ctx, ratingKeyStr, mediaIdStr, "", subtitleIndex)
+}
+
+func (a *Application) GetSubtitleEntriesForSource(ctx context.Context, ratingKeyStr, mediaIdStr, partIdStr string, subtitleIndex int) ([]SubtitleEntry, error) {
 	operationCtx, cancelOperation := a.operationContext(ctx)
 	defer cancelOperation()
 
-	var mediaId int64
-	if mediaIdStr != "" {
-		var err error
-		mediaId, err = strconv.ParseInt(mediaIdStr, 10, 64)
-		if err != nil {
-			return nil, fmt.Errorf("could not parse media id: %w", err)
-		}
-	}
-
-	cacheKey := subtitleCacheKey{
-		ratingKey:     ratingKeyStr,
-		mediaId:       mediaId,
-		subtitleIndex: subtitleIndex,
-	}
-
-	if entries, ok := a.subtitleCache.get(cacheKey); ok {
-		return entries, nil
-	}
-
-	libraryMetadata, err := a.plexAdmin.Content.GetMetadataItem(operationCtx, operations.GetMetadataItemRequest{
-		Ids: []string{ratingKeyStr},
-	})
+	metadata, err := a.getMetadataItem(operationCtx, ratingKeyStr, AuthTokenFromContext(operationCtx) != nil)
 	if err != nil {
 		return nil, fmt.Errorf("could not get library metadata: %w", err)
 	}
 
-	metadata := libraryMetadata.MediaContainerWithMetadata.MediaContainer.Metadata[0]
-
-	media, err := resolveMedia(metadata.Media, mediaId, mediaIdStr != "")
-	if err != nil {
-		return nil, err
-	}
-	part, err := resolvePart(media, mediaId, mediaIdStr != "")
+	_, part, err := resolveRequestedSource(metadata, mediaIdStr, partIdStr)
 	if err != nil {
 		return nil, err
 	}
 	if part == nil {
 		return nil, nil
+	}
+	callerID, err := subtitleCallerID(operationCtx)
+	if err != nil {
+		return nil, err
+	}
+	if a.subtitleCache == nil {
+		return nil, errors.New("subtitle cache is unavailable")
+	}
+	cacheKey := subtitleCacheKey{ratingKey: ratingKeyStr, mediaId: part.ID, subtitleIndex: subtitleIndex}
+	if entries, ok := a.subtitleCache.getForCaller(cacheKey, callerID); ok {
+		return entries, nil
 	}
 
 	source, err := selectSubtitleSource(part.Stream, subtitleIndex)
@@ -913,14 +985,14 @@ func (a *Application) GetSubtitleEntries(ctx context.Context, ratingKeyStr, medi
 		if err != nil {
 			return nil, fmt.Errorf("could not download external subtitle: %w", err)
 		}
-		a.subtitleCache.set(cacheKey, entries)
+		a.subtitleCache.setForCaller(cacheKey, entries, callerID)
 		return entries, nil
 	}
 
 	fileURL := fmt.Sprintf("%s%s?X-Plex-Token=%s",
 		a.config.Plex.Host,
 		part.Key,
-		a.config.Plex.Token,
+		a.plexSourceToken(operationCtx, AuthTokenFromContext(operationCtx) != nil),
 	)
 
 	release, err := a.acquireFFmpeg(operationCtx)
@@ -939,16 +1011,20 @@ func (a *Application) GetSubtitleEntries(ctx context.Context, ratingKeyStr, medi
 		return nil, err
 	}
 
-	a.subtitleCache.set(cacheKey, entries)
+	a.subtitleCache.setForCaller(cacheKey, entries, callerID)
 
 	return entries, nil
 }
 
 func (a *Application) downloadSubtitle(ctx context.Context, streamKey, codec string) ([]SubtitleEntry, error) {
+	return a.downloadSubtitleWithToken(ctx, streamKey, codec, a.plexSourceToken(ctx, AuthTokenFromContext(ctx) != nil))
+}
+
+func (a *Application) downloadSubtitleWithToken(ctx context.Context, streamKey, codec, token string) ([]SubtitleEntry, error) {
 	streamURL := fmt.Sprintf("%s%s?X-Plex-Token=%s",
 		a.config.Plex.Host,
 		streamKey,
-		a.config.Plex.Token,
+		token,
 	)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, streamURL, nil)
@@ -997,13 +1073,17 @@ func (a *Application) downloadSubtitle(ctx context.Context, streamKey, codec str
 }
 
 func (a *Application) prepareExternalSubtitle(ctx context.Context, source subtitleSource, fromMs, toMs int64, subtitleOffsets ...int64) (string, error) {
+	return a.prepareExternalSubtitleWithToken(ctx, source, fromMs, toMs, subtitleOffsets, a.plexSourceToken(ctx, AuthTokenFromContext(ctx) != nil))
+}
+
+func (a *Application) prepareExternalSubtitleWithToken(ctx context.Context, source subtitleSource, fromMs, toMs int64, subtitleOffsets []int64, token string) (string, error) {
 	if !source.External || source.StreamKey == "" {
 		return "", fmt.Errorf("external subtitle stream key is missing")
 	}
 	if source.PGS || !isSupportedTextSubtitle(source) {
 		return "", fmt.Errorf("external subtitle codec is not supported")
 	}
-	entries, err := a.downloadSubtitle(ctx, source.StreamKey, subtitleSourceCodec(source))
+	entries, err := a.downloadSubtitleWithToken(ctx, source.StreamKey, subtitleSourceCodec(source), token)
 	if err != nil {
 		return "", fmt.Errorf("could not download external subtitle: %w", err)
 	}
@@ -1014,32 +1094,32 @@ func (a *Application) prepareExternalSubtitle(ctx context.Context, source subtit
 	return subtitleFile, nil
 }
 
-func (a *Application) GetCachedSubtitleEntries(ratingKeyStr, mediaIdStr string, subtitleIndex int) ([]SubtitleEntry, bool) {
-	var mediaId int64
-	if mediaIdStr != "" {
-		var err error
-		mediaId, err = strconv.ParseInt(mediaIdStr, 10, 64)
-		if err != nil {
-			return nil, false
-		}
+func (a *Application) GetCachedSubtitleEntries(ctx context.Context, ratingKeyStr, mediaIdStr, partIdStr string, subtitleIndex int) ([]SubtitleEntry, bool) {
+	if a.subtitleCache == nil {
+		return nil, false
 	}
-
-	return a.subtitleCache.get(subtitleCacheKey{
-		ratingKey:     ratingKeyStr,
-		mediaId:       mediaId,
-		subtitleIndex: subtitleIndex,
-	})
+	metadata, err := a.getMetadataItem(ctx, ratingKeyStr, AuthTokenFromContext(ctx) != nil)
+	if err != nil {
+		return nil, false
+	}
+	_, part, err := resolveRequestedSource(metadata, mediaIdStr, partIdStr)
+	if err != nil || part == nil {
+		return nil, false
+	}
+	callerID, err := subtitleCallerID(ctx)
+	if err != nil {
+		return nil, false
+	}
+	return a.subtitleCache.getForCaller(subtitleCacheKey{
+		ratingKey: ratingKeyStr, mediaId: part.ID, subtitleIndex: subtitleIndex,
+	}, callerID)
 }
 
 func (a *Application) Clip(ctx context.Context, ratingKeyStr, mediaIdStr, from, to string, height, qp, subtitleIndex int) (string, error) {
-	libraryMetadata, err := a.plexAdmin.Content.GetMetadataItem(ctx, operations.GetMetadataItemRequest{
-		Ids: []string{ratingKeyStr},
-	})
+	metadata, err := a.getMetadataItem(ctx, ratingKeyStr, AuthTokenFromContext(ctx) != nil)
 	if err != nil {
 		return "", fmt.Errorf("could not get library metadata: %w", err)
 	}
-
-	metadata := libraryMetadata.MediaContainerWithMetadata.MediaContainer.Metadata[0]
 
 	var mediaId int64
 	mediaIdSupplied := mediaIdStr != ""
@@ -1065,7 +1145,7 @@ func (a *Application) Clip(ctx context.Context, ratingKeyStr, mediaIdStr, from, 
 	fileURL := fmt.Sprintf("%s%s?X-Plex-Token=%s",
 		a.config.Plex.Host,
 		part.Key,
-		a.config.Plex.Token,
+		a.plexSourceToken(ctx, AuthTokenFromContext(ctx) != nil),
 	)
 
 	// Extract subtitle for burning in if requested. For text subtitles, ExtractSubtitle
@@ -1161,10 +1241,11 @@ func (a *Application) Clip(ctx context.Context, ratingKeyStr, mediaIdStr, from, 
 }
 
 func (a *Application) Thumb(ctx context.Context, thumb string) (io.ReadCloser, string, error) {
+	token := a.plexSourceToken(ctx, AuthTokenFromContext(ctx) != nil)
 	transcodeURL := fmt.Sprintf("%s/photo/:/transcode?width=320&height=320&url=%s&X-Plex-Token=%s",
 		a.config.Plex.Host,
 		url.QueryEscape(thumb),
-		a.config.Plex.Token,
+		token,
 	)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, transcodeURL, nil)

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -38,7 +38,7 @@ function libraryResultToSession(result) {
     // Library items have no live view offset — clips start at the beginning.
     viewOffset: 0,
     thumb: result.artwork || '',
-    Media: [{Part: [{id: String(result.mediaId)}], videoResolution: result.videoResolution || '', audioChannels: result.audioChannels || 0}],
+    Media: [{Part: [{id: String(result.mediaId)}], videoResolution: result.videoResolution || '', videoCodec: result.videoCodec || '', videoProfile: result.videoProfile || '', audioChannels: result.audioChannels || 0, audioCodec: result.audioCodec || ''}],
     _sourceType: 'library',
     _partId: result.partId,
   }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -3,17 +3,79 @@ import {useCallback, useEffect, useMemo, useRef, useState} from "react";
 import {
   Box, Button, Container, Stack, Toolbar, Typography,
 } from "@mui/material";
-import SessionPicker from "./components/SessionPicker";
+import LibrarySearchPanel from "./components/LibrarySearchPanel";
 import ClipWorkspace from "./components/ClipWorkspace";
 import ClipLibrary from "./components/ClipLibrary";
 import ClipDetail from "./components/ClipDetail";
 import {stripSubtitleMarkup} from "./components/subtitle-markup";
 import {
   buildRenderJobRequest, buildRenderJobRequestFromSpec, isTerminal, isActive, JOB_STATES, snapshotJobSpec, AUDIO_MODES,
+  getSourcePartId, validateLibraryResult,
 } from "./components/render-jobs";
 import {
   isAbortError, isPgsSubtitleStream, millisToDuration, MIN_GAP_MS,
 } from "./utils";
+
+// Normalize a backend LibrarySearchResult into the session-shaped object the
+// workspace expects. The shape mirrors an active Plex session (ratingKey,
+// Media[].Part[].id, duration, title/hierarchy) so the existing preview /
+// subtitle / trim flows work unchanged. Two underscore-prefixed fields tag the
+// source kind so request builders can append `partId` only for library sources:
+//   _sourceType: 'library'
+//   _partId:    numeric part id from the search result
+// Active sessions carry neither field, so they resolve through the legacy path.
+function libraryResultToSession(result) {
+  return {
+    ratingKey: result.ratingKey,
+    type: result.type,
+    title: result.title,
+    grandparentTitle: result.grandparentTitle || '',
+    parentTitle: result.parentTitle || '',
+    parentIndex: result.seasonNumber ?? null,
+    index: result.episodeNumber ?? null,
+    year: result.year ?? null,
+    duration: result.duration,
+    // Library items have no live view offset — clips start at the beginning.
+    viewOffset: 0,
+    thumb: result.artwork || '',
+    Media: [{Part: [{id: String(result.mediaId)}], videoResolution: result.videoResolution || '', audioChannels: result.audioChannels || 0}],
+    _sourceType: 'library',
+    _partId: result.partId,
+  }
+}
+
+// Build the optional `&partId=` query segment for explicit library sources.
+// Active sessions return null here so the legacy request shape is preserved.
+function partIdParam(session) {
+  const partId = getSourcePartId(session)
+  return partId != null ? `&partId=${partId}` : ''
+}
+
+// Safely parse a fetch response expected to be a JSON array. The backend's
+// error envelopes ({error: {code, message}}) and non-2xx responses are turned
+// into typed errors instead of being stored where an array is expected —
+// downstream .filter/.map calls would otherwise crash on a non-array shape.
+// Returns [] for a 2xx response whose body isn't an array, so the UI degrades
+// to an empty state rather than a render crash.
+async function safeJsonArray(response) {
+  if (!response.ok) {
+    let body = null
+    try { body = await response.json() } catch { /* non-JSON or empty */ }
+    const message = body?.error?.message || `Request failed (${response.status}).`
+    const err = new Error(message)
+    err.status = response.status
+    err.code = body?.error?.code || 'request_error'
+    throw err
+  }
+  let data
+  try { data = await response.json() }
+  catch (e) {
+    const err = new Error('Received a malformed response from the server.')
+    err.code = 'malformed_response'
+    throw err
+  }
+  return Array.isArray(data) ? data : []
+}
 
 const POLL_INTERVAL_MS = 2000
 const SESSION_REFRESH_INTERVAL_MS = 10000
@@ -254,7 +316,7 @@ function App() {
     setPlayerError(false)
     setPlayerUrl(
       `/preview/${selectedSession.ratingKey}/${millisToDuration(start)}/${millisToDuration(end)}` +
-      `?mediaId=${selectedSession.Media[0].Part[0].id}${subtitleParam}${audioModeParam}${offsetParam}`
+      `?mediaId=${selectedSession.Media[0].Part[0].id}${partIdParam(selectedSession)}${subtitleParam}${audioModeParam}${offsetParam}`
     )
   }, [selectedSession, selectedSubtitle, audioMode, subtitleOffsetMs])
 
@@ -286,11 +348,11 @@ function App() {
 
       resetRenderState()
 
-      fetch(`/streams/${selectedSession.ratingKey}?mediaId=${encodeURIComponent(mediaId)}`, {signal: controller.signal})
-        .then(r => r.json())
+      fetch(`/streams/${selectedSession.ratingKey}?mediaId=${encodeURIComponent(mediaId)}${partIdParam(selectedSession)}`, {signal: controller.signal})
+        .then(safeJsonArray)
         .then(streams => {
           if (controller.signal.aborted || sessionGenerationRef.current !== generation) return
-          const availableStreams = Array.isArray(streams) ? streams : []
+          const availableStreams = streams
           const selectedStreamIndex = availableStreams.length > 0 ? availableStreams[0].index : -1
           setSubtitleStreams(availableStreams)
           setStreamsLoading(false)
@@ -304,10 +366,10 @@ function App() {
             stream.index !== selectedStreamIndex
           )
           unselectedTextStreams.forEach(stream => {
-            fetch(`/subtitles/${selectedSession.ratingKey}?subtitle=${stream.index}&mediaId=${mediaId}`, {
+            fetch(`/subtitles/${selectedSession.ratingKey}?subtitle=${stream.index}&mediaId=${mediaId}${partIdParam(selectedSession)}`, {
               signal: controller.signal,
             })
-              .then(r => r.json())
+              .then(safeJsonArray)
               .catch(() => {})
           })
         })
@@ -347,13 +409,13 @@ function App() {
     const generation = sessionGenerationRef.current
     const controller = new AbortController()
     const mediaId = selectedSession.Media[0].Part[0].id
-    fetch(`/subtitles/${selectedSession.ratingKey}?subtitle=${selectedSubtitle}&mediaId=${mediaId}`, {
+    fetch(`/subtitles/${selectedSession.ratingKey}?subtitle=${selectedSubtitle}&mediaId=${mediaId}${partIdParam(selectedSession)}`, {
       signal: controller.signal,
     })
-      .then(r => r.json())
+      .then(safeJsonArray)
       .then(entries => {
         if (controller.signal.aborted || sessionGenerationRef.current !== generation) return
-        setSubtitleEntries(entries || [])
+        setSubtitleEntries(entries)
       })
       .catch(err => {
         if (!controller.signal.aborted && !isAbortError(err) && sessionGenerationRef.current === generation) {
@@ -838,6 +900,29 @@ function App() {
     setSelectedSession(session)
   }, [stopSessionRefresh])
 
+// Library result selection — normalize the backend LibrarySearchResult into
+// the session-shaped object the workspace expects, then route through the
+// same selection path. The `_sourceType: 'library'` tag makes partId flow
+// through streams/subtitles/preview/render only for library sources; active
+// sessions are unchanged. Malformed results (missing/invalid ratingKey,
+// mediaId, or partId) are rejected before workspace entry so the user never
+// lands in a broken workspace that can't fetch streams or render.
+const handleSelectLibraryResult = useCallback((result) => {
+  const validationError = validateLibraryResult(result)
+  if (validationError) {
+    console.warn('Rejected malformed library result:', validationError, result)
+    return
+  }
+  stopSessionRefresh()
+  setSelectedSession(libraryResultToSession(result))
+}, [stopSessionRefresh])
+
+// Stable auth-required handler for the library search panel. setNeedsAuth is
+// stable (useState setter), so this callback keeps a stable identity across
+// session-poll re-renders — paired with the panel's ref capture it guarantees
+// polling never re-fires a library search.
+const handleLibraryAuthRequired = useCallback(() => setNeedsAuth(true), [])
+
   // ---------------------------------------------------------------- clip library navigation
   const openLibrary = useCallback(() => setView({name: 'library'}), [])
   const openClip = useCallback((clipId) => setView({name: 'clip', clipId}), [])
@@ -930,23 +1015,25 @@ function App() {
               onDeleted={handleClipDeleted}
             />
           ) : !selectedSession ? (
-            <Stack spacing={2.5} className="cs-rise">
+            <Stack spacing={4} className="cs-rise">
               <Box>
                 <Typography variant="overline" className="cs-section-label" sx={{color: '#ff7300'}}>
-                  Active sessions
+                  Pick a source
                 </Typography>
                 <Typography variant="h4" sx={{mt: 0.5}}>Pick something to clip</Typography>
                 <Typography variant="body2" sx={{color: 'text.secondary', mt: 0.5, maxWidth: 520}}>
-                  Choose an active Plex session to open the clip workspace — preview, trim, and grab a clip with subtitles.
+                  Choose an active Plex session, or search your Plex library to pick a clip source.
                 </Typography>
               </Box>
-              <SessionPicker
-                sessions={sessions}
-                loading={sessionsLoading}
-                error={sessionsError}
+              <LibrarySearchPanel
+                onSelect={handleSelectLibraryResult}
                 selectedKey={selectedSession?.ratingKey}
-                onSelect={handleSelectSession}
-                onRetry={retrySessions}
+                onAuthRequired={handleLibraryAuthRequired}
+                sessions={sessions}
+                sessionsLoading={sessionsLoading}
+                sessionsError={sessionsError}
+                onSelectSession={handleSelectSession}
+                onRetrySessions={retrySessions}
               />
             </Stack>
           ) : (

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -808,8 +808,9 @@ test('session cards surface existing metadata: progress, player state, resolutio
   expect(alphaCard).toHaveTextContent('00:50:00');
   // Player state dot label.
   expect(alphaCard).toHaveTextContent('Playing');
-  // Quality accent pill — resolution + audio combined.
-  expect(alphaCard).toHaveTextContent('1080 · 5.1');
+  // Resolution and audio are independently scannable chips.
+  expect(alphaCard).toHaveTextContent('1080');
+  expect(alphaCard).toHaveTextContent('5.1');
   // Footer — device + location. The user ('viewer') is omitted on owned cards
   // because the "Your session" badge already conveys ownership.
   expect(alphaCard).toHaveTextContent('Plex Web (Chrome)');
@@ -819,7 +820,8 @@ test('session cards surface existing metadata: progress, player state, resolutio
   // Beta — paused, 4k/7.1, remote, not owned.
   const betaCard = screen.getByRole('button', {name: /Beta/});
   expect(betaCard).toHaveTextContent('Paused');
-  expect(betaCard).toHaveTextContent('4K · 7.1');
+  expect(betaCard).toHaveTextContent('4K');
+  expect(betaCard).toHaveTextContent('7.1');
   // Footer includes the user (not owned), device, and location.
   expect(betaCard).toHaveTextContent('someone else');
   expect(betaCard).toHaveTextContent('Apple TV');
@@ -1814,7 +1816,8 @@ test('library search shows loading, then results with title, context, year, dura
   const movieCard = screen.getByRole('button', {name: /Library result.*Library Movie/});
   expect(movieCard).toHaveTextContent('Library Movie');
   expect(movieCard).toHaveTextContent('(2023)');
-  expect(movieCard).toHaveTextContent('1080 · 5.1');
+  expect(movieCard).toHaveTextContent('1080');
+  expect(movieCard).toHaveTextContent('5.1');
   expect(movieCard).toHaveTextContent('Movie');
   expect(movieCard).toHaveTextContent('01:30:00');
 
@@ -1822,7 +1825,8 @@ test('library search shows loading, then results with title, context, year, dura
   const episodeCard = screen.getByRole('button', {name: /Library result.*Library Show/});
   expect(episodeCard).toHaveTextContent('Library Show');
   expect(episodeCard).toHaveTextContent('S01E01 Pilot');
-  expect(episodeCard).toHaveTextContent('720 · 2.0');
+  expect(episodeCard).toHaveTextContent('720');
+  expect(episodeCard).toHaveTextContent('2.0');
   expect(episodeCard).toHaveTextContent('Episode');
   expect(episodeCard).toHaveTextContent('00:45:00');
 

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -140,7 +140,7 @@ async function selectSession(title) {
 }
 
 async function changeSession() {
-  const buttons = screen.getAllByRole('button', {name: 'Change session'});
+  const buttons = screen.getAllByRole('button', {name: 'Change source'});
   fireEvent.click(buttons[0]);
   await flush();
 }
@@ -1413,7 +1413,7 @@ test('active render jobs constrain session changes and keep polling alive', asyn
   const poll = requestFor(pending, url => url === '/render-jobs/job-session');
   await resolveRequest(poll, {id: 'job-session', status: 'running'});
 
-  const changeButtons = screen.getAllByRole('button', {name: 'Change session'});
+  const changeButtons = screen.getAllByRole('button', {name: 'Change source'});
   expect(changeButtons).toHaveLength(1);
   changeButtons.forEach(button => {
     expect(button).toBeDisabled();
@@ -1716,4 +1716,569 @@ test('a successful render surfaces the saved clip via Open in library without lo
   expect(screen.getByText('Alpha scene')).toBeInTheDocument();
   // Browser playback uses the inline public download URL (shareUrl === publicDownloadUrl).
   expect(document.querySelector('video').getAttribute('src')).toBe('https://clips.example.test/shared/clips/tok/download');
+});
+
+// ---------------------------------------------------------------------------
+// Phase 2 — Plex library search source selection
+// ---------------------------------------------------------------------------
+//
+// The library search panel is presented as a peer source choice to active
+// sessions. Selecting a library result normalizes it into a session-shaped
+// object and routes partId through streams/subtitles/preview/render, while
+// active-session sources remain unchanged (no partId).
+
+const libraryResults = [
+  {
+    ratingKey: 'L1', mediaId: 5001, partId: 6001, type: 'movie',
+    title: 'Library Movie', year: 2023, duration: 5400000,
+    artwork: '/thumb/L1', videoResolution: '1080', audioChannels: 6,
+  },
+  {
+    ratingKey: 'L2', mediaId: 5002, partId: 6002, type: 'episode',
+    title: 'Pilot', grandparentTitle: 'Library Show', seasonNumber: 1, episodeNumber: 1,
+    duration: 2700000, artwork: '/thumb/L2', videoResolution: '720', audioChannels: 2,
+  },
+];
+
+function librarySearchRequest(pending, occurrence = 0) {
+  return requestFor(pending, url => url.startsWith('/library/search?query='), occurrence);
+}
+
+async function searchLibrary(query) {
+  const input = screen.getByRole('textbox', {name: 'Search Plex library'});
+  fireEvent.change(input, {target: {value: query}});
+  // Debounce is 300ms with real timers; advance microtasks only.
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+async function searchLibraryWithFakeTimers(query) {
+  const input = screen.getByRole('textbox', {name: 'Search Plex library'});
+  fireEvent.change(input, {target: {value: query}});
+  // Only flush microtasks — the test advances the debounce timer explicitly.
+  await act(async () => { await Promise.resolve(); });
+}
+
+test('library search panel is presented as a peer source choice on the home view', async () => {
+  installFetch(response(sessions));
+  render(<App/>);
+  await flush();
+
+  // The unified picker has one shared result region: active sessions are the
+  // default contents, with library search taking over after a valid query.
+  expect(screen.getByRole('textbox', {name: 'Search Plex library'})).toBeInTheDocument();
+  expect(screen.getByText('Alpha')).toBeInTheDocument();
+  expect(screen.queryByText('Active sessions')).not.toBeInTheDocument();
+});
+
+test('library search debounces the query and does not fire below the 2-character minimum', async () => {
+  jest.useFakeTimers();
+  const pending = installFetch();
+  render(<App/>);
+  await flush();
+
+  // A single character is below the minimum — no search request fires.
+  await searchLibraryWithFakeTimers('A');
+  expect(pending.some(r => r.url.startsWith('/library/search'))).toBe(false);
+
+  // A second character crosses the minimum, but the debounce hasn't elapsed.
+  await searchLibraryWithFakeTimers('Al');
+  expect(pending.some(r => r.url.startsWith('/library/search'))).toBe(false);
+
+  // After the 300ms debounce, the search request fires.
+  await act(async () => { jest.advanceTimersByTime(300); });
+  const searchReq = librarySearchRequest(pending);
+  expect(searchReq).toBeDefined();
+  expect(decodeURIComponent(searchReq.url)).toBe('/library/search?query=Al');
+});
+
+test('library search shows loading, then results with title, context, year, duration, and quality', async () => {
+  const pending = installFetch();
+  render(<App/>);
+  await flush();
+
+  jest.useFakeTimers();
+  await searchLibraryWithFakeTimers('show');
+  await act(async () => { jest.advanceTimersByTime(300); });
+  jest.useRealTimers();
+
+  // Loading state is announced before results resolve.
+  expect(screen.getByText('Searching…')).toBeInTheDocument();
+
+  await resolveRequest(librarySearchRequest(pending), libraryResults);
+
+  // Movie result — title, year, duration, quality pill.
+  const movieCard = screen.getByRole('button', {name: /Library result.*Library Movie/});
+  expect(movieCard).toHaveTextContent('Library Movie');
+  expect(movieCard).toHaveTextContent('(2023)');
+  expect(movieCard).toHaveTextContent('1080 · 5.1');
+  expect(movieCard).toHaveTextContent('Movie');
+  expect(movieCard).toHaveTextContent('01:30:00');
+
+  // Episode result — show title, S01E01 + episode title, quality, duration.
+  const episodeCard = screen.getByRole('button', {name: /Library result.*Library Show/});
+  expect(episodeCard).toHaveTextContent('Library Show');
+  expect(episodeCard).toHaveTextContent('S01E01 Pilot');
+  expect(episodeCard).toHaveTextContent('720 · 2.0');
+  expect(episodeCard).toHaveTextContent('Episode');
+  expect(episodeCard).toHaveTextContent('00:45:00');
+
+  // Both cards carry the distinguishing "Library" badge.
+  expect(screen.getAllByText('Library')).toHaveLength(2);
+});
+
+test('library search empty state is presented clearly', async () => {
+  jest.useFakeTimers();
+  const pending = installFetch();
+  render(<App/>);
+  await flush();
+
+  await searchLibraryWithFakeTimers('zzz');
+  await act(async () => { jest.advanceTimersByTime(300); });
+  await resolveRequest(librarySearchRequest(pending), []);
+  jest.useRealTimers();
+
+  expect(screen.getByText('No matching titles in your Plex library.')).toBeInTheDocument();
+  expect(screen.getByText('Try a different search term.')).toBeInTheDocument();
+});
+
+test('library search error state offers a retry that re-runs the search', async () => {
+  jest.useFakeTimers();
+  const pending = installFetch();
+  render(<App/>);
+  await flush();
+
+  await searchLibraryWithFakeTimers('fail');
+  await act(async () => { jest.advanceTimersByTime(300); });
+  const firstSearch = librarySearchRequest(pending);
+  await resolveRequestWith(firstSearch, {}, {ok: false, status: 503});
+  jest.useRealTimers();
+
+  expect(screen.getByText(/Couldn’t search the Plex library/)).toBeInTheDocument();
+  expect(screen.getByRole('button', {name: 'Try again'})).toBeInTheDocument();
+
+  fireEvent.click(screen.getByRole('button', {name: 'Try again'}));
+  const secondSearch = librarySearchRequest(pending, 1);
+  expect(secondSearch).toBeDefined();
+  await resolveRequest(secondSearch, libraryResults);
+  expect(screen.getByText('Library Movie')).toBeInTheDocument();
+});
+
+test('selecting a library result opens the workspace and passes partId through streams, preview, and render', async () => {
+  jest.useFakeTimers();
+  const pending = installFetch();
+  render(<App/>);
+  await flush();
+
+  await searchLibraryWithFakeTimers('movie');
+  await act(async () => { jest.advanceTimersByTime(300); });
+  await resolveRequest(librarySearchRequest(pending), [libraryResults[0]]);
+  jest.useRealTimers();
+
+  fireEvent.click(screen.getByRole('button', {name: /Library result.*Library Movie/}));
+  await flush();
+
+  // The workspace opens with the library source context.
+  expect(screen.getByText('Now clipping')).toBeInTheDocument();
+  expect(screen.getByText('From your Plex library')).toBeInTheDocument();
+  expect(screen.getByText('Library Movie')).toBeInTheDocument();
+
+  // Streams request carries partId for the library source.
+  const streamsReq = requestFor(pending, url => url.startsWith('/streams/L1?mediaId=5001'));
+  expect(streamsReq.url).toBe('/streams/L1?mediaId=5001&partId=6001');
+
+  await resolveRequest(streamsReq, textStreams());
+
+  // Preview URL carries partId, and the clip starts at 00:00:00 (no viewOffset).
+  expect(mockPlayerUrls).toEqual([
+    '/preview/L1/00:00:00/00:01:00?mediaId=5001&partId=6001&subtitle=0',
+  ]);
+
+  // Render-job POST body carries partId for the library source.
+  fireEvent.click(screen.getByRole('button', {name: 'Render clip'}));
+  const createRequest = requestFor(pending, url => url === '/render-jobs');
+  expect(JSON.parse(createRequest.options.body)).toMatchObject({
+    ratingKey: 'L1', mediaId: 5001, partId: 6001,
+    fromMs: 0, toMs: 60000, subtitleIndex: 0, audioMode: 'standard', subtitleOffsetMs: 0,
+  });
+});
+
+test('library result subtitle prewarm requests carry partId', async () => {
+  jest.useFakeTimers();
+  const pending = installFetch();
+  render(<App/>);
+  await flush();
+
+  await searchLibraryWithFakeTimers('movie');
+  await act(async () => { jest.advanceTimersByTime(300); });
+  await resolveRequest(librarySearchRequest(pending), [libraryResults[0]]);
+  jest.useRealTimers();
+
+  fireEvent.click(screen.getByRole('button', {name: /Library result.*Library Movie/}));
+  const streamsReq = requestFor(pending, url => url.startsWith('/streams/L1?mediaId=5001'));
+  await resolveRequest(streamsReq, [
+    {index: 0, type: 'text', codec: 'srt', displayTitle: 'Selected'},
+    {index: 1, type: 'text', codec: 'webvtt', displayTitle: 'Prewarm'},
+  ]);
+
+  // The unselected text track is prewarmed with partId.
+  const prewarm = pending.find(r => r.url.includes('/subtitles/L1?subtitle=1'));
+  expect(prewarm).toBeDefined();
+  expect(prewarm.url).toBe('/subtitles/L1?subtitle=1&mediaId=5001&partId=6001');
+});
+
+test('library result subtitle entry fetch carries partId', async () => {
+  jest.useFakeTimers();
+  const pending = installFetch();
+  render(<App/>);
+  await flush();
+
+  await searchLibraryWithFakeTimers('movie');
+  await act(async () => { jest.advanceTimersByTime(300); });
+  await resolveRequest(librarySearchRequest(pending), [libraryResults[0]]);
+  jest.useRealTimers();
+
+  fireEvent.click(screen.getByRole('button', {name: /Library result.*Library Movie/}));
+  await resolveRequest(requestFor(pending, url => url.startsWith('/streams/L1?mediaId=5001')), textStreams());
+
+  // Switching subtitle track fires a subtitle-entry fetch with partId.
+  await selectSubtitle('Y track');
+  const yRequest = pending.filter(r => r.url.includes('/subtitles/L1?subtitle=1')).slice(-1)[0];
+  expect(yRequest.url).toBe('/subtitles/L1?subtitle=1&mediaId=5001&partId=6001');
+  await resolveRequest(yRequest, [{start: 1000, end: 2000, text: 'Y one'}]);
+  expect(screen.getByText('Y one')).toBeInTheDocument();
+});
+
+test('retry render from a library source resubmits the immutable spec with partId', async () => {
+  jest.useFakeTimers();
+  const pending = installFetch();
+  render(<App/>);
+  await flush();
+
+  await searchLibraryWithFakeTimers('movie');
+  await act(async () => { jest.advanceTimersByTime(300); });
+  await resolveRequest(librarySearchRequest(pending), [libraryResults[0]]);
+  jest.useRealTimers();
+
+  fireEvent.click(screen.getByRole('button', {name: /Library result.*Library Movie/}));
+  await resolveRequest(requestFor(pending, url => url.startsWith('/streams/L1?mediaId=5001')), textStreams());
+
+  fireEvent.click(screen.getByRole('button', {name: 'Render clip'}));
+  const firstCreate = requestFor(pending, url => url === '/render-jobs');
+  const submittedBody = JSON.parse(firstCreate.options.body);
+  expect(submittedBody).toEqual({
+    ratingKey: 'L1', mediaId: 5001, partId: 6001,
+    fromMs: 0, toMs: 60000, subtitleIndex: 0, audioMode: 'standard', subtitleOffsetMs: 0,
+  });
+
+  await resolveRequestWith(firstCreate, {id: 'job-lib-retry', status: 'queued'}, {status: 202});
+  const poll = requestFor(pending, url => url === '/render-jobs/job-lib-retry');
+  await resolveRequest(poll, {
+    id: 'job-lib-retry', status: 'failed',
+    error: {code: 'source_unavailable', message: 'Source unavailable.', retryable: true},
+  });
+
+  fireEvent.click(screen.getByRole('button', {name: 'Try again'}));
+  const secondCreate = requestFor(pending, url => url === '/render-jobs', 1);
+  expect(JSON.parse(secondCreate.options.body)).toEqual(submittedBody);
+  expect(JSON.parse(secondCreate.options.body)).toMatchObject({partId: 6001});
+});
+
+test('changing from a library source back to an active session omits partId (active-session regression)', async () => {
+  jest.useFakeTimers();
+  const pending = installFetch();
+  render(<App/>);
+  await flush();
+
+  // Select a library source first.
+  await searchLibraryWithFakeTimers('movie');
+  await act(async () => { jest.advanceTimersByTime(300); });
+  await resolveRequest(librarySearchRequest(pending), [libraryResults[0]]);
+  jest.useRealTimers();
+  fireEvent.click(screen.getByRole('button', {name: /Library result.*Library Movie/}));
+  await resolveRequest(requestFor(pending, url => url.startsWith('/streams/L1?mediaId=5001')), textStreams());
+
+  // Change source back to the picker, then select an active session.
+  await changeSession();
+  await selectSession('Alpha');
+
+  // Streams + preview for the active session omit partId entirely.
+  const streamsReq = requestFor(pending, url => url === '/streams/A?mediaId=101');
+  expect(streamsReq.url).toBe('/streams/A?mediaId=101');
+  await resolveRequest(streamsReq, textStreams());
+  expect(mockPlayerUrls.slice(-1)[0]).toBe('/preview/A/00:00:00/00:01:00?mediaId=101&subtitle=0');
+
+  // The render payload for an active session omits partId.
+  fireEvent.click(screen.getByRole('button', {name: 'Render clip'}));
+  const createRequest = requestFor(pending, url => url === '/render-jobs');
+  expect(JSON.parse(createRequest.options.body)).toEqual({
+    ratingKey: 'A', mediaId: 101, fromMs: 0, toMs: 60000,
+    subtitleIndex: 0, audioMode: 'standard', subtitleOffsetMs: 0,
+  });
+  expect(JSON.parse(createRequest.options.body)).not.toHaveProperty('partId');
+});
+
+test('session context shows the source kind for an active session (regression)', async () => {
+  const pending = installFetch();
+  render(<App/>);
+  await flush();
+  await selectSession('Alpha');
+
+  expect(screen.getByText('Now clipping')).toBeInTheDocument();
+  expect(screen.getByText('Active Plex session')).toBeInTheDocument();
+  expect(screen.getByRole('button', {name: 'Change source'})).toBeInTheDocument();
+});
+
+// ---------------------------------------------------------------------------
+// Gate 2 regressions — malformed library-source responses and search races.
+// ---------------------------------------------------------------------------
+
+async function selectLibraryResultForRegression(pending, result = libraryResults[0]) {
+  await searchLibraryWithFakeTimers('movie');
+  await act(async () => { jest.advanceTimersByTime(300); });
+  await resolveRequest(librarySearchRequest(pending), [result]);
+  jest.useRealTimers();
+  fireEvent.click(screen.getByRole('button', {name: /Library result/}));
+  await flush();
+}
+
+test.each([422, 503])(
+  'library-source streams %s responses keep the workspace alive and surface an error',
+  async status => {
+    jest.useFakeTimers();
+    const pending = installFetch();
+    render(<App/>);
+    await flush();
+    await selectLibraryResultForRegression(pending);
+
+    const streamsRequest = requestFor(pending, url => url.startsWith('/streams/L1?mediaId=5001'));
+    expect(streamsRequest.url).toBe('/streams/L1?mediaId=5001&partId=6001');
+    await resolveRequestWith(streamsRequest, {error: {message: `streams failed (${status})`}}, {
+      ok: false, status,
+    });
+
+    expect(screen.getByText('From your Plex library')).toBeInTheDocument();
+    expect(screen.getByRole('alert')).toHaveTextContent('Couldn’t load subtitle tracks.');
+    expect(screen.getByText('Subtitles')).toBeInTheDocument();
+  }
+);
+
+test.each([422, 503])(
+  'library-source subtitle %s responses keep the workspace alive and surface an error',
+  async status => {
+    jest.useFakeTimers();
+    const pending = installFetch();
+    render(<App/>);
+    await flush();
+    await selectLibraryResultForRegression(pending);
+
+    const streamsRequest = requestFor(pending, url => url.startsWith('/streams/L1?mediaId=5001'));
+    await resolveRequest(streamsRequest, [{index: 0, type: 'text', codec: 'srt', displayTitle: 'Only track'}]);
+    const subtitleRequest = requestFor(pending, url => url === '/subtitles/L1?subtitle=0&mediaId=5001&partId=6001');
+    await resolveRequestWith(subtitleRequest, {error: {message: `subtitle failed (${status})`}}, {
+      ok: false, status,
+    });
+
+    expect(screen.getByText('From your Plex library')).toBeInTheDocument();
+    expect(screen.getByRole('alert')).toHaveTextContent('Couldn’t load subtitles for this track.');
+    expect(screen.getByText('Only track')).toBeInTheDocument();
+  }
+);
+
+test('non-array library stream bodies degrade to an empty state without crashing', async () => {
+  jest.useFakeTimers();
+  const pending = installFetch();
+  render(<App/>);
+  await flush();
+  await selectLibraryResultForRegression(pending);
+
+  const streamsRequest = requestFor(pending, url => url.startsWith('/streams/L1?mediaId=5001'));
+  await resolveRequest(streamsRequest, {streams: 'not an array'});
+  expect(screen.getByText('From your Plex library')).toBeInTheDocument();
+  expect(screen.getByText('No subtitle tracks available for this session.')).toBeInTheDocument();
+});
+
+test('non-array library subtitle bodies degrade to an empty state without crashing', async () => {
+  jest.useFakeTimers();
+  const pending = installFetch();
+  render(<App/>);
+  await flush();
+  await selectLibraryResultForRegression(pending);
+
+  const streamsRequest = requestFor(pending, url => url.startsWith('/streams/L1?mediaId=5001'));
+  await resolveRequest(streamsRequest, [{index: 0, type: 'text', codec: 'srt', displayTitle: 'Only track'}]);
+  const subtitleRequest = requestFor(pending, url => url === '/subtitles/L1?subtitle=0&mediaId=5001&partId=6001');
+  await resolveRequest(subtitleRequest, {entries: 'not an array'});
+
+  expect(screen.getByText('From your Plex library')).toBeInTheDocument();
+  expect(screen.getByText('No subtitle entries.')).toBeInTheDocument();
+});
+
+test('raw library query edits immediately invalidate late results from the old query', async () => {
+  jest.useFakeTimers();
+  const pending = installFetch();
+  render(<App/>);
+  await flush();
+
+  await searchLibraryWithFakeTimers('old');
+  await act(async () => { jest.advanceTimersByTime(300); });
+  const oldRequest = librarySearchRequest(pending);
+
+  await searchLibraryWithFakeTimers('new');
+  expect(oldRequest.options.signal.aborted).toBe(true);
+
+  // Resolve while the replacement query is still inside its debounce window.
+  await resolveRequest(oldRequest, [libraryResults[0]]);
+  expect(screen.queryByText('Library Movie')).not.toBeInTheDocument();
+
+  await act(async () => { jest.advanceTimersByTime(300); });
+  const newResult = {...libraryResults[0], ratingKey: 'L-new', title: 'New query result'};
+  const newRequest = librarySearchRequest(pending, 1);
+  await resolveRequest(newRequest, [newResult]);
+  jest.useRealTimers();
+  expect(screen.getByText('New query result')).toBeInTheDocument();
+  expect(screen.queryByText('Library Movie')).not.toBeInTheDocument();
+});
+
+test('malformed library result IDs are rejected before workspace entry or stream requests', async () => {
+  const malformedResults = [
+    {...libraryResults[0], ratingKey: 'bad-media', title: 'Bad media ID', mediaId: '5001.5'},
+    {...libraryResults[0], ratingKey: 'bad-part', title: 'Bad part ID', partId: 'not-an-id'},
+  ];
+  const pending = installFetch();
+  const warning = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  render(<App/>);
+  await flush();
+
+  jest.useFakeTimers();
+  await searchLibraryWithFakeTimers('bad');
+  await act(async () => { jest.advanceTimersByTime(300); });
+  await resolveRequest(librarySearchRequest(pending), malformedResults);
+  jest.useRealTimers();
+
+  fireEvent.click(screen.getByRole('button', {name: /Bad media ID/}));
+  await flush();
+  expect(screen.queryByText('Now clipping')).not.toBeInTheDocument();
+  expect(pending.some(request => request.url.startsWith('/streams/'))).toBe(false);
+
+  fireEvent.click(screen.getByRole('button', {name: /Bad part ID/}));
+  await flush();
+  expect(screen.queryByText('Now clipping')).not.toBeInTheDocument();
+  expect(pending.some(request => request.url.startsWith('/streams/'))).toBe(false);
+  expect(warning).toHaveBeenCalledTimes(2);
+});
+
+test('library artwork is encoded and partial episode hierarchy omits SnullEnull', async () => {
+  const result = {
+    ratingKey: 'L-art', mediaId: 7001, partId: 8001, type: 'episode',
+    title: 'Pilot', parentTitle: 'The Show', duration: 1200000,
+    artwork: '/library/poster?token=a&path=/show poster',
+  };
+  const pending = installFetch();
+  render(<App/>);
+  await flush();
+
+  jest.useFakeTimers();
+  await searchLibraryWithFakeTimers('art');
+  await act(async () => { jest.advanceTimersByTime(300); });
+  await resolveRequest(librarySearchRequest(pending), [result]);
+  jest.useRealTimers();
+
+  const card = screen.getByRole('button', {name: /Library result.*The Show.*Pilot/});
+  expect(card.querySelector('img')).toHaveAttribute(
+    'src', `/thumb?path=${encodeURIComponent(result.artwork)}`
+  );
+  expect(card).toHaveTextContent('The Show');
+  expect(card).toHaveTextContent('Pilot');
+  expect(card).not.toHaveTextContent('SnullEnull');
+});
+
+test('library search exposes one accessible live status region while loading and after empty results', async () => {
+  jest.useFakeTimers();
+  const pending = installFetch();
+  render(<App/>);
+  await flush();
+  await searchLibraryWithFakeTimers('status');
+  await act(async () => { jest.advanceTimersByTime(300); });
+
+  const status = screen.getByLabelText('Plex library search status');
+  expect(status).toHaveAttribute('aria-live', 'polite');
+  expect(status).toHaveAttribute('aria-busy', 'true');
+  expect(screen.getByText('Searching…')).toBeInTheDocument();
+
+  await resolveRequest(librarySearchRequest(pending), []);
+  expect(status).toHaveAttribute('aria-live', 'polite');
+  expect(status).not.toHaveAttribute('aria-busy', 'true');
+  expect(status).toHaveTextContent('No matching titles in your Plex library.');
+});
+
+test('a session-poll re-render does not refire a settled library search', async () => {
+  // Regression: App passed an inline onAuthRequired to LibrarySearchPanel, and
+  // the panel's search effect once listed it in its dependency array. Session
+  // polling on the home view calls setSessions ~every 10s, re-rendering App
+  // with a fresh callback identity and retriggering the search effect — a
+  // visible periodic refetch for a query that hadn't changed. The effect now
+  // reads onAuthRequired through a ref, so only committed query / explicit
+  // retry refire.
+  jest.useFakeTimers();
+  const {sessionRequests, pending} = installTrackedSessionsFetch();
+  render(<App/>);
+  await resolveRequest(sessionRequests[0], sessions);
+
+  await searchLibraryWithFakeTimers('movie');
+  await act(async () => { jest.advanceTimersByTime(300); });
+  await resolveRequest(librarySearchRequest(pending), [libraryResults[0]]);
+
+  expect(screen.getByText('Library Movie')).toBeInTheDocument();
+  const searchesBefore = pending.filter(r => r.url.startsWith('/library/search')).length;
+  expect(searchesBefore).toBe(1);
+
+  // Let the picker cadence run. A refresh request may or may not be created
+  // before the test's microtask turn; either way, a session update must not
+  // refire the settled library search.
+  await advancePolling(10000);
+  const refreshRequests = sessionRequests.slice(1);
+  for (const request of refreshRequests) await resolveRequest(request, sessions);
+  await advancePolling(10000);
+  const laterRefreshRequests = sessionRequests.slice(1 + refreshRequests.length);
+  for (const request of laterRefreshRequests) await resolveRequest(request, sessions);
+
+  const searchesAfter = pending.filter(r => r.url.startsWith('/library/search')).length;
+  expect(searchesAfter).toBe(searchesBefore);
+  expect(screen.getByText('Library Movie')).toBeInTheDocument();
+});
+
+test('library search classifies authentication, validation, and retryable failures', async () => {
+  const cases = [
+    {query: 'auth', status: 401, expected: 'auth'},
+    {query: 'valid', status: 422, expected: 'validation'},
+    {query: 'busy', status: 503, expected: 'retryable'},
+  ];
+
+  for (const testCase of cases) {
+    jest.useFakeTimers();
+    const pending = installFetch();
+    const view = render(<App/>);
+    await flush();
+    await searchLibraryWithFakeTimers(testCase.query);
+    await act(async () => { jest.advanceTimersByTime(300); });
+    const searchRequest = librarySearchRequest(pending);
+    const body = testCase.status === 422 ? {error: {message: 'The search query is invalid.'}} : {};
+    await resolveRequestWith(searchRequest, body, {ok: false, status: testCase.status});
+
+    if (testCase.expected === 'auth') {
+      expect(screen.getByRole('link', {name: 'Log in with Plex'})).toBeInTheDocument();
+    } else if (testCase.expected === 'validation') {
+      expect(screen.getByRole('alert')).toHaveTextContent('The search query is invalid.');
+      expect(screen.queryByRole('button', {name: 'Try again'})).not.toBeInTheDocument();
+    } else {
+      expect(screen.getByRole('alert')).toHaveTextContent('Couldn’t search the Plex library.');
+      expect(screen.getByRole('button', {name: 'Try again'})).toBeInTheDocument();
+    }
+    view.unmount();
+    jest.useRealTimers();
+  }
 });

--- a/frontend/src/components/LibraryResultCard.js
+++ b/frontend/src/components/LibraryResultCard.js
@@ -87,6 +87,8 @@ export default function LibraryResultCard({result, active, onSelect, onNavigate}
   const res = resolutionLabel(result.videoResolution)
   const audio = audioLayoutLabel(result.audioChannels)
   const quality = qualitySummary(res, audio)
+  const codec = result.videoCodec ? String(result.videoCodec).toUpperCase() : null
+  const main10 = String(result.videoProfile || '').toLowerCase() === 'main 10'
   const tLabel = typeLabel(result.type)
   const navigation = result.type === 'show' || result.type === 'season'
   const selectable = result.type === 'movie' || result.type === 'episode'
@@ -186,10 +188,10 @@ export default function LibraryResultCard({result, active, onSelect, onNavigate}
               </Typography>
             )}
 
-            {quality && (
-              <Box sx={{
+            {(quality || codec || main10) && (
+              <Box sx={{display: 'flex', flexWrap: 'wrap', gap: 0.75, mt: 0.5}}>
+              {quality && <Box sx={{
                 alignSelf: 'flex-start',
-                mt: 0.5,
                 px: 1.25, py: 0.35,
                 borderRadius: 999,
                 fontSize: '0.72rem',
@@ -202,6 +204,13 @@ export default function LibraryResultCard({result, active, onSelect, onNavigate}
                 border: '1px solid rgba(255,115,0,0.32)',
               }}>
                 {quality}
+              </Box>}
+              {codec && <Box sx={{px: 1.25, py: 0.35, borderRadius: 999, fontSize: '0.72rem', fontWeight: 700,
+                letterSpacing: '0.03em', fontFamily: 'var(--cs-mono-font)', color: '#cfe3ff',
+                backgroundColor: 'rgba(73,121,193,0.14)', border: '1px solid rgba(143,184,255,0.32)'}}>{codec}</Box>}
+              {main10 && <Box sx={{px: 1.25, py: 0.35, borderRadius: 999, fontSize: '0.72rem', fontWeight: 700,
+                letterSpacing: '0.03em', fontFamily: 'var(--cs-mono-font)', color: '#d9c6ff',
+                backgroundColor: 'rgba(137,98,201,0.15)', border: '1px solid rgba(185,151,246,0.38)'}}>Main 10</Box>}
               </Box>
             )}
 

--- a/frontend/src/components/LibraryResultCard.js
+++ b/frontend/src/components/LibraryResultCard.js
@@ -1,0 +1,223 @@
+import {Box, Card, CardActionArea, CardContent, CardMedia, Grid, Typography} from "@mui/material";
+import {millisToDuration} from "../utils";
+
+// Plex library search result card. Mirrors the SessionPicker card's visual
+// language (16:9 artwork, title + context, quality pill, muted footer) so the
+// two source kinds read as peers. Differences are intentional and signal the
+// source type rather than a live session:
+//   • a "Library" badge instead of "Your session"
+//   • no progress bar (library items have no viewOffset)
+//   • a footer that names the media type and total runtime
+//
+// `result` follows the backend LibrarySearchResult contract: ratingKey,
+// mediaId, partId, title, type, year, grandparentTitle, parentTitle,
+// seasonNumber, episodeNumber, duration, artwork, videoResolution, audioChannels.
+
+function getResultName(result) {
+  if (result.type === 'episode') {
+    // Show title falls back through grandparent → parent → episode title so a
+    // sparse hub result still has a recognizable primary line.
+    const top = result.grandparentTitle || result.parentTitle || result.title || ''
+    // Only compose the S##E## line when at least one number is present —
+    // rendering "SnullEnull" for a result missing both is worse than omitting
+    // the line. When only one number exists, show the available one.
+    const hasSeason = result.seasonNumber != null
+    const hasEpisode = result.episodeNumber != null
+    let bottom = ''
+    if (hasSeason || hasEpisode) {
+      const season = hasSeason ? String(result.seasonNumber).padStart(2, '0') : ''
+      const episode = hasEpisode ? String(result.episodeNumber).padStart(2, '0') : ''
+      const code = `S${season}E${episode}`
+      bottom = result.title ? `${code} ${result.title}` : code
+    } else if (result.title && result.title !== top) {
+      bottom = result.title
+    }
+    return {top, bottom}
+  }
+  return {top: result.title, bottom: result.year ? `(${result.year})` : ''}
+}
+
+function audioLayoutLabel(channels) {
+  if (channels == null) return null
+  const n = Number(channels)
+  if (!Number.isFinite(n) || n <= 0) return null
+  if (n === 1) return '1.0'
+  if (n === 2) return '2.0'
+  if (n === 6) return '5.1'
+  if (n === 8) return '7.1'
+  return `${n}ch`
+}
+
+function resolutionLabel(res) {
+  if (!res) return null
+  const s = String(res).trim()
+  return s ? s.toUpperCase() : null
+}
+
+function qualitySummary(res, audio) {
+  const parts = [res, audio].filter(Boolean)
+  return parts.length ? parts.join(' · ') : null
+}
+
+function typeLabel(type) {
+  if (type === 'movie') return 'Movie'
+  if (type === 'episode') return 'Episode'
+  if (type === 'show') return 'Show'
+  if (type === 'season') return 'Season'
+  return null
+}
+
+function FilmPlaceholder() {
+  return (
+    <Box sx={{
+      position: 'absolute', inset: 0, display: 'grid', placeItems: 'center',
+      background: 'linear-gradient(135deg, #1b1e26, #11141a)',
+    }}>
+      <svg viewBox="0 0 24 24" width="42" height="42" fill="none" stroke="rgba(255,255,255,0.18)"
+        strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+        <rect x="3" y="4" width="18" height="16" rx="2"/>
+        <path d="M3 9h18M3 15h18M8 4v16M16 4v16"/>
+      </svg>
+    </Box>
+  )
+}
+
+export default function LibraryResultCard({result, active, onSelect, onNavigate}) {
+  const name = getResultName(result)
+  const res = resolutionLabel(result.videoResolution)
+  const audio = audioLayoutLabel(result.audioChannels)
+  const quality = qualitySummary(res, audio)
+  const tLabel = typeLabel(result.type)
+  const navigation = result.type === 'show' || result.type === 'season'
+  const selectable = result.type === 'movie' || result.type === 'episode'
+  const duration = result.duration
+  const thumbPath = result.artwork || null
+
+  // Footer — media type, total runtime. Muted like the session card footer.
+  const footerParts = []
+  if (tLabel) footerParts.push(tLabel)
+  if (duration > 0) footerParts.push(millisToDuration(duration))
+  const footer = footerParts.join('  ·  ')
+
+  return (
+    <Grid item xs={12} sm={6} md={4} key={result.ratingKey}>
+      <Card
+        sx={{
+          height: '100%',
+          position: 'relative',
+          display: 'flex',
+          flexDirection: 'column',
+          overflow: 'hidden',
+          transition: 'transform 180ms ease, border-color 180ms ease, box-shadow 180ms ease',
+          // Library cards use a cooler accent than the warm "Your session"
+          // wash — they're a peer source kind, not the same kind. Selected
+          // keeps the dominant orange border + shadow so the active source is
+          // always unmistakable regardless of how it was picked.
+          borderColor: active
+            ? 'rgba(255,115,0,0.6)'
+            : 'rgba(255,255,255,0.08)',
+          background: active
+            ? 'linear-gradient(180deg, rgba(255,115,0,0.10), rgba(255,115,0,0.02) 68%, rgba(255,115,0,0) 100%)'
+            : undefined,
+          boxShadow: active ? '0 14px 40px -22px rgba(255,115,0,0.7)' : undefined,
+          '&:hover': {transform: 'translateY(-2px)', borderColor: 'rgba(255,115,0,0.4)'},
+        }}
+      >
+        <CardActionArea
+          onClick={() => navigation ? onNavigate?.(result) : selectable ? onSelect(result) : undefined}
+          disabled={!navigation && !selectable}
+          aria-label={`${navigation ? `Browse ${result.type === 'show' ? 'seasons' : 'episodes'}` : selectable ? 'Library result' : 'Unavailable library result'}. ${name.top}${name.bottom ? ' ' + name.bottom : ''}`}
+          sx={{
+            display: 'flex', flexDirection: 'column', alignItems: 'stretch', height: '100%',
+            '&.Mui-focusVisible, &:focus-visible': {
+              outline: '2px solid #ff7300',
+              outlineOffset: '2px',
+            },
+          }}
+          focusRipple
+        >
+          <Box sx={{position: 'relative', width: '100%', aspectRatio: '16 / 9', background: '#11141a', flexShrink: 0}}>
+            {thumbPath ? (
+              <CardMedia
+                component="img"
+                sx={{position: 'absolute', inset: 0, width: '100%', height: '100%', objectFit: 'cover'}}
+                image={`/thumb?path=${encodeURIComponent(thumbPath)}`}
+                alt=""
+              />
+            ) : (
+              <FilmPlaceholder/>
+            )}
+            {/* Library badge — top-right over the thumbnail. A cooler outline
+                pill distinguishes library sources from the warm filled "Your
+                session" badge on active-session cards. */}
+            <Box
+              sx={{
+                position: 'absolute',
+                top: 10,
+                right: 10,
+                zIndex: 1,
+                pointerEvents: 'none',
+                px: 1.25,
+                py: 0.4,
+                borderRadius: 999,
+                fontSize: '0.7rem',
+                fontWeight: 700,
+                letterSpacing: '0.05em',
+                textTransform: 'uppercase',
+                lineHeight: 1,
+                whiteSpace: 'nowrap',
+                color: '#cfe3ff',
+                backgroundColor: 'rgba(28,42,76,0.78)',
+                border: '1px solid rgba(143,184,255,0.35)',
+                backdropFilter: 'blur(4px)',
+              }}
+            >
+              {navigation ? 'Browse' : 'Library'}
+            </Box>
+          </Box>
+
+          <CardContent sx={{flex: 1, display: 'flex', flexDirection: 'column', gap: 1, p: 2, minWidth: 0}}>
+            <Typography noWrap sx={{fontWeight: 700, fontSize: '1.08rem', lineHeight: 1.25}}>
+              {name.top}
+            </Typography>
+            {name.bottom && (
+              <Typography noWrap variant="body2" sx={{color: 'text.secondary', mt: -0.5}}>
+                {name.bottom}
+              </Typography>
+            )}
+
+            {quality && (
+              <Box sx={{
+                alignSelf: 'flex-start',
+                mt: 0.5,
+                px: 1.25, py: 0.35,
+                borderRadius: 999,
+                fontSize: '0.72rem',
+                fontWeight: 700,
+                letterSpacing: '0.03em',
+                fontFamily: 'var(--cs-mono-font)',
+                whiteSpace: 'nowrap',
+                color: '#ffd9b0',
+                backgroundColor: 'rgba(255,115,0,0.12)',
+                border: '1px solid rgba(255,115,0,0.32)',
+              }}>
+                {quality}
+              </Box>
+            )}
+
+            {footer && (
+              <Typography noWrap variant="caption" sx={{color: 'text.secondary', mt: 'auto', pt: 0.5}}>
+                {footer}
+              </Typography>
+            )}
+            {navigation && (
+              <Typography variant="caption" sx={{color: '#cfe3ff', fontWeight: 700, mt: 'auto', pt: 0.5}}>
+                {result.type === 'show' ? 'Browse seasons' : 'Browse episodes'}
+              </Typography>
+            )}
+          </CardContent>
+        </CardActionArea>
+      </Card>
+    </Grid>
+  )
+}

--- a/frontend/src/components/LibraryResultCard.js
+++ b/frontend/src/components/LibraryResultCard.js
@@ -86,9 +86,10 @@ export default function LibraryResultCard({result, active, onSelect, onNavigate}
   const name = getResultName(result)
   const res = resolutionLabel(result.videoResolution)
   const audio = audioLayoutLabel(result.audioChannels)
-  const quality = qualitySummary(res, audio)
+  const quality = qualitySummary(res, null)
   const codec = result.videoCodec ? String(result.videoCodec).toUpperCase() : null
   const main10 = String(result.videoProfile || '').toLowerCase() === 'main 10'
+  const audioInfo = [result.audioCodec ? String(result.audioCodec).toUpperCase() : null, audio].filter(Boolean).join(' · ')
   const tLabel = typeLabel(result.type)
   const navigation = result.type === 'show' || result.type === 'season'
   const selectable = result.type === 'movie' || result.type === 'episode'
@@ -188,7 +189,7 @@ export default function LibraryResultCard({result, active, onSelect, onNavigate}
               </Typography>
             )}
 
-            {(quality || codec || main10) && (
+            {(quality || audioInfo || codec || main10) && (
               <Box sx={{display: 'flex', flexWrap: 'wrap', gap: 0.75, mt: 0.5}}>
               {quality && <Box sx={{
                 alignSelf: 'flex-start',
@@ -208,6 +209,9 @@ export default function LibraryResultCard({result, active, onSelect, onNavigate}
               {codec && <Box sx={{px: 1.25, py: 0.35, borderRadius: 999, fontSize: '0.72rem', fontWeight: 700,
                 letterSpacing: '0.03em', fontFamily: 'var(--cs-mono-font)', color: '#cfe3ff',
                 backgroundColor: 'rgba(73,121,193,0.14)', border: '1px solid rgba(143,184,255,0.32)'}}>{codec}</Box>}
+              {audioInfo && <Box sx={{px: 1.25, py: 0.35, borderRadius: 999, fontSize: '0.72rem', fontWeight: 700,
+                letterSpacing: '0.03em', fontFamily: 'var(--cs-mono-font)', color: '#d6dbe5',
+                backgroundColor: 'rgba(255,255,255,0.06)', border: '1px solid rgba(255,255,255,0.14)'}}>{audioInfo}</Box>}
               {main10 && <Box sx={{px: 1.25, py: 0.35, borderRadius: 999, fontSize: '0.72rem', fontWeight: 700,
                 letterSpacing: '0.03em', fontFamily: 'var(--cs-mono-font)', color: '#d9c6ff',
                 backgroundColor: 'rgba(137,98,201,0.15)', border: '1px solid rgba(185,151,246,0.38)'}}>Main 10</Box>}

--- a/frontend/src/components/LibrarySearchPanel.js
+++ b/frontend/src/components/LibrarySearchPanel.js
@@ -1,0 +1,491 @@
+import {Box, Button, Grid, IconButton, InputAdornment, LinearProgress, TextField, Typography} from "@mui/material";
+import {useCallback, useEffect, useRef, useState} from "react";
+import LibraryResultCard from "./LibraryResultCard";
+import SessionCard from "./SessionCard";
+import {SessionEmptyState, SessionErrorState, SessionLoadingGrid, orderSessionsOwnedFirst} from "./SessionPicker";
+import StateMessage from "./StateMessage";
+import {isAbortError} from "../utils";
+
+// Unified Plex source picker. One heading, one search field, one results
+// region. With an empty query the region shows active Plex sessions as the
+// immediate/default list; typing a valid query swaps that region to library
+// matches — never a separate competing section. Clearing the query restores
+// the session list.
+//
+// Source-type identity is preserved through badges: active-session cards carry
+// the warm "Your session" badge, library cards carry the cooler "Library"
+// badge. Both render in the same Grid so they read as one cohesive list.
+//
+// Behaviour:
+//   • 300ms debounce + a 2-character minimum before firing a library search
+//   • the backend caps queries at 128 runes; we enforce the same bound
+//     client-side so a long paste never produces a 422 round-trip
+//   • every raw input edit immediately aborts the in-flight request and bumps
+//     a generation token, so a slow response for an old query can never
+//     commit (the debounce timer alone is not enough — a request fired for a
+//     prior committed query could resolve during the new debounce window)
+//   • 401/403 route to onAuthRequired so the app shows its login state
+//   • 422 is validation feedback (non-retryable); retry is offered only for
+//     network failures, 429, and 5xx
+//   • one coherent status region (aria-live=polite) carries the loading /
+//     error / empty / results announcements without duplication
+//   • active-session loading/error/empty states render in the same region,
+//     so the picker never shows a busy two-panel layout
+
+const DEBOUNCE_MS = 300
+const MIN_QUERY_CHARS = 2
+const MAX_QUERY_RUNES = 128
+
+function SearchIcon(props) {
+  return (
+    <svg viewBox="0 0 24 24" width="1em" height="1em" fill="none" stroke="currentColor"
+      strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" {...props}>
+      <circle cx="11" cy="11" r="7"/><path d="m21 21-4.3-4.3"/>
+    </svg>
+  )
+}
+function ClearIcon(props) {
+  return (
+    <svg viewBox="0 0 24 24" width="1em" height="1em" fill="none" stroke="currentColor"
+      strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" {...props}>
+      <path d="M18 6 6 18M6 6l12 12"/>
+    </svg>
+  )
+}
+
+export default function LibrarySearchPanel({
+  onSelect, selectedKey, disabled, onAuthRequired,
+  // Active-session props — rendered in the results region when the query is
+  // empty. The contracts (selection shape, polling, partId-free requests) are
+  // unchanged; the panel only takes over presentation.
+  sessions, sessionsLoading, sessionsError, onSelectSession, onRetrySessions,
+}) {
+  const [query, setQuery] = useState('')
+  const [committed, setCommitted] = useState('') // debounced, min-length-gated
+  const [retryCount, setRetryCount] = useState(0)
+  const [results, setResults] = useState(null) // null = no search yet; [] = empty
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState(null) // {kind: 'validation'|'retryable', message}
+  const [hierarchy, setHierarchy] = useState([])
+  const [children, setChildren] = useState(null)
+  const [hierarchyLoading, setHierarchyLoading] = useState(false)
+  const [hierarchyError, setHierarchyError] = useState(null)
+
+  const abortRef = useRef(null)
+  const generationRef = useRef(0)
+  const hierarchyAbortRef = useRef(null)
+  const hierarchyGenerationRef = useRef(0)
+  const backButtonRef = useRef(null)
+
+  // onAuthRequired arrives from App as an inline arrow (`() => setNeedsAuth(true)`),
+  // so its identity changes on every parent render. Session polling on the home
+  // view calls setSessions ~every 10s, re-rendering App and producing a fresh
+  // callback. If the search effect listed onAuthRequired in its dependency
+  // array, each poll would re-run the effect and re-fetch /library/search for
+  // a query that hadn't changed — a visible refetch loop. We capture the latest
+  // callback in a ref (updated during render, which is safe and idempotent for
+  // refs) and call through it inside the effect. The ref object itself is
+  // stable, so the effect's deps stay [committed, retryCount] and the search
+  // fires only on intended inputs. 401/403 still route to whatever App passed
+  // most recently.
+  const onAuthRequiredRef = useRef(onAuthRequired)
+  onAuthRequiredRef.current = onAuthRequired
+
+  // Immediately abort any in-flight search and invalidate its generation on
+  // every raw input edit. The debounce effect below schedules a new committed
+  // query, but without this guard a request already in flight for a previous
+  // committed query could resolve during the debounce window and commit stale
+  // results. Bumping the generation here ensures the in-flight response's
+  // generation check fails even before committed changes.
+  const resetHierarchy = useCallback(() => {
+    hierarchyAbortRef.current?.abort()
+    hierarchyGenerationRef.current += 1
+    setHierarchy([])
+    setChildren(null)
+    setHierarchyError(null)
+    setHierarchyLoading(false)
+  }, [])
+
+  const handleQueryChange = useCallback((e) => {
+    const next = e.target.value
+    const normalizedChanged = next.trim() !== query.trim()
+    setQuery(next)
+    if (!normalizedChanged) return
+    if (abortRef.current) {
+      abortRef.current.abort()
+      abortRef.current = null
+    }
+    generationRef.current += 1
+    setLoading(false)
+    setResults(null)
+    setError(null)
+    resetHierarchy()
+  }, [query, resetHierarchy])
+
+  const loadChildren = useCallback((node, nextHierarchy) => {
+    hierarchyAbortRef.current?.abort()
+    const controller = new AbortController()
+    hierarchyAbortRef.current = controller
+    const generation = ++hierarchyGenerationRef.current
+    setHierarchy(nextHierarchy)
+    setHierarchyLoading(true)
+    setHierarchyError(null)
+    setChildren(null)
+    fetch(`/library/metadata/${encodeURIComponent(node.ratingKey)}/children`, {signal: controller.signal})
+      .then(async response => {
+        if (response.status === 401 || response.status === 403) {
+          onAuthRequiredRef.current?.()
+          const error = new Error('Authentication required.')
+          error.kind = 'auth'
+          throw error
+        }
+        if (!response.ok) {
+          const body = await response.json().catch(() => null)
+          const error = new Error(body?.error?.message || 'Couldn’t load this part of your library.')
+          error.kind = response.status === 404 || response.status === 422 ? 'validation' : 'retryable'
+          throw error
+        }
+        const data = await response.json()
+        if (!Array.isArray(data)) throw new Error('Received an invalid library response.')
+        return data
+      })
+      .then(data => {
+        if (controller.signal.aborted || hierarchyGenerationRef.current !== generation) return
+        setChildren(data)
+      })
+      .catch(nextError => {
+        if (controller.signal.aborted || isAbortError(nextError) || hierarchyGenerationRef.current !== generation) return
+        setHierarchyError(nextError)
+      })
+      .finally(() => {
+        if (!controller.signal.aborted && hierarchyGenerationRef.current === generation) setHierarchyLoading(false)
+      })
+  }, [])
+
+  const handleNavigate = useCallback((node) => {
+    if (node?.ratingKey) loadChildren(node, [...hierarchy, node])
+  }, [hierarchy, loadChildren])
+
+  const handleHierarchyBack = useCallback(() => {
+    if (hierarchy.length <= 1) {
+      resetHierarchy()
+      return
+    }
+    const nextHierarchy = hierarchy.slice(0, -1)
+    loadChildren(nextHierarchy[nextHierarchy.length - 1], nextHierarchy)
+  }, [hierarchy, loadChildren, resetHierarchy])
+
+  useEffect(() => () => {
+    hierarchyAbortRef.current?.abort()
+    hierarchyGenerationRef.current += 1
+  }, [])
+
+  useEffect(() => {
+    if (hierarchy.length) backButtonRef.current?.focus()
+  }, [hierarchy.length])
+
+  // Debounce + minimum-length gate. Below the minimum, committed clears so the
+  // search effect tears down to the session list. The 128-rune bound is
+  // enforced on the trimmed value so leading/trailing whitespace doesn't eat
+  // into the budget; a too-long query is surfaced as validation feedback, not
+  // fired.
+  //
+  // Rune count ([...str].length) matches the backend's utf8.RuneCountInString:
+  // String.prototype.length counts UTF-16 code units, so an astral character
+  // (e.g. an emoji) counts as 2 — enforcing length would reject a 64-emoji
+  // query that the backend accepts at 128 runes.
+  useEffect(() => {
+    const trimmed = query.trim()
+    const runeCount = [...trimmed].length
+    if (runeCount === 0) {
+      setCommitted('')
+      setError(null)
+      return
+    }
+    if (runeCount > MAX_QUERY_RUNES) {
+      setCommitted('')
+      setError({kind: 'validation', message: `Search is too long — keep it under ${MAX_QUERY_RUNES} characters.`})
+      return
+    }
+    if (runeCount < MIN_QUERY_CHARS) {
+      setCommitted('')
+      return
+    }
+    const t = setTimeout(() => setCommitted(trimmed), DEBOUNCE_MS)
+    return () => clearTimeout(t)
+  }, [query])
+
+  // Fire the search for the committed query. Aborts any in-flight request on
+  // change/unmount so stale results can't commit.
+  useEffect(() => {
+    if (!committed) {
+      abortRef.current?.abort()
+      abortRef.current = null
+      setResults(null)
+      setLoading(false)
+      return
+    }
+    const generation = ++generationRef.current
+    const controller = new AbortController()
+    abortRef.current = controller
+    setLoading(true)
+    setError(null)
+    fetch(`/library/search?query=${encodeURIComponent(committed)}`, {signal: controller.signal})
+      .then(r => {
+        if (controller.signal.aborted || generationRef.current !== generation) return null
+        if (r.status === 401 || r.status === 403) {
+          // Route auth failures to the app's login handling — the search panel
+          // doesn't own the auth surface. Called through the ref so a parent
+          // re-render (e.g. session polling) doesn't retrigger this effect.
+          onAuthRequiredRef.current?.()
+          const e = new Error('Authentication required.')
+          e.kind = 'auth'
+          throw e
+        }
+        if (r.status === 422) {
+          // Validation feedback from the backend (e.g. disallowed characters).
+          // Non-retryable — the user must change the query.
+          return r.json().then(body => {
+            const e = new Error(body?.error?.message || 'That search isn’t valid.')
+            e.kind = 'validation'
+            throw e
+          })
+        }
+        if (r.status === 429 || r.status >= 500) {
+          const e = new Error('Plex library search is temporarily unavailable.')
+          e.kind = 'retryable'
+          e.status = r.status
+          throw e
+        }
+        if (!r.ok) {
+          const e = new Error(`Plex library search failed (${r.status}).`)
+          e.kind = 'retryable'
+          throw e
+        }
+        return r.json()
+      })
+      .then(data => {
+        if (data === null) return // aborted or superseded
+        if (controller.signal.aborted || generationRef.current !== generation) return
+        setResults(Array.isArray(data) ? data : [])
+      })
+      .catch(err => {
+        if (controller.signal.aborted || isAbortError(err) || generationRef.current !== generation) return
+        if (err?.kind === 'auth') {
+          // Auth already routed via onAuthRequired; don't surface a retryable
+          // error in the panel — the app is switching to the login view.
+          setError(null)
+          setResults(null)
+          return
+        }
+        if (err?.kind === 'validation') {
+          setError({kind: 'validation', message: err.message})
+          setResults(null)
+          return
+        }
+        // Network failure or 429/5xx — retryable.
+        setError({kind: 'retryable', message: err?.message || 'Couldn’t search the Plex library.'})
+        setResults(null)
+      })
+      .finally(() => {
+        if (!controller.signal.aborted && generationRef.current === generation) setLoading(false)
+      })
+    return () => {
+      controller.abort()
+      if (abortRef.current === controller) abortRef.current = null
+    }
+  // onAuthRequired is intentionally read via ref (see onAuthRequiredRef) so
+  // parent re-renders don't retrigger the search. Only committed query and
+  // explicit retry should re-fire.
+  }, [committed, retryCount])
+
+  const trimmedQuery = query.trim()
+  const queryRuneCount = [...trimmedQuery].length
+  const validLibraryQuery = queryRuneCount >= MIN_QUERY_CHARS && queryRuneCount <= MAX_QUERY_RUNES
+  const searchPending = validLibraryQuery && !committed
+  const searching = Boolean(committed) || searchPending
+  const searchLoading = loading || searchPending
+  const showResults = results != null && Boolean(committed) && !searchLoading && !error
+  const empty = showResults && results.length === 0
+  const validationError = error?.kind === 'validation'
+  const retryableError = error?.kind === 'retryable'
+  const searchOwnsRegion = searching || validationError || retryableError
+  const hierarchyActive = hierarchy.length > 0
+
+  // One concise status line for the helper text. The full messages live in the
+  // status region below; this is a compact visual cue kept distinct so
+  // screen-reader users don't hear the same phrase twice.
+  const helperText =
+    searchLoading ? 'Searching…' :
+    validationError ? 'Invalid search.' :
+    retryableError ? 'Search failed.' :
+    empty ? 'No matches.' :
+    showResults ? `${results.length} ${results.length === 1 ? 'result' : 'results'}.` :
+    searching ? 'Searching…' :
+    'Active sessions show here. Or type at least two characters to search your library.'
+
+  // The results region renders exactly one of: library loading/error/empty/
+  // results (when searching), or session loading/error/empty/cards (when not).
+  // This is the single cohesive surface — there is no second panel.
+  const sortedSessions = orderSessionsOwnedFirst(sessions)
+
+  return (
+    <Box className="cs-rise-2" sx={{display: 'flex', flexDirection: 'column', gap: 1.5}}>
+      <TextField
+        fullWidth
+        variant="outlined"
+        size="small"
+        placeholder="Search your Plex library…"
+        label="Search Plex library"
+        value={query}
+        onChange={handleQueryChange}
+        disabled={disabled}
+        inputProps={{maxLength: MAX_QUERY_RUNES, 'aria-label': 'Search Plex library'}}
+        InputProps={{
+          startAdornment: <InputAdornment position="start"><SearchIcon sx={{color: 'text.secondary', fontSize: 18}}/></InputAdornment>,
+          endAdornment: query ? (
+            <InputAdornment position="end">
+              <IconButton
+                aria-label="Clear library search"
+                size="small"
+                edge="end"
+                onClick={() => handleQueryChange({target: {value: ''}})}
+                disabled={disabled}
+              >
+                <ClearIcon sx={{fontSize: 18}}/>
+              </IconButton>
+            </InputAdornment>
+          ) : null,
+        }}
+        helperText={helperText}
+        FormHelperTextProps={{sx: {color: (validationError || retryableError) ? '#ffb4a8' : 'text.disabled'}}}
+      />
+
+      {/* Single coherent status region — the one place loading / error / empty
+          / results announcements live. aria-live=polite gives assistive tech a
+          single, non-duplicative feed of search state. We deliberately do not
+          use role="status" here because this is a persistent container that
+          swaps between several states over time (a live region), not a single
+          transient status message — using role="status" would collide with the
+          session loading skeleton's own role="status" and confuse
+          getByRole('status'). */}
+      <Box
+        aria-live="polite"
+        aria-busy={(hierarchyActive ? hierarchyLoading : searchOwnsRegion ? searchLoading : sessionsLoading) || undefined}
+        aria-label="Plex library search status"
+        sx={{minHeight: 160, position: 'relative'}}
+      >
+        {searchLoading && !hierarchyActive && (
+          <LinearProgress
+            aria-hidden
+            sx={{
+              position: 'absolute', top: 0, left: 0, right: 0, zIndex: 1,
+              height: 3, backgroundColor: 'transparent',
+              '& .MuiLinearProgress-bar': {backgroundColor: '#ff7300'},
+            }}
+          />
+        )}
+
+        {hierarchyActive && (
+          <Box sx={{mb: 2}}>
+            <Button ref={backButtonRef} size="small" onClick={handleHierarchyBack} sx={{mb: 0.75, px: 0}}>← Back</Button>
+            <Typography variant="body2" sx={{color: 'text.secondary'}}>
+              {hierarchy.map(item => item.title).filter(Boolean).join('  /  ')}
+            </Typography>
+          </Box>
+        )}
+        {hierarchyActive && hierarchyLoading && <LinearProgress sx={{mb: 2, '& .MuiLinearProgress-bar': {backgroundColor: '#ff7300'}}}/>}
+        {hierarchyActive && hierarchyError && (
+          <StateMessage variant="error" title={hierarchyError.kind === 'validation' ? 'This library item is no longer available.' : 'Couldn’t load this part of your library.'} hint={hierarchyError.message}
+            action={hierarchyError.kind === 'retryable' ? <Button size="small" onClick={() => loadChildren(hierarchy[hierarchy.length - 1], hierarchy)}>Try again</Button> : null}/>
+        )}
+        {hierarchyActive && !hierarchyLoading && !hierarchyError && children?.length === 0 && (
+          <StateMessage variant="empty" title="Nothing is available here." hint="Try another season or return to the search results."/>
+        )}
+        {hierarchyActive && !hierarchyLoading && !hierarchyError && children?.length > 0 && (
+          <Grid container spacing={3} sx={{mx: 'auto', px: {xs: 2, sm: 3}}}>
+            {children.map(result => <LibraryResultCard key={result.ratingKey} result={result}
+              active={result.ratingKey === selectedKey} onSelect={onSelect} onNavigate={handleNavigate}/>) }
+          </Grid>
+        )}
+
+        {/* --- Library search states (when a valid query is committed) --- */}
+        {!hierarchyActive && validationError && (
+          <StateMessage
+            variant="error"
+            title={error.message}
+            hint="Try a shorter or different search term."
+          />
+        )}
+
+        {!hierarchyActive && retryableError && (
+          <StateMessage
+            variant="error"
+            title="Couldn’t search the Plex library."
+            hint="Plex may be unreachable. Try again in a moment."
+            action={
+              <Box
+                component="button"
+                type="button"
+                onClick={() => setRetryCount(n => n + 1)}
+                sx={{
+                  mt: 1, px: 2, py: 0.5, borderRadius: 999, cursor: 'pointer',
+                  border: '1px solid rgba(255,255,255,0.2)', background: 'transparent',
+                  color: '#ffd9b0', font: 'inherit', fontWeight: 600,
+                }}
+              >
+                Try again
+              </Box>
+            }
+          />
+        )}
+
+        {!hierarchyActive && empty && (
+          <StateMessage
+            variant="empty"
+            title="No matching titles in your Plex library."
+            hint="Try a different search term."
+          />
+        )}
+
+        {!hierarchyActive && showResults && results.length > 0 && (
+          <Grid container spacing={3} sx={{mx: 'auto', px: {xs: 2, sm: 3}}}>
+            {results.map(result => (
+              <LibraryResultCard
+                key={result.ratingKey}
+                result={result}
+                active={result.ratingKey === selectedKey}
+                onSelect={onSelect}
+                onNavigate={handleNavigate}
+              />
+            ))}
+          </Grid>
+        )}
+
+        {/* --- Active-session states (empty query — the default list) --- */}
+        {!hierarchyActive && !searchOwnsRegion && (
+          <>
+            {sessionsLoading ? (
+              <SessionLoadingGrid/>
+            ) : sessionsError ? (
+              <SessionErrorState onRetry={onRetrySessions}/>
+            ) : !sessions || sessions.length === 0 ? (
+              <SessionEmptyState/>
+            ) : (
+              <Grid container spacing={3} sx={{mx: 'auto', px: {xs: 2, sm: 3}}}>
+                {sortedSessions.map(session => (
+                  <SessionCard
+                    key={session.ratingKey}
+                    session={session}
+                    active={session.ratingKey === selectedKey}
+                    onSelect={onSelectSession}
+                  />
+                ))}
+              </Grid>
+            )}
+          </>
+        )}
+      </Box>
+    </Box>
+  )
+}

--- a/frontend/src/components/SessionCard.js
+++ b/frontend/src/components/SessionCard.js
@@ -1,0 +1,266 @@
+import {Box, Card, CardActionArea, CardContent, CardMedia, Grid, LinearProgress, Typography} from "@mui/material";
+
+// A single active-session source card. Extracted from SessionPicker so the
+// unified source picker can render session cards in the same results region as
+// library cards without duplicating the markup. The visual language is
+// preserved exactly — "Your session" badge, player-state dot, progress bar,
+// quality pill, muted footer — so active-session sources keep their identity
+// inside the unified picker.
+
+function millisToDuration(millis) {
+  const hours = Math.floor(millis / 1000 / 60 / 60)
+  const minutes = Math.floor(millis / 1000 / 60) % 60
+  const seconds = Math.floor(millis / 1000) % 60
+  return String(hours).padStart(2, '0') + ':' + String(minutes).padStart(2, '0') + ':' + String(seconds).padStart(2, '0')
+}
+
+function getVideoName(session) {
+  if (session.type === "episode") {
+    return {
+      top: session.grandparentTitle,
+      bottom: `S${String(session.parentIndex).padStart(2, '0')}E${String(session.index).padStart(2, '0')} ${session.title}`,
+    }
+  }
+  return {top: `${session.title}`, bottom: session.year ? `(${session.year})` : ''}
+}
+
+function getPlayerState(state) {
+  switch (state) {
+    case 'playing': return {color: '#7fd391', label: 'Playing'}
+    case 'paused': return {color: '#ffd9a0', label: 'Paused'}
+    case 'buffering': return {color: '#8fb8ff', label: 'Buffering'}
+    default: return null
+  }
+}
+
+function audioLayoutLabel(channels) {
+  if (channels == null) return null
+  const n = Number(channels)
+  if (!Number.isFinite(n) || n <= 0) return null
+  if (n === 1) return '1.0'
+  if (n === 2) return '2.0'
+  if (n === 6) return '5.1'
+  if (n === 8) return '7.1'
+  return `${n}ch`
+}
+
+function resolutionLabel(res) {
+  if (!res) return null
+  const s = String(res).trim()
+  return s ? s.toUpperCase() : null
+}
+
+function qualitySummary(res, audio) {
+  const parts = [res, audio].filter(Boolean)
+  return parts.length ? parts.join(' · ') : null
+}
+
+function locationLabel(loc) {
+  if (loc === 'lan') return 'Local'
+  if (loc === 'wan') return 'Remote'
+  return null
+}
+
+function FilmPlaceholder() {
+  return (
+    <Box sx={{
+      position: 'absolute', inset: 0, display: 'grid', placeItems: 'center',
+      background: 'linear-gradient(135deg, #1b1e26, #11141a)',
+    }}>
+      <svg viewBox="0 0 24 24" width="42" height="42" fill="none" stroke="rgba(255,255,255,0.18)"
+        strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+        <rect x="3" y="4" width="18" height="16" rx="2"/>
+        <path d="M3 9h18M3 15h18M8 4v16M16 4v16"/>
+      </svg>
+    </Box>
+  )
+}
+
+export default function SessionCard({session, active, onSelect}) {
+  const name = getVideoName(session)
+  const owned = session.ownedByCurrentUser === true
+
+  const duration = session.duration
+  const viewOffset = session.viewOffset
+  const hasProgress = duration != null && viewOffset != null && duration > 0
+  const progressPct = hasProgress ? Math.min(100, Math.max(0, (viewOffset / duration) * 100)) : 0
+  const playerState = getPlayerState(session.Player?.state)
+  const playerTitle = session.Player?.title
+  const res = resolutionLabel(session.Media?.[0]?.videoResolution)
+  const audio = audioLayoutLabel(session.Media?.[0]?.audioChannels)
+  const quality = qualitySummary(res, audio)
+  const loc = locationLabel(session.Session?.location)
+  const userTitle = session.User?.title
+  const thumbPath = session.thumb || session.grandparentThumb || null
+
+  const footerParts = []
+  if (!owned && userTitle) footerParts.push(userTitle)
+  if (playerTitle) footerParts.push(playerTitle)
+  if (loc) footerParts.push(loc)
+  const footer = footerParts.join('  ·  ')
+
+  return (
+    <Grid item xs={12} sm={6} md={4} key={session.ratingKey}>
+      <Card
+        sx={{
+          height: '100%',
+          position: 'relative',
+          display: 'flex',
+          flexDirection: 'column',
+          overflow: 'hidden',
+          transition: 'transform 180ms ease, border-color 180ms ease, box-shadow 180ms ease',
+          borderColor: active
+            ? 'rgba(255,115,0,0.6)'
+            : owned ? 'rgba(255,115,0,0.4)' : 'rgba(255,255,255,0.08)',
+          background: owned
+            ? 'linear-gradient(180deg, rgba(255,115,0,0.13), rgba(255,115,0,0.02) 68%, rgba(255,115,0,0) 100%)'
+            : undefined,
+          boxShadow: active
+            ? '0 14px 40px -22px rgba(255,115,0,0.7)'
+            : owned ? '0 10px 30px -22px rgba(255,115,0,0.45)' : undefined,
+          '&:hover': {transform: 'translateY(-2px)', borderColor: 'rgba(255,115,0,0.4)'},
+        }}
+      >
+        <CardActionArea
+          onClick={() => onSelect(session)}
+          data-owned={owned ? 'true' : undefined}
+          aria-label={owned ? `Your session. ${name.top}${name.bottom ? ' ' + name.bottom : ''}` : undefined}
+          sx={{
+            display: 'flex', flexDirection: 'column', alignItems: 'stretch', height: '100%',
+            '&.Mui-focusVisible, &:focus-visible': {
+              outline: '2px solid #ff7300',
+              outlineOffset: '2px',
+            },
+          }}
+          focusRipple
+        >
+          <Box sx={{position: 'relative', width: '100%', aspectRatio: '16 / 9', background: '#11141a', flexShrink: 0}}>
+            {thumbPath ? (
+              <CardMedia
+                component="img"
+                sx={{position: 'absolute', inset: 0, width: '100%', height: '100%', objectFit: 'cover'}}
+                image={`/thumb?path=${thumbPath}`}
+                alt=""
+              />
+            ) : (
+              <FilmPlaceholder/>
+            )}
+            {playerState && (
+              <Box
+                sx={{
+                  position: 'absolute', left: 10, bottom: 10, zIndex: 1, pointerEvents: 'none',
+                  display: 'inline-flex', alignItems: 'center', gap: 0.75,
+                  px: 1, py: 0.4, borderRadius: 999,
+                  backgroundColor: 'rgba(13,15,20,0.72)',
+                  backdropFilter: 'blur(4px)',
+                }}
+              >
+                <Box sx={{
+                  width: 8, height: 8, borderRadius: '50%',
+                  backgroundColor: playerState.color,
+                  boxShadow: `0 0 8px ${playerState.color}`,
+                }}/>
+                <Typography
+                  component="span"
+                  sx={{
+                    fontSize: '0.66rem', fontWeight: 700, letterSpacing: '0.06em',
+                    textTransform: 'uppercase', lineHeight: 1, color: 'rgba(255,255,255,0.92)',
+                  }}
+                >
+                  {playerState.label}
+                </Typography>
+              </Box>
+            )}
+            {owned && (
+              <Box
+                sx={{
+                  position: 'absolute',
+                  top: 10,
+                  right: 10,
+                  zIndex: 1,
+                  pointerEvents: 'none',
+                  px: 1.25,
+                  py: 0.4,
+                  borderRadius: 999,
+                  fontSize: '0.7rem',
+                  fontWeight: 700,
+                  letterSpacing: '0.05em',
+                  textTransform: 'uppercase',
+                  lineHeight: 1,
+                  whiteSpace: 'nowrap',
+                  color: '#1a1206',
+                  backgroundColor: '#ff7300',
+                  boxShadow: '0 4px 14px -4px rgba(255,115,0,0.7)',
+                }}
+              >
+                Your session
+              </Box>
+            )}
+          </Box>
+
+          <CardContent sx={{flex: 1, display: 'flex', flexDirection: 'column', gap: 1, p: 2, minWidth: 0}}>
+            <Typography noWrap sx={{fontWeight: 700, fontSize: '1.08rem', lineHeight: 1.25}}>
+              {name.top}
+            </Typography>
+            {name.bottom && (
+              <Typography noWrap variant="body2" sx={{color: 'text.secondary', mt: -0.5}}>
+                {name.bottom}
+              </Typography>
+            )}
+
+            {hasProgress && (
+              <Box sx={{mt: 0.5, minWidth: 0}}>
+                <LinearProgress
+                  variant="determinate"
+                  value={progressPct}
+                  aria-hidden
+                  sx={{
+                    height: 6, borderRadius: 999,
+                    backgroundColor: 'rgba(255,255,255,0.08)',
+                    '& .MuiLinearProgress-bar': {
+                      borderRadius: 999,
+                      backgroundColor: '#ff7300',
+                    },
+                  }}
+                />
+                <Box sx={{display: 'flex', justifyContent: 'space-between', mt: 0.5, gap: 1}}>
+                  <Typography variant="caption" sx={{fontFamily: 'var(--cs-mono-font)', color: '#ff7300'}}>
+                    {millisToDuration(viewOffset)}
+                  </Typography>
+                  <Typography variant="caption" sx={{fontFamily: 'var(--cs-mono-font)', color: 'text.disabled'}}>
+                    {millisToDuration(duration)}
+                  </Typography>
+                </Box>
+              </Box>
+            )}
+
+            {quality && (
+              <Box sx={{
+                alignSelf: 'flex-start',
+                mt: 0.5,
+                px: 1.25, py: 0.35,
+                borderRadius: 999,
+                fontSize: '0.72rem',
+                fontWeight: 700,
+                letterSpacing: '0.03em',
+                fontFamily: 'var(--cs-mono-font)',
+                whiteSpace: 'nowrap',
+                color: '#ffd9b0',
+                backgroundColor: 'rgba(255,115,0,0.12)',
+                border: '1px solid rgba(255,115,0,0.32)',
+              }}>
+                {quality}
+              </Box>
+            )}
+
+            {footer && (
+              <Typography noWrap variant="caption" sx={{color: 'text.secondary', mt: 'auto', pt: 0.5}}>
+                {footer}
+              </Typography>
+            )}
+          </CardContent>
+        </CardActionArea>
+      </Card>
+    </Grid>
+  )
+}

--- a/frontend/src/components/SessionCard.js
+++ b/frontend/src/components/SessionCard.js
@@ -88,9 +88,10 @@ export default function SessionCard({session, active, onSelect}) {
   const playerTitle = session.Player?.title
   const res = resolutionLabel(session.Media?.[0]?.videoResolution)
   const audio = audioLayoutLabel(session.Media?.[0]?.audioChannels)
-  const quality = qualitySummary(res, audio)
+  const quality = qualitySummary(res, null)
   const codec = session.Media?.[0]?.videoCodec ? String(session.Media[0].videoCodec).toUpperCase() : null
   const main10 = String(session.Media?.[0]?.videoProfile || '').toLowerCase() === 'main 10'
+  const audioInfo = [session.Media?.[0]?.audioCodec ? String(session.Media[0].audioCodec).toUpperCase() : null, audio].filter(Boolean).join(' · ')
   const loc = locationLabel(session.Session?.location)
   const userTitle = session.User?.title
   const thumbPath = session.thumb || session.grandparentThumb || null
@@ -236,7 +237,7 @@ export default function SessionCard({session, active, onSelect}) {
               </Box>
             )}
 
-            {(quality || codec || main10) && (
+            {(quality || audioInfo || codec || main10) && (
               <Box sx={{display: 'flex', flexWrap: 'wrap', gap: 0.75, mt: 0.5}}>
               {quality && <Box sx={{
                 alignSelf: 'flex-start',
@@ -256,6 +257,9 @@ export default function SessionCard({session, active, onSelect}) {
               {codec && <Box sx={{px: 1.25, py: 0.35, borderRadius: 999, fontSize: '0.72rem', fontWeight: 700,
                 letterSpacing: '0.03em', fontFamily: 'var(--cs-mono-font)', color: '#cfe3ff',
                 backgroundColor: 'rgba(73,121,193,0.14)', border: '1px solid rgba(143,184,255,0.32)'}}>{codec}</Box>}
+              {audioInfo && <Box sx={{px: 1.25, py: 0.35, borderRadius: 999, fontSize: '0.72rem', fontWeight: 700,
+                letterSpacing: '0.03em', fontFamily: 'var(--cs-mono-font)', color: '#d6dbe5',
+                backgroundColor: 'rgba(255,255,255,0.06)', border: '1px solid rgba(255,255,255,0.14)'}}>{audioInfo}</Box>}
               {main10 && <Box sx={{px: 1.25, py: 0.35, borderRadius: 999, fontSize: '0.72rem', fontWeight: 700,
                 letterSpacing: '0.03em', fontFamily: 'var(--cs-mono-font)', color: '#d9c6ff',
                 backgroundColor: 'rgba(137,98,201,0.15)', border: '1px solid rgba(185,151,246,0.38)'}}>Main 10</Box>}

--- a/frontend/src/components/SessionCard.js
+++ b/frontend/src/components/SessionCard.js
@@ -89,6 +89,8 @@ export default function SessionCard({session, active, onSelect}) {
   const res = resolutionLabel(session.Media?.[0]?.videoResolution)
   const audio = audioLayoutLabel(session.Media?.[0]?.audioChannels)
   const quality = qualitySummary(res, audio)
+  const codec = session.Media?.[0]?.videoCodec ? String(session.Media[0].videoCodec).toUpperCase() : null
+  const main10 = String(session.Media?.[0]?.videoProfile || '').toLowerCase() === 'main 10'
   const loc = locationLabel(session.Session?.location)
   const userTitle = session.User?.title
   const thumbPath = session.thumb || session.grandparentThumb || null
@@ -234,10 +236,10 @@ export default function SessionCard({session, active, onSelect}) {
               </Box>
             )}
 
-            {quality && (
-              <Box sx={{
+            {(quality || codec || main10) && (
+              <Box sx={{display: 'flex', flexWrap: 'wrap', gap: 0.75, mt: 0.5}}>
+              {quality && <Box sx={{
                 alignSelf: 'flex-start',
-                mt: 0.5,
                 px: 1.25, py: 0.35,
                 borderRadius: 999,
                 fontSize: '0.72rem',
@@ -250,6 +252,13 @@ export default function SessionCard({session, active, onSelect}) {
                 border: '1px solid rgba(255,115,0,0.32)',
               }}>
                 {quality}
+              </Box>}
+              {codec && <Box sx={{px: 1.25, py: 0.35, borderRadius: 999, fontSize: '0.72rem', fontWeight: 700,
+                letterSpacing: '0.03em', fontFamily: 'var(--cs-mono-font)', color: '#cfe3ff',
+                backgroundColor: 'rgba(73,121,193,0.14)', border: '1px solid rgba(143,184,255,0.32)'}}>{codec}</Box>}
+              {main10 && <Box sx={{px: 1.25, py: 0.35, borderRadius: 999, fontSize: '0.72rem', fontWeight: 700,
+                letterSpacing: '0.03em', fontFamily: 'var(--cs-mono-font)', color: '#d9c6ff',
+                backgroundColor: 'rgba(137,98,201,0.15)', border: '1px solid rgba(185,151,246,0.38)'}}>Main 10</Box>}
               </Box>
             )}
 

--- a/frontend/src/components/SessionContext.js
+++ b/frontend/src/components/SessionContext.js
@@ -1,8 +1,9 @@
 import {Box, Button, Typography} from "@mui/material";
 
-// Session context bar — makes the active session unmistakable in the workspace.
-// Shows the title/context and provides a graceful Change-session affordance.
-// The Change-session button is disabled when a render job is active.
+// Session context bar — makes the active source unmistakable in the workspace.
+// Shows the title/context, a small source-kind label (Active session vs. Plex
+// library), and a graceful Change-source affordance. The Change button is
+// disabled when a render job is active.
 function getVideoName(session) {
   if (session.type === "episode") {
     return {
@@ -15,6 +16,8 @@ function getVideoName(session) {
 
 export default function SessionContext({session, onChangeSession, changeDisabled, changeDisabledReason}) {
   const name = getVideoName(session)
+  const isLibrary = session?._sourceType === 'library'
+  const sourceLabel = isLibrary ? 'From your Plex library' : 'Active Plex session'
   return (
     <Box className="cs-session-context cs-rise">
       <Box sx={{flex: 1, minWidth: 0}}>
@@ -29,6 +32,9 @@ export default function SessionContext({session, onChangeSession, changeDisabled
             {name.bottom}
           </Typography>
         )}
+        <Typography variant="caption" sx={{color: 'text.disabled', mt: 0.4, display: 'block'}}>
+          {sourceLabel}
+        </Typography>
       </Box>
       <Button
         variant="outlined"
@@ -38,7 +44,7 @@ export default function SessionContext({session, onChangeSession, changeDisabled
         title={changeDisabled ? changeDisabledReason : ''}
         sx={{borderColor: 'rgba(255,255,255,0.2)', flexShrink: 0}}
       >
-        Change session
+        Change source
       </Button>
     </Box>
   )

--- a/frontend/src/components/SessionContext.js
+++ b/frontend/src/components/SessionContext.js
@@ -25,6 +25,7 @@ export default function SessionContext({session, onChangeSession, changeDisabled
   const codec = media?.videoCodec ? String(media.videoCodec).toUpperCase() : null
   const main10 = String(media?.videoProfile || '').toLowerCase() === 'main 10'
   const audioCodec = media?.audioCodec ? String(media.audioCodec).toUpperCase() : null
+  const audioInfo = [audioCodec, audio].filter(Boolean).join(' · ')
   return (
     <Box className="cs-session-context cs-rise">
       <Box sx={{flex: 1, minWidth: 0}}>
@@ -42,13 +43,12 @@ export default function SessionContext({session, onChangeSession, changeDisabled
         <Typography variant="caption" sx={{color: 'text.disabled', mt: 0.4, display: 'block'}}>
           {sourceLabel}
         </Typography>
-        {(resolution || audio || codec || main10 || audioCodec) && (
+        {(resolution || audioInfo || codec || main10) && (
           <Box aria-label="Source media details" sx={{display: 'flex', flexWrap: 'wrap', gap: 0.75, mt: 1}}>
             {resolution && <MediaChip>{resolution}</MediaChip>}
-            {audio && <MediaChip>{audio}</MediaChip>}
+            {audioInfo && <MediaChip>{audioInfo}</MediaChip>}
             {codec && <MediaChip tone="blue">{codec}</MediaChip>}
             {main10 && <MediaChip tone="purple">Main 10</MediaChip>}
-            {audioCodec && <MediaChip tone="muted">{audioCodec}</MediaChip>}
           </Box>
         )}
       </Box>

--- a/frontend/src/components/SessionContext.js
+++ b/frontend/src/components/SessionContext.js
@@ -18,6 +18,13 @@ export default function SessionContext({session, onChangeSession, changeDisabled
   const name = getVideoName(session)
   const isLibrary = session?._sourceType === 'library'
   const sourceLabel = isLibrary ? 'From your Plex library' : 'Active Plex session'
+  const media = session?.Media?.[0]
+  const resolution = media?.videoResolution ? String(media.videoResolution).toUpperCase() : null
+  const audioChannels = Number(media?.audioChannels)
+  const audio = Number.isFinite(audioChannels) && audioChannels > 0 ? (audioChannels === 6 ? '5.1' : audioChannels === 8 ? '7.1' : audioChannels === 2 ? '2.0' : audioChannels === 1 ? '1.0' : `${audioChannels}ch`) : null
+  const codec = media?.videoCodec ? String(media.videoCodec).toUpperCase() : null
+  const main10 = String(media?.videoProfile || '').toLowerCase() === 'main 10'
+  const audioCodec = media?.audioCodec ? String(media.audioCodec).toUpperCase() : null
   return (
     <Box className="cs-session-context cs-rise">
       <Box sx={{flex: 1, minWidth: 0}}>
@@ -35,6 +42,15 @@ export default function SessionContext({session, onChangeSession, changeDisabled
         <Typography variant="caption" sx={{color: 'text.disabled', mt: 0.4, display: 'block'}}>
           {sourceLabel}
         </Typography>
+        {(resolution || audio || codec || main10 || audioCodec) && (
+          <Box aria-label="Source media details" sx={{display: 'flex', flexWrap: 'wrap', gap: 0.75, mt: 1}}>
+            {resolution && <MediaChip>{resolution}</MediaChip>}
+            {audio && <MediaChip>{audio}</MediaChip>}
+            {codec && <MediaChip tone="blue">{codec}</MediaChip>}
+            {main10 && <MediaChip tone="purple">Main 10</MediaChip>}
+            {audioCodec && <MediaChip tone="muted">{audioCodec}</MediaChip>}
+          </Box>
+        )}
       </Box>
       <Button
         variant="outlined"
@@ -48,4 +64,14 @@ export default function SessionContext({session, onChangeSession, changeDisabled
       </Button>
     </Box>
   )
+}
+
+function MediaChip({children, tone = 'default'}) {
+  const colors = {
+    default: {color: '#ffd9b0', background: 'rgba(255,115,0,0.12)', border: 'rgba(255,115,0,0.32)'},
+    blue: {color: '#cfe3ff', background: 'rgba(73,121,193,0.14)', border: 'rgba(143,184,255,0.32)'},
+    purple: {color: '#d9c6ff', background: 'rgba(137,98,201,0.15)', border: 'rgba(185,151,246,0.38)'},
+    muted: {color: '#d6dbe5', background: 'rgba(255,255,255,0.06)', border: 'rgba(255,255,255,0.14)'},
+  }[tone]
+  return <Box sx={{px: 1, py: 0.25, borderRadius: 999, fontSize: '0.68rem', fontWeight: 700, letterSpacing: '0.04em', fontFamily: 'var(--cs-mono-font)', color: colors.color, backgroundColor: colors.background, border: `1px solid ${colors.border}`}}>{children}</Box>
 }

--- a/frontend/src/components/SessionPicker.js
+++ b/frontend/src/components/SessionPicker.js
@@ -1,6 +1,7 @@
-import {Box, Button, Card, CardActionArea, CardContent, CardMedia, Grid, LinearProgress, Typography} from "@mui/material";
+import {Box, Button, Card, CardContent, Grid} from "@mui/material";
 import {useMemo} from "react";
 import StateMessage from "./StateMessage";
+import SessionCard from "./SessionCard";
 
 const visuallyHidden = {
   position: 'absolute',
@@ -14,383 +15,104 @@ const visuallyHidden = {
   border: 0,
 };
 
-function millisToDuration(millis) {
-  const hours = Math.floor(millis / 1000 / 60 / 60)
-  const minutes = Math.floor(millis / 1000 / 60) % 60
-  const seconds = Math.floor(millis / 1000) % 60
-  return String(hours).padStart(2, '0') + ':' + String(minutes).padStart(2, '0') + ':' + String(seconds).padStart(2, '0')
+// Stable owned-first ordering: owned sessions surface first so the user's own
+// sessions lead the scan, while the original relative order is preserved within
+// each group (stable partition, no secondary sort key). Exported so the
+// unified source picker can share the exact same ordering.
+export function orderSessionsOwnedFirst(sessions) {
+  if (!sessions) return sessions
+  const ordered = sessions.reduce((acc, session) => {
+    (session.ownedByCurrentUser === true ? acc.owned : acc.rest).push(session)
+    return acc
+  }, {owned: [], rest: []})
+  return [...ordered.owned, ...ordered.rest]
 }
 
-function getVideoName(session) {
-  if (session.type === "episode") {
-    return {
-      top: session.grandparentTitle,
-      bottom: `S${String(session.parentIndex).padStart(2, '0')}E${String(session.index).padStart(2, '0')} ${session.title}`,
-    }
-  }
-  return {top: `${session.title}`, bottom: session.year ? `(${session.year})` : ''}
-}
-
-// Map Plex player state → a colored status dot + short label. All states are
-// existing fields from the session API; nothing is invented.
-function getPlayerState(state) {
-  switch (state) {
-    case 'playing': return {color: '#7fd391', label: 'Playing'}
-    case 'paused': return {color: '#ffd9a0', label: 'Paused'}
-    case 'buffering': return {color: '#8fb8ff', label: 'Buffering'}
-    default: return null
-  }
-}
-
-// Audio channels → human layout. The API delivers a channel count; the 5.1/7.1
-// mapping is the standard industry convention (5.1 = 6 channels incl. LFE),
-// not an inferred detail. Defensive for missing/odd values.
-function audioLayoutLabel(channels) {
-  if (channels == null) return null
-  const n = Number(channels)
-  if (!Number.isFinite(n) || n <= 0) return null
-  if (n === 1) return '1.0'
-  if (n === 2) return '2.0'
-  if (n === 6) return '5.1'
-  if (n === 8) return '7.1'
-  return `${n}ch`
-}
-
-// Resolution → tidy uppercase chip text. Plex sends values like "4k", "1080",
-// "720", "sd". Uppercase the raw value; do not synthesize a "p" suffix since
-// the API does not distinguish interlaced vs progressive.
-function resolutionLabel(res) {
-  if (!res) return null
-  const s = String(res).trim()
-  return s ? s.toUpperCase() : null
-}
-
-// Combine resolution + audio layout into one compact quality summary, e.g.
-// "1080 · 5.1". Each part optional; returns null when neither is present so
-// the pill can be omitted entirely.
-function qualitySummary(res, audio) {
-  const parts = [res, audio].filter(Boolean)
-  return parts.length ? parts.join(' · ') : null
-}
-
-// Session.location ("lan" | "wan") → local/remote label.
-function locationLabel(loc) {
-  if (loc === 'lan') return 'Local'
-  if (loc === 'wan') return 'Remote'
-  return null
-}
-
-// Inline film placeholder — used when neither thumb nor grandparentThumb is
-// available, so the card never emits a broken image request.
-function FilmPlaceholder() {
+// Loading skeleton grid — exported so the unified picker reuses the exact
+// same placeholder cards during the initial session load.
+export function SessionLoadingGrid() {
   return (
-    <Box sx={{
-      position: 'absolute', inset: 0, display: 'grid', placeItems: 'center',
-      background: 'linear-gradient(135deg, #1b1e26, #11141a)',
-    }}>
-      <svg viewBox="0 0 24 24" width="42" height="42" fill="none" stroke="rgba(255,255,255,0.18)"
-        strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
-        <rect x="3" y="4" width="18" height="16" rx="2"/>
-        <path d="M3 9h18M3 15h18M8 4v16M16 4v16"/>
-      </svg>
-    </Box>
+    <>
+      <Box component="span" role="status" aria-live="polite" sx={visuallyHidden}>
+        Loading sessions…
+      </Box>
+      <Grid
+        container
+        spacing={3}
+        sx={{mx: 'auto', px: {xs: 2, sm: 3}}}
+        aria-busy="true"
+        aria-label="Loading active Plex sessions"
+      >
+        {[0, 1, 2, 3, 4, 5].map(i => (
+          <Grid item xs={12} sm={6} md={4} key={i}>
+            <Card sx={{height: '100%', display: 'flex', flexDirection: 'column', overflow: 'hidden'}}>
+              <Box sx={{
+                width: '100%', aspectRatio: '16 / 9', flexShrink: 0,
+                background: 'linear-gradient(110deg,#222633,#1b1e26)',
+                borderBottom: '1px solid rgba(255,255,255,0.06)',
+              }}/>
+              <CardContent sx={{display: 'flex', flexDirection: 'column', gap: 1.25}}>
+                <Box sx={{height: 24, width: '76%', borderRadius: 1, background: '#2a2f3a'}}/>
+                <Box sx={{height: 16, width: '42%', borderRadius: 1, background: '#232733', mb: 0.5}}/>
+                <Box sx={{height: 6, width: '100%', borderRadius: 999, background: '#232733', mb: 0.75}}/>
+                <Box sx={{height: 8, width: '38%', borderRadius: 999, background: '#2a2f3a'}}/>
+                <Box sx={{height: 12, width: '64%', borderRadius: 1, background: '#232733', mt: 0.5}}/>
+              </CardContent>
+            </Card>
+          </Grid>
+        ))}
+      </Grid>
+    </>
+  )
+}
+
+// Session error state — exported for reuse in the unified picker.
+export function SessionErrorState({onRetry}) {
+  return (
+    <StateMessage
+      variant="error"
+      title="Couldn’t load your Plex sessions."
+      hint="Check that the CutScene server is reachable and Plex is linked."
+      live
+      action={onRetry && (
+        <Button variant="outlined" color="primary" size="small" onClick={onRetry}
+          sx={{mt: 1, borderColor: 'rgba(255,255,255,0.2)'}}>
+          Try again
+        </Button>
+      )}
+    />
+  )
+}
+
+// No-sessions empty state — exported for reuse in the unified picker.
+export function SessionEmptyState() {
+  return (
+    <StateMessage
+      variant="empty"
+      title="No active Plex sessions."
+      hint="Start playing something in Plex and it will appear here."
+      live
+    />
   )
 }
 
 export default function SessionPicker({sessions, loading, error, selectedKey, onSelect, onRetry}) {
-  // Stable owned-first ordering: owned sessions surface first so the user's
-  // own sessions lead the scan, while the original relative order is preserved
-  // within each group (stable partition, no secondary sort key). This hook must
-  // run before every conditional return.
-  const orderedSessions = useMemo(() => {
-    if (!sessions) return sessions
-    return sessions.reduce((acc, session) => {
-      (session.ownedByCurrentUser === true ? acc.owned : acc.rest).push(session)
-      return acc
-    }, {owned: [], rest: []})
-  }, [sessions])
-  const sortedSessions = orderedSessions ? [...orderedSessions.owned, ...orderedSessions.rest] : orderedSessions
+  const sortedSessions = useMemo(() => orderSessionsOwnedFirst(sessions), [sessions])
 
-  if (loading) {
-    return (
-      <>
-        <Box component="span" role="status" aria-live="polite" sx={visuallyHidden}>
-          Loading sessions…
-        </Box>
-        <Grid
-          container
-          spacing={3}
-          sx={{mx: 'auto', px: {xs: 2, sm: 3}}}
-          aria-busy="true"
-          aria-label="Loading active Plex sessions"
-        >
-          {[0, 1, 2, 3, 4, 5].map(i => (
-            <Grid item xs={12} sm={6} md={4} key={i}>
-              <Card sx={{height: '100%', display: 'flex', flexDirection: 'column', overflow: 'hidden'}}>
-                <Box sx={{
-                  width: '100%', aspectRatio: '16 / 9', flexShrink: 0,
-                  background: 'linear-gradient(110deg,#222633,#1b1e26)',
-                  borderBottom: '1px solid rgba(255,255,255,0.06)',
-                }}/>
-                <CardContent sx={{display: 'flex', flexDirection: 'column', gap: 1.25}}>
-                  <Box sx={{height: 24, width: '76%', borderRadius: 1, background: '#2a2f3a'}}/>
-                  <Box sx={{height: 16, width: '42%', borderRadius: 1, background: '#232733', mb: 0.5}}/>
-                  <Box sx={{height: 6, width: '100%', borderRadius: 999, background: '#232733', mb: 0.75}}/>
-                  <Box sx={{height: 8, width: '38%', borderRadius: 999, background: '#2a2f3a'}}/>
-                  <Box sx={{height: 12, width: '64%', borderRadius: 1, background: '#232733', mt: 0.5}}/>
-                </CardContent>
-              </Card>
-            </Grid>
-          ))}
-        </Grid>
-      </>
-    )
-  }
-
-  if (error) {
-    return (
-      <StateMessage
-        variant="error"
-        title="Couldn’t load your Plex sessions."
-        hint="Check that the CutScene server is reachable and Plex is linked."
-        live
-        action={onRetry && (
-          <Button variant="outlined" color="primary" size="small" onClick={onRetry}
-            sx={{mt: 1, borderColor: 'rgba(255,255,255,0.2)'}}>
-            Try again
-          </Button>
-        )}
-      />
-    )
-  }
-
-  if (!sessions || sessions.length === 0) {
-    return (
-      <StateMessage
-        variant="empty"
-        title="No active Plex sessions."
-        hint="Start playing something in Plex and it will appear here."
-        live
-      />
-    )
-  }
+  if (loading) return <SessionLoadingGrid/>
+  if (error) return <SessionErrorState onRetry={onRetry}/>
+  if (!sessions || sessions.length === 0) return <SessionEmptyState/>
 
   return (
     <Grid container spacing={3} sx={{mx: 'auto', px: {xs: 2, sm: 3}}}>
-      {sortedSessions.map((session, index) => {
-        const name = getVideoName(session)
-        const active = session.ratingKey === selectedKey
-        // The session API tags sessions owned by the current user with
-        // `ownedByCurrentUser: true`. Treat absent/false as not owned so the
-        // UI degrades gracefully when the field isn't supplied.
-        const owned = session.ownedByCurrentUser === true
-
-        // Existing session metadata, surfaced defensively — each is optional.
-        const duration = session.duration
-        const viewOffset = session.viewOffset
-        const hasProgress = duration != null && viewOffset != null && duration > 0
-        const progressPct = hasProgress ? Math.min(100, Math.max(0, (viewOffset / duration) * 100)) : 0
-        const playerState = getPlayerState(session.Player?.state)
-        const playerTitle = session.Player?.title
-        const res = resolutionLabel(session.Media?.[0]?.videoResolution)
-        const audio = audioLayoutLabel(session.Media?.[0]?.audioChannels)
-        const quality = qualitySummary(res, audio)
-        const loc = locationLabel(session.Session?.location)
-        const userTitle = session.User?.title
-        // Thumbnail: episode still first, fall back to the show poster
-        // (grandparentThumb) when the episode has no art. If neither exists,
-        // render a placeholder instead of a broken image request.
-        const thumbPath = session.thumb || session.grandparentThumb || null
-
-        // Muted footer line — supporting context, dot-separated. The user is
-        // omitted on owned cards because the "Your session" badge already
-        // conveys ownership; showing your own name would be redundant.
-        const footerParts = []
-        if (!owned && userTitle) footerParts.push(userTitle)
-        if (playerTitle) footerParts.push(playerTitle)
-        if (loc) footerParts.push(loc)
-        const footer = footerParts.join('  ·  ')
-
-        return (
-          <Grid item xs={12} sm={6} md={4} key={session.ratingKey}>
-            <Card
-              sx={{
-                height: '100%',
-                position: 'relative',
-                display: 'flex',
-                flexDirection: 'column',
-                overflow: 'hidden',
-                transition: 'transform 180ms ease, border-color 180ms ease, box-shadow 180ms ease',
-                borderColor: active
-                  ? 'rgba(255,115,0,0.6)'
-                  : owned ? 'rgba(255,115,0,0.4)' : 'rgba(255,255,255,0.08)',
-                // Owned cards get a stronger warm wash — a richer gradient that
-                // reads at a glance, plus a faint inset ring so the highlight
-                // has structure without competing with the selected state's
-                // stronger border + shadow. Selected/active stays dominant.
-                background: owned
-                  ? 'linear-gradient(180deg, rgba(255,115,0,0.13), rgba(255,115,0,0.02) 68%, rgba(255,115,0,0) 100%)'
-                  : undefined,
-                boxShadow: active
-                  ? '0 14px 40px -22px rgba(255,115,0,0.7)'
-                  : owned ? '0 10px 30px -22px rgba(255,115,0,0.45)' : undefined,
-                '&:hover': {transform: 'translateY(-2px)', borderColor: 'rgba(255,115,0,0.4)'},
-              }}
-            >
-              <CardActionArea
-                onClick={() => onSelect(session)}
-                data-owned={owned ? 'true' : undefined}
-                aria-label={owned ? `Your session. ${name.top}${name.bottom ? ' ' + name.bottom : ''}` : undefined}
-                sx={{
-                  display: 'flex', flexDirection: 'column', alignItems: 'stretch', height: '100%',
-                  // Explicit, accessible focus ring — the default ripple is hard
-                  // to see on the dark background.
-                  '&.Mui-focusVisible, &:focus-visible': {
-                    outline: '2px solid #ff7300',
-                    outlineOffset: '2px',
-                  },
-                }}
-                focusRipple
-              >
-                {/* Thumbnail — full-width 16:9, with graceful fallback */}
-                <Box sx={{position: 'relative', width: '100%', aspectRatio: '16 / 9', background: '#11141a', flexShrink: 0}}>
-                  {thumbPath ? (
-                    <CardMedia
-                      component="img"
-                      sx={{position: 'absolute', inset: 0, width: '100%', height: '100%', objectFit: 'cover'}}
-                      image={`/thumb?path=${thumbPath}`}
-                      alt=""
-                    />
-                  ) : (
-                    <FilmPlaceholder/>
-                  )}
-                  {/* Player state dot — bottom-left over the thumbnail */}
-                  {playerState && (
-                    <Box
-                      sx={{
-                        position: 'absolute', left: 10, bottom: 10, zIndex: 1, pointerEvents: 'none',
-                        display: 'inline-flex', alignItems: 'center', gap: 0.75,
-                        px: 1, py: 0.4, borderRadius: 999,
-                        backgroundColor: 'rgba(13,15,20,0.72)',
-                        backdropFilter: 'blur(4px)',
-                      }}
-                    >
-                      <Box sx={{
-                        width: 8, height: 8, borderRadius: '50%',
-                        backgroundColor: playerState.color,
-                        boxShadow: `0 0 8px ${playerState.color}`,
-                      }}/>
-                      <Typography
-                        component="span"
-                        sx={{
-                          fontSize: '0.66rem', fontWeight: 700, letterSpacing: '0.06em',
-                          textTransform: 'uppercase', lineHeight: 1, color: 'rgba(255,255,255,0.92)',
-                        }}
-                      >
-                        {playerState.label}
-                      </Typography>
-                    </Box>
-                  )}
-                  {/* Your-session badge — top-right over the thumbnail */}
-                  {owned && (
-                    <Box
-                      sx={{
-                        position: 'absolute',
-                        top: 10,
-                        right: 10,
-                        zIndex: 1,
-                        pointerEvents: 'none',
-                        px: 1.25,
-                        py: 0.4,
-                        borderRadius: 999,
-                        fontSize: '0.7rem',
-                        fontWeight: 700,
-                        letterSpacing: '0.05em',
-                        textTransform: 'uppercase',
-                        lineHeight: 1,
-                        whiteSpace: 'nowrap',
-                        color: '#1a1206',
-                        backgroundColor: '#ff7300',
-                        boxShadow: '0 4px 14px -4px rgba(255,115,0,0.7)',
-                      }}
-                    >
-                      Your session
-                    </Box>
-                  )}
-                </Box>
-
-                <CardContent sx={{flex: 1, display: 'flex', flexDirection: 'column', gap: 1, p: 2, minWidth: 0}}>
-                  {/* Primary + secondary — full card width, one line each */}
-                  <Typography noWrap sx={{fontWeight: 700, fontSize: '1.08rem', lineHeight: 1.25}}>
-                    {name.top}
-                  </Typography>
-                  {name.bottom && (
-                    <Typography noWrap variant="body2" sx={{color: 'text.secondary', mt: -0.5}}>
-                      {name.bottom}
-                    </Typography>
-                  )}
-
-                  {/* Progress — viewOffset / duration, with times */}
-                  {hasProgress && (
-                    <Box sx={{mt: 0.5, minWidth: 0}}>
-                      <LinearProgress
-                        variant="determinate"
-                        value={progressPct}
-                        aria-hidden
-                        sx={{
-                          height: 6, borderRadius: 999,
-                          backgroundColor: 'rgba(255,255,255,0.08)',
-                          '& .MuiLinearProgress-bar': {
-                            borderRadius: 999,
-                            backgroundColor: '#ff7300',
-                          },
-                        }}
-                      />
-                      <Box sx={{display: 'flex', justifyContent: 'space-between', mt: 0.5, gap: 1}}>
-                        <Typography variant="caption" sx={{fontFamily: 'var(--cs-mono-font)', color: '#ff7300'}}>
-                          {millisToDuration(viewOffset)}
-                        </Typography>
-                        <Typography variant="caption" sx={{fontFamily: 'var(--cs-mono-font)', color: 'text.disabled'}}>
-                          {millisToDuration(duration)}
-                        </Typography>
-                      </Box>
-                    </Box>
-                  )}
-
-                  {/* Quality accent — resolution · audio layout, the most
-                      decision-useful technical signal (source quality you'll
-                      get). Accent-styled so it reads above the footer. */}
-                  {quality && (
-                    <Box sx={{
-                      alignSelf: 'flex-start',
-                      mt: 0.5,
-                      px: 1.25, py: 0.35,
-                      borderRadius: 999,
-                      fontSize: '0.72rem',
-                      fontWeight: 700,
-                      letterSpacing: '0.03em',
-                      fontFamily: 'var(--cs-mono-font)',
-                      whiteSpace: 'nowrap',
-                      color: '#ffd9b0',
-                      backgroundColor: 'rgba(255,115,0,0.12)',
-                      border: '1px solid rgba(255,115,0,0.32)',
-                    }}>
-                      {quality}
-                    </Box>
-                  )}
-
-                  {/* Footer — supporting context (who/where), muted */}
-                  {footer && (
-                    <Typography noWrap variant="caption" sx={{color: 'text.secondary', mt: 'auto', pt: 0.5}}>
-                      {footer}
-                    </Typography>
-                  )}
-                </CardContent>
-              </CardActionArea>
-            </Card>
-          </Grid>
-        )
-      })}
+      {sortedSessions.map(session => (
+        <SessionCard
+          key={session.ratingKey}
+          session={session}
+          active={session.ratingKey === selectedKey}
+          onSelect={onSelect}
+        />
+      ))}
     </Grid>
   )
 }

--- a/frontend/src/components/render-jobs.js
+++ b/frontend/src/components/render-jobs.js
@@ -46,10 +46,17 @@ export function audioModeLabel(value) {
 // `subtitleOffsetMs` shifts subtitle timing in the rendered output — positive
 // delays subtitles (later), negative advances them (earlier). It is always
 // present in the payload so the backend can rely on the field.
+//
+// `partId` is included only for explicit library sources (session._sourceType
+// === 'library'). Active-session sources omit it entirely so the backend
+// follows the legacy session-resolution path. A library source with an invalid
+// partId throws here rather than silently omitting the field — the backend
+// requires partId to resolve an explicit library source, so a silent omission
+// would route the request through the wrong (session-based) path.
 export function buildRenderJobRequest(session, startPosition, endPosition, selectedSubtitle, audioMode, subtitleOffsetMs) {
   const mediaId = normalizeMediaId(session?.Media?.[0]?.Part?.[0]?.id)
   if (mediaId == null) throw new Error('The selected media part has an invalid media ID.')
-  return {
+  const body = {
     ratingKey: session.ratingKey,
     mediaId,
     fromMs: startPosition,
@@ -58,13 +65,19 @@ export function buildRenderJobRequest(session, startPosition, endPosition, selec
     audioMode: audioMode || AUDIO_MODES.STANDARD,
     subtitleOffsetMs: clampSubtitleOffsetMs(subtitleOffsetMs),
   }
+  if (session?._sourceType === 'library') {
+    const partId = normalizePartId(session._partId)
+    if (partId == null) throw new Error('The selected library source has an invalid part ID.')
+    body.partId = partId
+  }
+  return body
 }
 
 // Build a request body from an immutable submitted spec (for re-render).
 export function buildRenderJobRequestFromSpec(spec) {
   const mediaId = normalizeMediaId(spec?.mediaId)
   if (mediaId == null) throw new Error('The submitted render job has an invalid media ID.')
-  return {
+  const body = {
     ratingKey: spec.ratingKey,
     mediaId,
     fromMs: spec.fromMs,
@@ -73,6 +86,16 @@ export function buildRenderJobRequestFromSpec(spec) {
     audioMode: spec.audioMode || AUDIO_MODES.STANDARD,
     subtitleOffsetMs: clampSubtitleOffsetMs(spec?.subtitleOffsetMs),
   }
+  // A library-source spec carries its partId; re-render must preserve it.
+  // Reject (rather than silently omit) if the spec claims to be a library
+  // source but lacks a valid partId — the backend needs it to resolve the
+  // source without an active session.
+  if (spec?.sourceType === 'library' || spec?.partId != null) {
+    const partId = normalizePartId(spec?.partId)
+    if (partId == null) throw new Error('The submitted render job has an invalid part ID.')
+    body.partId = partId
+  }
+  return body
 }
 
 // Plex may return Part ids as strings. Keep the API payload numeric and reject
@@ -81,6 +104,40 @@ export function normalizeMediaId(value) {
   if (value == null || (typeof value === 'string' && value.trim() === '')) return null
   const numeric = Number(value)
   return Number.isFinite(numeric) && Number.isInteger(numeric) ? numeric : null
+}
+
+// Like normalizeMediaId, but for the explicit library-source part id. Returns
+// null for absent/invalid values so callers can omit the field entirely.
+export function normalizePartId(value) {
+  if (value == null || value === '') return null
+  const numeric = Number(value)
+  return Number.isFinite(numeric) && Number.isInteger(numeric) && numeric > 0 ? numeric : null
+}
+
+// Library sources tag the selected session with `_sourceType: 'library'` and a
+// numeric `_partId`. Active sessions carry neither field, so they resolve to
+// null and the legacy request shape (no partId) is preserved. For library
+// sources, an invalid partId returns null — callers that must include partId
+// (buildRenderJobRequest) throw instead of silently omitting it.
+export function getSourcePartId(session) {
+  if (!session || session._sourceType !== 'library') return null
+  return normalizePartId(session._partId)
+}
+
+// Validate a backend LibrarySearchResult before accepting it as a clip source.
+// Returns a descriptive error string when the result is malformed, or null when
+// it is acceptable. The workspace cannot function without a usable ratingKey,
+// mediaId, and partId — rejecting up front prevents a broken workspace that
+// can't fetch streams, preview, or render.
+export function validateLibraryResult(result) {
+  if (!result || typeof result !== 'object') return 'This library result is malformed.'
+  const ratingKey = result.ratingKey
+  if (typeof ratingKey !== 'string' || ratingKey.trim() === '') return 'This library result is missing a rating key.'
+  const mediaId = normalizeMediaId(result.mediaId)
+  if (mediaId == null || mediaId <= 0) return 'This library result has an invalid media ID.'
+  const partId = normalizePartId(result.partId)
+  if (partId == null) return 'This library result has an invalid part ID.'
+  return null
 }
 
 // Whether an error code is a transport/polling issue (not a render failure).
@@ -98,6 +155,8 @@ export function snapshotJobSpec(session, startPosition, endPosition, selectedSub
   return {
     ratingKey: session.ratingKey,
     mediaId: normalizeMediaId(session?.Media?.[0]?.Part?.[0]?.id),
+    partId: getSourcePartId(session),
+    sourceType: session?._sourceType === 'library' ? 'library' : 'session',
     title: session.title || session.grandparentTitle || '',
     fromMs: startPosition,
     toMs: endPosition,

--- a/library_search.go
+++ b/library_search.go
@@ -190,7 +190,7 @@ func (a *Application) SearchLibrary(ctx context.Context, query string) ([]Librar
 		}
 
 		selectedItem := &item
-		media, part, sourceErr := selectLibraryMetadataSource(selectedItem, 0, false)
+		media, part, sourceErr := selectLibraryMetadataSourceForDiscovery(selectedItem)
 		if sourceErr != nil {
 			// Hub entries are often intentionally abbreviated. Re-fetch through
 			// the caller's PMS token before deciding that the item is not playable.
@@ -205,7 +205,7 @@ func (a *Application) SearchLibrary(ctx context.Context, query string) ([]Librar
 				}
 				continue
 			}
-			media, part, sourceErr = selectLibraryMetadataSource(selectedItem, 0, false)
+			media, part, sourceErr = selectLibraryMetadataSourceForDiscovery(selectedItem)
 		}
 		if sourceErr != nil || selectedItem == nil || media == nil || part == nil {
 			continue
@@ -213,7 +213,7 @@ func (a *Application) SearchLibrary(ctx context.Context, query string) ([]Librar
 		if !validPlayableLibraryMetadata(selectedItem, ratingKey, media, part) {
 			continue
 		}
-		if _, sourceErr = selectedSourceDuration(media, part); sourceErr != nil {
+		if duration, durationErr := selectedDiscoverySourceDuration(selectedItem, media, part); durationErr != nil || duration <= 0 {
 			continue
 		}
 		seen[ratingKey] = struct{}{}
@@ -238,12 +238,8 @@ func librarySearchResultFromMetadata(item *components.Metadata, media *component
 	result.Year = intValue(item.Year)
 	result.SeasonNumber = intValue(item.ParentIndex)
 	result.EpisodeNumber = intValue(item.Index)
-	if item.Duration != nil && *item.Duration > 0 {
-		result.Duration = int64(*item.Duration)
-	} else if media.Duration != nil && *media.Duration > 0 {
-		result.Duration = int64(*media.Duration)
-	} else if part.Duration != nil && *part.Duration > 0 {
-		result.Duration = int64(*part.Duration)
+	if duration, err := selectedDiscoverySourceDuration(item, media, part); err == nil {
+		result.Duration = duration
 	}
 	result.VideoResolution = stringValue(media.VideoResolution)
 	result.VideoCodec = stringValue(media.VideoCodec)
@@ -367,11 +363,11 @@ func (a *Application) GetLibraryMetadataChildren(ctx context.Context, ratingKey 
 		if episode == nil || !validLibraryNavigationMetadata(episode, childRatingKey, "episode") || !libraryChildBelongsTo(episode, ratingKey) {
 			continue
 		}
-		media, part, resolveErr := selectLibraryMetadataSource(episode, 0, false)
+		media, part, resolveErr := selectLibraryMetadataSourceForDiscovery(episode)
 		if resolveErr != nil || media == nil || part == nil || media.ID <= 0 || part.ID <= 0 {
 			continue
 		}
-		if _, resolveErr = selectedSourceDuration(media, part); resolveErr != nil {
+		if duration, durationErr := selectedDiscoverySourceDuration(episode, media, part); durationErr != nil || duration <= 0 {
 			continue
 		}
 		// Preserve hierarchy fields from the children listing when the detailed

--- a/library_search.go
+++ b/library_search.go
@@ -360,7 +360,10 @@ func (a *Application) GetLibraryMetadataChildren(ctx context.Context, ratingKey 
 			}
 			return nil, fetchErr
 		}
-		if episode == nil || !validLibraryNavigationMetadata(episode, childRatingKey, "episode") || !libraryChildBelongsTo(episode, ratingKey) {
+		// Containment was authorized from the /children listing above. Plex's
+		// detailed metadata may omit or rewrite ParentRatingKey, so do not apply
+		// that parent-key check a second time to the refetched episode.
+		if episode == nil || !validLibraryNavigationMetadata(episode, childRatingKey, "episode") {
 			continue
 		}
 		media, part, resolveErr := selectLibraryMetadataSourceForDiscovery(episode)

--- a/library_search.go
+++ b/library_search.go
@@ -60,6 +60,7 @@ type LibrarySearchResult struct {
 
 	VideoResolution string `json:"videoResolution,omitempty"`
 	VideoCodec      string `json:"videoCodec,omitempty"`
+	VideoProfile    string `json:"videoProfile,omitempty"`
 	AudioCodec      string `json:"audioCodec,omitempty"`
 	AudioChannels   int    `json:"audioChannels,omitempty"`
 	Container       string `json:"container,omitempty"`
@@ -243,6 +244,7 @@ func librarySearchResultFromMetadata(item *components.Metadata, media *component
 	}
 	result.VideoResolution = stringValue(media.VideoResolution)
 	result.VideoCodec = stringValue(media.VideoCodec)
+	result.VideoProfile = stringValue(media.VideoProfile)
 	result.AudioCodec = stringValue(media.AudioCodec)
 	if media.AudioChannels != nil {
 		result.AudioChannels = *media.AudioChannels

--- a/library_search.go
+++ b/library_search.go
@@ -1,0 +1,562 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/LukeHagar/plexgo/models/components"
+)
+
+const (
+	maxLibrarySearchQueryRunes = 128
+	maxLibrarySearchResults    = 50
+	maxLibrarySearchCandidates = 100
+	maxLibrarySearchRefetches  = 12
+	// Hierarchy is explicitly rejected above this aggregate cap rather than
+	// returning a silently truncated page. Phase 3B can add bounded paging.
+	maxLibraryChildren      = 100
+	librarySearchTimeout    = 10 * time.Second
+	libraryChildrenTimeout  = 10 * time.Second
+	maxLibraryResponseBytes = 8 << 20
+)
+
+// callerPlexHTTPClient never follows redirects. Plex tokens are credentials;
+// stopping at the redirect response is safer than relying on net/http's
+// redirect-header heuristics, and applies equally to search, metadata, and
+// hierarchy requests.
+var callerPlexHTTPClient = &http.Client{
+	Timeout: librarySearchTimeout,
+	CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+		return http.ErrUseLastResponse
+	},
+}
+
+// LibrarySearchResult is deliberately independent of Plex's hub response. It
+// is the stable, small contract used by callers to select a source. In
+// particular, it never exposes a Plex filesystem path.
+type LibrarySearchResult struct {
+	RatingKey            string `json:"ratingKey"`
+	MediaID              int64  `json:"mediaId,omitempty"`
+	PartID               int64  `json:"partId,omitempty"`
+	Title                string `json:"title"`
+	Type                 string `json:"type"`
+	Year                 *int   `json:"year,omitempty"`
+	GrandparentTitle     string `json:"grandparentTitle,omitempty"`
+	ParentTitle          string `json:"parentTitle,omitempty"`
+	ParentRatingKey      string `json:"parentRatingKey,omitempty"`
+	GrandparentRatingKey string `json:"grandparentRatingKey,omitempty"`
+	SeasonNumber         *int   `json:"seasonNumber,omitempty"`
+	EpisodeNumber        *int   `json:"episodeNumber,omitempty"`
+	Duration             int64  `json:"duration"`
+	Artwork              string `json:"artwork,omitempty"`
+
+	VideoResolution string `json:"videoResolution,omitempty"`
+	VideoCodec      string `json:"videoCodec,omitempty"`
+	AudioCodec      string `json:"audioCodec,omitempty"`
+	AudioChannels   int    `json:"audioChannels,omitempty"`
+	Container       string `json:"container,omitempty"`
+	Bitrate         int    `json:"bitrate,omitempty"`
+	Width           int    `json:"width,omitempty"`
+	Height          int    `json:"height,omitempty"`
+	FileSize        int64  `json:"fileSize,omitempty"`
+}
+
+type plexSearchResponse struct {
+	MediaContainer *struct {
+		Hub      []plexSearchHub       `json:"Hub,omitempty"`
+		Metadata []components.Metadata `json:"Metadata,omitempty"`
+	} `json:"MediaContainer"`
+}
+
+type plexSearchHub struct {
+	Metadata []components.Metadata `json:"Metadata,omitempty"`
+}
+
+type plexMetadataResponse struct {
+	MediaContainer *struct {
+		Metadata  []components.Metadata `json:"Metadata,omitempty"`
+		TotalSize int                   `json:"totalSize,omitempty"`
+		Offset    int                   `json:"offset,omitempty"`
+		Size      int                   `json:"size,omitempty"`
+	} `json:"MediaContainer"`
+}
+
+func validateLibrarySearchQuery(query string) (string, error) {
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return "", errors.New("query is required")
+	}
+	if !utf8.ValidString(query) || utf8.RuneCountInString(query) > maxLibrarySearchQueryRunes {
+		return "", fmt.Errorf("query must be between 1 and %d characters", maxLibrarySearchQueryRunes)
+	}
+	for _, r := range query {
+		if r < 0x20 || r == 0x7f {
+			return "", errors.New("query contains invalid characters")
+		}
+	}
+	return query, nil
+}
+
+func (a *Application) SearchLibrary(ctx context.Context, query string) ([]LibrarySearchResult, error) {
+	query, err := validateLibrarySearchQuery(query)
+	if err != nil {
+		return nil, err
+	}
+	token := AuthTokenFromContext(ctx)
+	if token == nil || strings.TrimSpace(*token) == "" {
+		return nil, errors.New("missing auth token")
+	}
+	searchCtx, cancel := context.WithTimeout(ctx, librarySearchTimeout)
+	defer cancel()
+
+	base, err := url.Parse(a.config.Plex.Host)
+	if err != nil || (base.Scheme != "http" && base.Scheme != "https") || base.Host == "" || base.User != nil {
+		return nil, errors.New("configured Plex origin is invalid")
+	}
+	base.Path = strings.TrimRight(base.Path, "/") + "/hubs/search"
+	values := base.Query()
+	values.Set("query", query)
+	values.Set("X-Plex-Container-Size", fmt.Sprintf("%d", maxLibrarySearchResults))
+	base.RawQuery = values.Encode()
+
+	req, err := http.NewRequestWithContext(searchCtx, http.MethodGet, base.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("X-Plex-Token", *token)
+	req.Header.Set("Accept", "application/json")
+	resp, err := callerPlexHTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("could not search Plex library: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("Plex library search returned status %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxLibraryResponseBytes))
+	if err != nil {
+		return nil, err
+	}
+	var search plexSearchResponse
+	if err := json.Unmarshal(body, &search); err != nil {
+		return nil, fmt.Errorf("could not decode Plex library search: %w", err)
+	}
+	if search.MediaContainer == nil {
+		return nil, errors.New("could not decode Plex library search: missing media container")
+	}
+
+	items := make([]components.Metadata, 0)
+	for _, hub := range search.MediaContainer.Hub {
+		items = append(items, hub.Metadata...)
+	}
+	// A few PMS versions return Metadata without Hub for a single result.
+	items = append(items, search.MediaContainer.Metadata...)
+
+	results := make([]LibrarySearchResult, 0, minInt(len(items), maxLibrarySearchResults))
+	seen := make(map[string]struct{})
+	refetches := 0
+	for candidate, item := range items {
+		if candidate >= maxLibrarySearchCandidates {
+			break
+		}
+		if len(results) >= maxLibrarySearchResults || (item.Type != "movie" && item.Type != "episode" && item.Type != "show") {
+			continue
+		}
+		ratingKey := stringValue(item.RatingKey)
+		if ratingKey == "" || item.Title == "" {
+			continue
+		}
+		if _, keyErr := validateLibraryRatingKey(ratingKey); keyErr != nil {
+			continue
+		}
+		if _, ok := seen[ratingKey]; ok {
+			continue
+		}
+		if item.Type == "show" {
+			if !validLibraryNavigationMetadata(&item, ratingKey, "show") {
+				continue
+			}
+			seen[ratingKey] = struct{}{}
+			results = append(results, libraryNavigationResultFromMetadata(&item))
+			continue
+		}
+
+		selectedItem := &item
+		media, part, sourceErr := selectLibraryMetadataSource(selectedItem, 0, false)
+		if sourceErr != nil {
+			// Hub entries are often intentionally abbreviated. Re-fetch through
+			// the caller's PMS token before deciding that the item is not playable.
+			if refetches >= maxLibrarySearchRefetches {
+				return nil, errors.New("library metadata detail resolution limit exceeded")
+			}
+			refetches++
+			selectedItem, sourceErr = a.getMetadataItem(searchCtx, ratingKey, true)
+			if sourceErr != nil {
+				if !isExplicitLibraryItemFailure(sourceErr) {
+					return nil, sourceErr
+				}
+				continue
+			}
+			media, part, sourceErr = selectLibraryMetadataSource(selectedItem, 0, false)
+		}
+		if sourceErr != nil || selectedItem == nil || media == nil || part == nil {
+			continue
+		}
+		if !validPlayableLibraryMetadata(selectedItem, ratingKey, media, part) {
+			continue
+		}
+		if _, sourceErr = selectedSourceDuration(media, part); sourceErr != nil {
+			continue
+		}
+		seen[ratingKey] = struct{}{}
+		results = append(results, librarySearchResultFromMetadata(selectedItem, media, part))
+	}
+	return results, nil
+}
+
+func librarySearchResultFromMetadata(item *components.Metadata, media *components.Media, part *components.Part) LibrarySearchResult {
+	result := LibrarySearchResult{
+		RatingKey: stringValue(item.RatingKey), MediaID: media.ID, PartID: part.ID,
+		Title: item.Title, Type: item.Type, GrandparentTitle: stringValue(item.GrandparentTitle),
+		ParentTitle: stringValue(item.ParentTitle), ParentRatingKey: stringValue(item.ParentRatingKey),
+		GrandparentRatingKey: stringValue(item.GrandparentRatingKey), Artwork: stringValue(item.Thumb),
+	}
+	if result.Artwork == "" {
+		result.Artwork = stringValue(item.GrandparentThumb)
+	}
+	if result.Artwork == "" {
+		result.Artwork = stringValue(item.Art)
+	}
+	result.Year = intValue(item.Year)
+	result.SeasonNumber = intValue(item.ParentIndex)
+	result.EpisodeNumber = intValue(item.Index)
+	if item.Duration != nil && *item.Duration > 0 {
+		result.Duration = int64(*item.Duration)
+	} else if media.Duration != nil && *media.Duration > 0 {
+		result.Duration = int64(*media.Duration)
+	} else if part.Duration != nil && *part.Duration > 0 {
+		result.Duration = int64(*part.Duration)
+	}
+	result.VideoResolution = stringValue(media.VideoResolution)
+	result.VideoCodec = stringValue(media.VideoCodec)
+	result.AudioCodec = stringValue(media.AudioCodec)
+	if media.AudioChannels != nil {
+		result.AudioChannels = *media.AudioChannels
+	}
+	result.Container = stringValue(media.Container)
+	if result.Container == "" {
+		result.Container = stringValue(part.Container)
+	}
+	if media.Bitrate != nil {
+		result.Bitrate = *media.Bitrate
+	}
+	if media.Width != nil {
+		result.Width = *media.Width
+	}
+	if media.Height != nil {
+		result.Height = *media.Height
+	}
+	if part.Size != nil {
+		result.FileSize = *part.Size
+	}
+	return result
+}
+
+// libraryNavigationResultFromMetadata deliberately copies only presentation
+// fields. Shows and seasons have no playable source and therefore never carry
+// media/part identifiers or Plex file paths in the public contract.
+func libraryNavigationResultFromMetadata(item *components.Metadata) LibrarySearchResult {
+	result := LibrarySearchResult{
+		RatingKey: stringValue(item.RatingKey), Title: item.Title, Type: item.Type,
+		GrandparentTitle: stringValue(item.GrandparentTitle), ParentTitle: stringValue(item.ParentTitle),
+		ParentRatingKey: stringValue(item.ParentRatingKey), GrandparentRatingKey: stringValue(item.GrandparentRatingKey),
+		Artwork: stringValue(item.Thumb), Year: intValue(item.Year),
+	}
+	if result.Artwork == "" {
+		result.Artwork = stringValue(item.GrandparentThumb)
+	}
+	if result.Artwork == "" {
+		result.Artwork = stringValue(item.Art)
+	}
+	switch item.Type {
+	case "show":
+		// Shows are navigation roots and have no episode coordinates.
+	case "season":
+		result.SeasonNumber = intValue(item.Index)
+	case "episode":
+		result.SeasonNumber = intValue(item.ParentIndex)
+		result.EpisodeNumber = intValue(item.Index)
+	}
+	return result
+}
+
+// GetLibraryMetadataChildren returns one level of a caller-visible Plex TV
+// hierarchy. Shows expose seasons and seasons expose playable episodes. The
+// Plex /children response is intentionally decoded into Metadata and then
+// reduced to LibrarySearchResult so Plex keys and local file paths never leak.
+func (a *Application) GetLibraryMetadataChildren(ctx context.Context, ratingKey string) ([]LibrarySearchResult, error) {
+	ratingKey, err := validateLibraryRatingKey(ratingKey)
+	if err != nil {
+		return nil, err
+	}
+	token := AuthTokenFromContext(ctx)
+	if token == nil || strings.TrimSpace(*token) == "" {
+		return nil, errors.New("missing auth token")
+	}
+
+	childrenCtx, cancel := context.WithTimeout(ctx, libraryChildrenTimeout)
+	defer cancel()
+	parent, err := a.getMetadataItem(childrenCtx, ratingKey, true)
+	if err != nil {
+		return nil, err
+	}
+	if parent == nil || (parent.Type != "show" && parent.Type != "season") {
+		return nil, &sourceValidationError{message: "requested media is not navigable"}
+	}
+
+	children, err := a.getLibraryChildren(childrenCtx, ratingKey, *token)
+	if err != nil {
+		return nil, err
+	}
+	results := make([]LibrarySearchResult, 0, len(children))
+	for i := range children {
+		child := &children[i]
+		childRatingKey := stringValue(child.RatingKey)
+		if childRatingKey == "" || len(childRatingKey) > 512 || child.Title == "" {
+			continue
+		}
+		if _, keyErr := validateLibraryRatingKey(childRatingKey); keyErr != nil {
+			continue
+		}
+		if !libraryChildBelongsTo(child, ratingKey) {
+			continue
+		}
+
+		if parent.Type == "show" {
+			if child.Type != "season" {
+				continue
+			}
+			result := libraryNavigationResultFromMetadata(child)
+			if result.SeasonNumber == nil {
+				continue
+			}
+			results = append(results, result)
+			continue
+		}
+
+		if child.Type != "episode" {
+			continue
+		}
+		// Hub/children entries are commonly abbreviated. Re-fetch each episode
+		// through the caller-scoped Plex client before resolving a playable Part.
+		episode, fetchErr := a.getMetadataItem(childrenCtx, childRatingKey, true)
+		if fetchErr != nil {
+			if isExplicitLibraryItemFailure(fetchErr) {
+				continue
+			}
+			return nil, fetchErr
+		}
+		if episode == nil || !validLibraryNavigationMetadata(episode, childRatingKey, "episode") || !libraryChildBelongsTo(episode, ratingKey) {
+			continue
+		}
+		media, part, resolveErr := selectLibraryMetadataSource(episode, 0, false)
+		if resolveErr != nil || media == nil || part == nil || media.ID <= 0 || part.ID <= 0 {
+			continue
+		}
+		if _, resolveErr = selectedSourceDuration(media, part); resolveErr != nil {
+			continue
+		}
+		// Preserve hierarchy fields from the children listing when the detailed
+		// metadata response omits them. This keeps season/episode numbering
+		// accurate without trusting any unvalidated child media fields.
+		epForResult := *episode
+		if epForResult.ParentIndex == nil {
+			epForResult.ParentIndex = intValue(child.ParentIndex)
+		}
+		if epForResult.Index == nil {
+			epForResult.Index = intValue(child.Index)
+		}
+		if epForResult.ParentTitle == nil {
+			epForResult.ParentTitle = stringPointerValue(child.ParentTitle)
+		}
+		if epForResult.GrandparentTitle == nil {
+			epForResult.GrandparentTitle = stringPointerValue(child.GrandparentTitle)
+		}
+		if epForResult.ParentRatingKey == nil {
+			epForResult.ParentRatingKey = stringPointerValue(child.ParentRatingKey)
+		}
+		if epForResult.GrandparentRatingKey == nil {
+			epForResult.GrandparentRatingKey = stringPointerValue(child.GrandparentRatingKey)
+		}
+		results = append(results, librarySearchResultFromMetadata(&epForResult, media, part))
+	}
+	return results, nil
+}
+
+func validateLibraryRatingKey(ratingKey string) (string, error) {
+	if ratingKey == "" || len(ratingKey) > 512 || !utf8.ValidString(ratingKey) {
+		return "", &sourceValidationError{message: "ratingKey is invalid"}
+	}
+	for _, r := range ratingKey {
+		if r < 0x20 || r == 0x7f || r == '/' || r == '\\' {
+			return "", &sourceValidationError{message: "ratingKey is invalid"}
+		}
+	}
+	return ratingKey, nil
+}
+
+func libraryChildBelongsTo(child *components.Metadata, parentRatingKey string) bool {
+	if child == nil {
+		return false
+	}
+	if parent := strings.TrimSpace(stringValue(child.ParentRatingKey)); parent != "" && parent != parentRatingKey {
+		return false
+	}
+	return true
+}
+
+func validLibraryNavigationMetadata(item *components.Metadata, requestedRatingKey, expectedType string) bool {
+	return item != nil && item.Type == expectedType && strings.TrimSpace(item.Title) != "" &&
+		stringValue(item.RatingKey) == requestedRatingKey
+}
+
+func validPlayableLibraryMetadata(item *components.Metadata, requestedRatingKey string, media *components.Media, part *components.Part) bool {
+	return item != nil && (item.Type == "movie" || item.Type == "episode") &&
+		strings.TrimSpace(item.Title) != "" && stringValue(item.RatingKey) == requestedRatingKey &&
+		media != nil && media.ID > 0 && part != nil && part.ID > 0
+}
+
+func isExplicitLibraryItemFailure(err error) bool {
+	var validationErr *sourceValidationError
+	if errors.As(err, &validationErr) {
+		return true
+	}
+	status := plexMetadataStatus(err)
+	return status == http.StatusBadRequest || status == http.StatusUnauthorized ||
+		status == http.StatusForbidden || status == http.StatusNotFound || status == http.StatusUnprocessableEntity
+}
+
+func stringPointerValue(value *string) *string {
+	if value == nil {
+		return nil
+	}
+	copy := *value
+	return &copy
+}
+
+func (a *Application) getLibraryChildren(ctx context.Context, ratingKey, token string) ([]components.Metadata, error) {
+	base, err := url.Parse(a.config.Plex.Host)
+	if err != nil || (base.Scheme != "http" && base.Scheme != "https") || base.Host == "" || base.User != nil {
+		return nil, errors.New("configured Plex origin is invalid")
+	}
+	base.Path = strings.TrimRight(base.Path, "/") + "/library/metadata/" + url.PathEscape(ratingKey) + "/children"
+	values := base.Query()
+	values.Set("X-Plex-Container-Size", fmt.Sprintf("%d", maxLibraryChildren))
+	values.Set("X-Plex-Container-Start", "0")
+	base.RawQuery = values.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, base.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("X-Plex-Token", token)
+	req.Header.Set("Accept", "application/json")
+	resp, err := callerPlexHTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("could not get Plex library children: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, &libraryHTTPError{status: resp.StatusCode}
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxLibraryResponseBytes))
+	if err != nil {
+		return nil, fmt.Errorf("could not read Plex library children: %w", err)
+	}
+	var response plexMetadataResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		return nil, fmt.Errorf("could not decode Plex library children: %w", err)
+	}
+	if response.MediaContainer == nil {
+		return nil, errors.New("could not decode Plex library children: missing media container")
+	}
+	if response.MediaContainer.Offset != 0 {
+		return nil, &sourceValidationError{message: "library hierarchy pagination is incomplete"}
+	}
+	if response.MediaContainer.TotalSize > maxLibraryChildren || len(response.MediaContainer.Metadata) > maxLibraryChildren {
+		return nil, &sourceValidationError{message: "requested hierarchy is too large"}
+	}
+	if response.MediaContainer.TotalSize > 0 && len(response.MediaContainer.Metadata) < response.MediaContainer.TotalSize {
+		return nil, &sourceValidationError{message: "library hierarchy pagination is incomplete"}
+	}
+	if response.MediaContainer.TotalSize == 0 && len(response.MediaContainer.Metadata) >= maxLibraryChildren {
+		return nil, &sourceValidationError{message: "library hierarchy pagination is incomplete"}
+	}
+	return response.MediaContainer.Metadata, nil
+}
+
+type libraryHTTPError struct{ status int }
+
+func (e *libraryHTTPError) Error() string {
+	return fmt.Sprintf("Plex library request returned status %d", e.status)
+}
+
+// getCallerMetadataItem is the caller-scoped metadata path. It is kept as a
+// small HTTP helper rather than relying on an SDK client's redirect policy, so
+// the no-redirect credential rule is enforced even for tests or callers that
+// construct an Application with a custom PlexGo client.
+func (a *Application) getCallerMetadataItem(ctx context.Context, ratingKey, token string) (*components.Metadata, error) {
+	base, err := url.Parse(a.config.Plex.Host)
+	if err != nil || (base.Scheme != "http" && base.Scheme != "https") || base.Host == "" || base.User != nil {
+		return nil, errors.New("configured Plex origin is invalid")
+	}
+	base.Path = strings.TrimRight(base.Path, "/") + "/library/metadata/" + url.PathEscape(ratingKey)
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, base.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	request.Header.Set("X-Plex-Token", token)
+	request.Header.Set("Accept", "application/json")
+	response, err := callerPlexHTTPClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("could not get Plex metadata: %w", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		return nil, &libraryHTTPError{status: response.StatusCode}
+	}
+	body, err := io.ReadAll(io.LimitReader(response.Body, maxLibraryResponseBytes))
+	if err != nil {
+		return nil, fmt.Errorf("could not read Plex metadata: %w", err)
+	}
+	var decoded plexMetadataResponse
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		return nil, fmt.Errorf("could not decode Plex metadata: %w", err)
+	}
+	if decoded.MediaContainer == nil {
+		return nil, errors.New("could not decode Plex metadata: missing media container")
+	}
+	if len(decoded.MediaContainer.Metadata) == 0 {
+		return nil, &sourceValidationError{message: "requested media is unavailable"}
+	}
+	metadata := decoded.MediaContainer.Metadata[0]
+	if metadata.RatingKey == nil || *metadata.RatingKey == "" || *metadata.RatingKey != ratingKey {
+		return nil, &sourceValidationError{message: "requested media is unavailable"}
+	}
+	return &metadata, nil
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/library_search.go
+++ b/library_search.go
@@ -351,6 +351,16 @@ func (a *Application) GetLibraryMetadataChildren(ctx context.Context, ratingKey 
 		if child.Type != "episode" {
 			continue
 		}
+		// A complete /children item is already caller-scoped and has passed the
+		// listing containment check above. Use it directly when it is already
+		// clip-ready; Plex detail responses are not guaranteed to preserve the
+		// same parent-key representation.
+		if media, part, resolveErr := selectLibraryMetadataSourceForDiscovery(child); resolveErr == nil && media != nil && part != nil {
+			if duration, durationErr := selectedDiscoverySourceDuration(child, media, part); durationErr == nil && duration > 0 {
+				results = append(results, librarySearchResultFromMetadata(child, media, part))
+				continue
+			}
+		}
 		// Hub/children entries are commonly abbreviated. Re-fetch each episode
 		// through the caller-scoped Plex client before resolving a playable Part.
 		episode, fetchErr := a.getMetadataItem(childrenCtx, childRatingKey, true)

--- a/library_search.go
+++ b/library_search.go
@@ -196,7 +196,10 @@ func (a *Application) SearchLibrary(ctx context.Context, query string) ([]Librar
 			// Hub entries are often intentionally abbreviated. Re-fetch through
 			// the caller's PMS token before deciding that the item is not playable.
 			if refetches >= maxLibrarySearchRefetches {
-				return nil, errors.New("library metadata detail resolution limit exceeded")
+				// The detail budget is an intentional bound, not an upstream
+				// failure. Preserve the successfully resolved prefix rather than
+				// turning it into an all-or-nothing error response.
+				break
 			}
 			refetches++
 			selectedItem, sourceErr = a.getMetadataItem(searchCtx, ratingKey, true)

--- a/library_search_test.go
+++ b/library_search_test.go
@@ -320,7 +320,7 @@ func TestLibraryMetadataChildrenTrustsValidatedListingContainment(t *testing.T) 
 		case "/library/metadata/season-1":
 			_, _ = io.WriteString(w, `{"MediaContainer":{"Metadata":[{"ratingKey":"season-1","type":"season","title":"Season 1","index":1}]}}`)
 		case "/library/metadata/season-1/children":
-			_, _ = io.WriteString(w, `{"MediaContainer":{"Metadata":[{"ratingKey":"episode-missing-parent","type":"episode","title":"Missing parent","parentRatingKey":"season-1","index":1},{"ratingKey":"episode-different-parent","type":"episode","title":"Different parent","parentRatingKey":"season-1","index":2},{"ratingKey":"episode-invalid-listing-parent","type":"episode","title":"Invalid listing parent","parentRatingKey":"other-season","index":3}]}}`)
+			_, _ = io.WriteString(w, `{"MediaContainer":{"Metadata":[{"ratingKey":"episode-complete","type":"episode","title":"Complete listing","parentRatingKey":"season-1","index":0,"Media":[{"id":103,"Part":[{"id":203,"duration":1000,"key":"/library/parts/203/file"}]}]},{"ratingKey":"episode-missing-parent","type":"episode","title":"Missing parent","parentRatingKey":"season-1","index":1},{"ratingKey":"episode-different-parent","type":"episode","title":"Different parent","parentRatingKey":"season-1","index":2},{"ratingKey":"episode-invalid-listing-parent","type":"episode","title":"Invalid listing parent","parentRatingKey":"other-season","index":3}]}}`)
 		case "/library/metadata/episode-missing-parent":
 			_, _ = io.WriteString(w, `{"MediaContainer":{"Metadata":[{"ratingKey":"episode-missing-parent","type":"episode","title":"Missing parent","Media":[{"id":101,"Part":[{"id":201,"duration":1000,"key":"/library/parts/201/file"}]}]}]}}`)
 		case "/library/metadata/episode-different-parent":
@@ -337,10 +337,10 @@ func TestLibraryMetadataChildrenTrustsValidatedListingContainment(t *testing.T) 
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(results) != 2 {
-		t.Fatalf("listing containment results = %+v, want two valid episodes", results)
+	if len(results) != 3 {
+		t.Fatalf("listing containment results = %+v, want three valid episodes", results)
 	}
-	if results[0].RatingKey != "episode-missing-parent" || results[1].RatingKey != "episode-different-parent" {
+	if results[0].RatingKey != "episode-complete" || results[1].RatingKey != "episode-missing-parent" || results[2].RatingKey != "episode-different-parent" {
 		t.Fatalf("unexpected listing containment results = %+v", results)
 	}
 }

--- a/library_search_test.go
+++ b/library_search_test.go
@@ -1,0 +1,570 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/LukeHagar/plexgo"
+	"github.com/LukeHagar/plexgo/models/components"
+	"github.com/gofiber/fiber/v3"
+)
+
+func TestSearchLibraryUsesCallerTokenFiltersAndRefetchesHubs(t *testing.T) {
+	plex := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Plex-Token") != "user-token" {
+			t.Errorf("Plex token = %q, want caller token", r.Header.Get("X-Plex-Token"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/hubs/search":
+			if r.URL.Query().Get("query") != "space" {
+				t.Errorf("search query = %q", r.URL.Query().Get("query"))
+			}
+			_, _ = io.WriteString(w, `{"MediaContainer":{"Hub":[{"Metadata":[
+                {"ratingKey":"movie-1","type":"movie","title":"Space Movie","year":2024,"thumb":"/library/metadata/movie-1/thumb","Media":[{"id":11,"videoResolution":"1080","videoCodec":"h264","Part":[{"id":101,"key":"/library/parts/101/file","size":1234}]}]},
+                {"ratingKey":"show-1","type":"show","title":"Not clip-capable"},
+                {"ratingKey":"episode-1","type":"episode","title":"Pilot","grandparentTitle":"The Show","parentTitle":"Season 1","parentIndex":1,"index":1,"Media":[{"id":12,"Part":[{"id":102,"key":"/library/parts/102/file","duration":60000}]}]},
+                {"ratingKey":"movie-2","type":"movie","title":"Needs details"}
+            ]}]}}`)
+		case "/library/metadata/movie-2":
+			_, _ = io.WriteString(w, `{"MediaContainer":{"Metadata":[{"ratingKey":"movie-2","type":"movie","title":"Needs details","Media":[{"id":22,"duration":90000,"videoResolution":"4k","Part":[{"id":202,"key":"/library/parts/202/file","size":4567}]}]}]}}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer plex.Close()
+	config := Config{}
+	config.Plex.Host = plex.URL
+	app := &Application{config: config}
+	app.plexUser = plexgo.New(plexgo.WithServerURL(plex.URL), plexgo.WithSecuritySource(app.plexSecurityUserToken))
+	results, err := app.SearchLibrary(ContextWithAuthToken(context.Background(), "user-token"), " space ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 4 {
+		t.Fatalf("got %d results, want 4: %+v", len(results), results)
+	}
+	if results[0].RatingKey != "movie-1" || results[0].MediaID != 11 || results[0].PartID != 101 || results[0].FileSize != 1234 {
+		t.Fatalf("first result = %+v", results[0])
+	}
+	if results[1].RatingKey != "show-1" || results[1].Type != "show" || results[1].MediaID != 0 || results[1].PartID != 0 {
+		t.Fatalf("show result = %+v", results[1])
+	}
+	showJSON, err := json.Marshal(results[1])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(showJSON), `"mediaId"`) || strings.Contains(string(showJSON), `"partId"`) {
+		t.Fatalf("show result exposed playable IDs: %s", showJSON)
+	}
+	if results[2].RatingKey != "episode-1" || results[2].Type != "episode" || results[2].MediaID != 12 || results[2].PartID != 102 {
+		t.Fatalf("direct episode result = %+v", results[2])
+	}
+	if results[3].RatingKey != "movie-2" || results[3].MediaID != 22 || results[3].PartID != 202 || results[3].Duration != 90000 {
+		t.Fatalf("refetched result = %+v", results[3])
+	}
+}
+
+func TestSearchLibraryRequiresCallerTokenAndValidQuery(t *testing.T) {
+	app := &Application{}
+	if _, err := app.SearchLibrary(context.Background(), "movie"); err == nil {
+		t.Fatal("search without caller token was accepted")
+	}
+	ctx := ContextWithAuthToken(context.Background(), "user-token")
+	if _, err := app.SearchLibrary(ctx, "\n"); err == nil {
+		t.Fatal("control-character query was accepted")
+	}
+}
+
+func TestSearchLibraryPropagatesSystemicDetailFailures(t *testing.T) {
+	for _, testCase := range []struct {
+		name string
+		body string
+	}{
+		{name: "server error", body: "status"},
+		{name: "malformed metadata", body: "malformed"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			plex := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				if r.URL.Path == "/hubs/search" {
+					_, _ = io.WriteString(w, `{"MediaContainer":{"Hub":[{"Metadata":[{"ratingKey":"movie-1","type":"movie","title":"Movie"}]}]}}`)
+					return
+				}
+				if r.URL.Path == "/library/metadata/movie-1" {
+					if testCase.body == "status" {
+						w.WriteHeader(http.StatusBadGateway)
+						return
+					}
+					_, _ = io.WriteString(w, "{not-json")
+					return
+				}
+				http.NotFound(w, r)
+			}))
+			defer plex.Close()
+			config := Config{}
+			config.Plex.Host = plex.URL
+			app := &Application{config: config}
+			results, err := app.SearchLibrary(ContextWithAuthToken(context.Background(), "caller-token"), "movie")
+			if err == nil || results != nil {
+				t.Fatalf("results=%v err=%v; systemic detail failure returned partial success", results, err)
+			}
+		})
+	}
+}
+
+func TestLibrarySourceSelectionBindsPlayablePartForPreviewAndRender(t *testing.T) {
+	duration := 120000
+	metadata := &components.Metadata{
+		RatingKey: stringPointer("movie-1"), Type: "movie", Title: "Library movie",
+		Media: []components.Media{
+			{ID: 10, Duration: &duration, VideoProfile: stringPointer("main 10"), Part: []components.Part{{ID: 100, Key: "/bad"}}},
+			{ID: 11, Duration: &duration, Part: []components.Part{{ID: 101, Key: "/library/parts/101/file"}}},
+		},
+	}
+	media, part, err := selectLibraryMetadataSource(metadata, 101, true)
+	if err != nil || media.ID != 11 || part.ID != 101 {
+		t.Fatalf("library source = media=%v part=%v err=%v", media, part, err)
+	}
+	request := RenderJobCreateRequest{RatingKey: "movie-1", MediaID: 101, FromMs: 0, ToMs: 1000, SubtitleIndex: -1}
+	spec, err := validateRenderJobRequestWithMetadataAndItem(request, User{Uuid: "user-a"}, nil, metadata.Media, previewSessionSelection{mediaID: 11, partID: 101, selected: 101}, metadata)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if spec.PartKey != "/library/parts/101/file" || spec.Title != "Library movie" {
+		t.Fatalf("render source snapshot = %+v", spec)
+	}
+	if _, _, err := selectLibraryMetadataSource(metadata, 100, true); err == nil {
+		t.Fatal("main-10 source was accepted")
+	}
+}
+
+func TestSubtitleCacheIsolatedByValidatedCaller(t *testing.T) {
+	var streamRequests int
+	plex := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/library/metadata/movie-1":
+			_, _ = io.WriteString(w, `{"MediaContainer":{"Metadata":[{"ratingKey":"movie-1","type":"movie","title":"Movie","Media":[{"id":10,"Part":[{"id":200,"key":"/library/parts/200/file","Stream":[{"streamType":3,"key":"/library/streams/200","codec":"srt"}]}]}]}]}}`)
+		case "/library/streams/200":
+			streamRequests++
+			w.Header().Set("Content-Type", "text/plain")
+			_, _ = io.WriteString(w, "1\n00:00:01,000 --> 00:00:02,000\ncaller-specific\n")
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer plex.Close()
+	config := Config{}
+	config.Plex.Host = plex.URL
+	app := &Application{config: config, subtitleCache: newSubtitleCache(8)}
+	app.plexUser = plexgo.New(plexgo.WithServerURL(plex.URL), plexgo.WithSecuritySource(app.plexSecurityUserToken))
+	for _, user := range []User{{Uuid: "user-a"}, {Uuid: "user-b"}} {
+		ctx := ContextWithUser(ContextWithAuthToken(context.Background(), user.Uuid+"-token"), user)
+		entries, err := app.GetSubtitleEntries(ctx, "movie-1", "200", 0)
+		if err != nil || len(entries) != 1 || entries[0].Text != "caller-specific" {
+			t.Fatalf("caller %s subtitle result = %+v, %v", user.Uuid, entries, err)
+		}
+	}
+	if streamRequests != 2 {
+		t.Fatalf("subtitle cache crossed callers; stream requests = %d, want 2", streamRequests)
+	}
+}
+
+func TestExplicitPartRenderSkipsSessionStatusAndUsesCallerToken(t *testing.T) {
+	plex := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/status/sessions" {
+			t.Fatal("explicit library render called /status/sessions")
+		}
+		if r.Header.Get("X-Plex-Token") != "caller-token" {
+			t.Errorf("metadata token = %q, want caller-token", r.Header.Get("X-Plex-Token"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"MediaContainer":{"Metadata":[{"ratingKey":"movie-1","type":"movie","title":"Library movie","Media":[{"id":11,"duration":60000,"Part":[{"id":101,"key":"/library/parts/101/file","duration":60000}]}]}]}}`)
+	}))
+	defer plex.Close()
+	manager, err := newRenderJobManager(t.TempDir(), writeRenderOutput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer manager.stopAndWait()
+	config := Config{}
+	config.Plex.Host = plex.URL
+	config.Plex.Token = "admin-token"
+	application := &Application{config: config, plexUser: nil, renderJobs: manager}
+	application.plexUser = plexgo.New(plexgo.WithServerURL(plex.URL), plexgo.WithSecuritySource(application.plexSecurityUserToken))
+	api := &API{config: config, app: application}
+	httpApp := fiber.New()
+	httpApp.Post("/render", func(ctx fiber.Ctx) error {
+		userCtx := ContextWithUser(ContextWithAuthToken(context.Background(), "caller-token"), User{Uuid: "user-a"})
+		ctx.SetUserContext(userCtx)
+		return api.createRenderJob(ctx)
+	})
+	request := httptest.NewRequest(http.MethodPost, "/render", strings.NewReader(`{"ratingKey":"movie-1","mediaId":11,"partId":101,"fromMs":0,"toMs":1000}`))
+	request.Header.Set("Content-Type", "application/json")
+	response, err := httpApp.Test(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusAccepted {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("library render status = %d body=%s", response.StatusCode, body)
+	}
+}
+
+func TestMultipartSourceWithoutPartDurationIsRejected(t *testing.T) {
+	metadata := &components.Metadata{RatingKey: stringPointer("movie-1"), Type: "movie", Title: "Movie", Media: []components.Media{{ID: 1, Part: []components.Part{{ID: 2, Key: "/a"}, {ID: 3, Key: "/b"}}}}}
+	media, part, err := resolveLibraryMetadataSource(metadata, 1, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := selectedSourceDuration(media, part); err == nil {
+		t.Fatal("multipart source without selected part duration was accepted")
+	}
+}
+
+func stringPointer(value string) *string { return &value }
+
+func newHierarchyFixture(t *testing.T) *Application {
+	t.Helper()
+	plex := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("X-Plex-Token"); got != "caller-token" {
+			t.Errorf("%s token = %q, want caller-token", r.URL.Path, got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/library/metadata/show-1":
+			_, _ = io.WriteString(w, `{"MediaContainer":{"Metadata":[{"ratingKey":"show-1","type":"show","title":"The Show","thumb":"/library/metadata/show-1/thumb"}]}}`)
+		case "/library/metadata/show-1/children":
+			_, _ = io.WriteString(w, `{"MediaContainer":{"Metadata":[{"ratingKey":"season-1","type":"season","title":"Season 1","index":1,"parentRatingKey":"show-1","parentTitle":"The Show","thumb":"/library/metadata/season-1/thumb","Media":[{"id":999,"Part":[{"id":998,"key":"/library/parts/998/file"}]}]}]}}`)
+		case "/library/metadata/season-1":
+			_, _ = io.WriteString(w, `{"MediaContainer":{"Metadata":[{"ratingKey":"season-1","type":"season","title":"Season 1","index":1,"parentRatingKey":"show-1","parentTitle":"The Show"}]}}`)
+		case "/library/metadata/season-1/children":
+			_, _ = io.WriteString(w, `{"MediaContainer":{"Metadata":[{"ratingKey":"episode-1","type":"episode","title":"Pilot","index":2,"parentIndex":1,"parentRatingKey":"season-1","parentTitle":"Season 1","grandparentRatingKey":"show-1","grandparentTitle":"The Show"}]}}`)
+		case "/library/metadata/episode-1":
+			_, _ = io.WriteString(w, `{"MediaContainer":{"Metadata":[{"ratingKey":"episode-1","type":"episode","title":"Pilot","index":2,"parentIndex":1,"parentRatingKey":"season-1","parentTitle":"Season 1","grandparentRatingKey":"show-1","grandparentTitle":"The Show","Media":[{"id":21,"duration":60000,"Part":[{"id":31,"duration":60000,"accessible":true,"exists":true,"key":"/library/parts/31/file","size":42}]}]}]}}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(plex.Close)
+	config := Config{}
+	config.Plex.Host = plex.URL
+	app := &Application{config: config}
+	app.plexUser = plexgo.New(plexgo.WithServerURL(plex.URL), plexgo.WithSecuritySource(app.plexSecurityUserToken))
+	return app
+}
+
+func TestLibraryMetadataChildrenShowReturnsNonPlayableSeasons(t *testing.T) {
+	app := newHierarchyFixture(t)
+	seasons, err := app.GetLibraryMetadataChildren(ContextWithAuthToken(context.Background(), "caller-token"), "show-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(seasons) != 1 || seasons[0].Type != "season" || seasons[0].RatingKey != "season-1" || seasons[0].SeasonNumber == nil || *seasons[0].SeasonNumber != 1 {
+		t.Fatalf("season results = %+v", seasons)
+	}
+	if seasons[0].MediaID != 0 || seasons[0].PartID != 0 {
+		t.Fatalf("season became playable: %+v", seasons[0])
+	}
+	body, err := json.Marshal(seasons)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(body), "/library/parts/998/file") {
+		t.Fatalf("season response exposed a raw file path: %s", body)
+	}
+}
+
+func TestLibraryMetadataChildrenSeasonReturnsPlayableEpisodesWithoutRawPaths(t *testing.T) {
+	app := newHierarchyFixture(t)
+	episodes, err := app.GetLibraryMetadataChildren(ContextWithAuthToken(context.Background(), "caller-token"), "season-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(episodes) != 1 {
+		t.Fatalf("episode results = %+v", episodes)
+	}
+	episode := episodes[0]
+	if episode.Type != "episode" || episode.RatingKey != "episode-1" || episode.MediaID != 21 || episode.PartID != 31 || episode.SeasonNumber == nil || *episode.SeasonNumber != 1 || episode.EpisodeNumber == nil || *episode.EpisodeNumber != 2 {
+		t.Fatalf("normalized episode = %+v", episode)
+	}
+	body, err := json.Marshal([]LibrarySearchResult{episode})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(body), "/library/parts/31/file") {
+		t.Fatalf("hierarchy response exposed a raw file path: %s", body)
+	}
+}
+
+func TestLibraryMetadataChildrenSkipsInaccessibleEpisodesAndRejectsMovies(t *testing.T) {
+	plex := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/library/metadata/season-1":
+			_, _ = io.WriteString(w, `{"MediaContainer":{"Metadata":[{"ratingKey":"season-1","type":"season","title":"Season 1","index":1}]}}`)
+		case "/library/metadata/season-1/children":
+			_, _ = io.WriteString(w, `{"MediaContainer":{"Metadata":[{"ratingKey":"episode-bad","type":"episode","title":"Unavailable","index":1},{"ratingKey":"episode-good","type":"episode","title":"Available","index":2}]}}`)
+		case "/library/metadata/episode-bad":
+			_, _ = io.WriteString(w, `{"MediaContainer":{"Metadata":[{"ratingKey":"episode-bad","type":"episode","title":"Unavailable","Media":[{"id":41,"Part":[{"id":51,"accessible":false,"key":"/private/unavailable.mkv"}]}]}]}}`)
+		case "/library/metadata/episode-good":
+			_, _ = io.WriteString(w, `{"MediaContainer":{"Metadata":[{"ratingKey":"episode-good","type":"episode","title":"Available","index":2,"Media":[{"id":42,"Part":[{"id":52,"duration":1000,"key":"/library/parts/52/file"}]}]}]}}`)
+		case "/library/metadata/movie-1":
+			_, _ = io.WriteString(w, `{"MediaContainer":{"Metadata":[{"ratingKey":"movie-1","type":"movie","title":"Movie"}]}}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer plex.Close()
+	config := Config{}
+	config.Plex.Host = plex.URL
+	app := &Application{config: config}
+	app.plexUser = plexgo.New(plexgo.WithServerURL(plex.URL), plexgo.WithSecuritySource(app.plexSecurityUserToken))
+	ctx := ContextWithAuthToken(context.Background(), "caller-token")
+
+	episodes, err := app.GetLibraryMetadataChildren(ctx, "season-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(episodes) != 1 || episodes[0].RatingKey != "episode-good" || episodes[0].MediaID != 42 || episodes[0].PartID != 52 {
+		t.Fatalf("inaccessible episode was not filtered: %+v", episodes)
+	}
+	if _, err := app.GetLibraryMetadataChildren(ctx, "movie-1"); err == nil {
+		t.Fatal("movie was accepted as a navigable hierarchy parent")
+	}
+}
+
+func TestCallerLibraryRequestsDoNotForwardTokensAcrossRedirects(t *testing.T) {
+	var targetRequests int
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		targetRequests++
+		if got := r.Header.Get("X-Plex-Token"); got != "" {
+			t.Errorf("redirect target received caller token %q", got)
+		}
+		http.Error(w, "unexpected redirect follow", http.StatusInternalServerError)
+	}))
+	defer target.Close()
+	source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL+"/redirect-target", http.StatusFound)
+	}))
+	defer source.Close()
+
+	config := Config{}
+	config.Plex.Host = source.URL
+	app := &Application{config: config}
+	ctx := ContextWithAuthToken(context.Background(), "caller-token")
+	if _, err := app.SearchLibrary(ctx, "space"); err == nil {
+		t.Fatal("redirecting search unexpectedly succeeded")
+	}
+	if _, err := app.GetLibraryMetadataChildren(ctx, "show-1"); err == nil {
+		t.Fatal("redirecting metadata unexpectedly succeeded")
+	}
+	if targetRequests != 0 {
+		t.Fatalf("redirect target received %d requests; caller token crossed origin", targetRequests)
+	}
+}
+
+func TestLibraryMetadataChildrenPropagatesSystemicFailures(t *testing.T) {
+	for _, testCase := range []struct {
+		name string
+		body func(http.ResponseWriter, *http.Request)
+	}{
+		{name: "server error", body: func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+		}},
+		{name: "malformed JSON", body: func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, "{not-json")
+		}},
+		{name: "timeout", body: func(w http.ResponseWriter, r *http.Request) {
+			<-r.Context().Done()
+		}},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			plex := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/library/metadata/show-1" {
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = io.WriteString(w, `{"MediaContainer":{"Metadata":[{"ratingKey":"show-1","type":"show","title":"Show"}]}}`)
+					return
+				}
+				if r.URL.Path == "/library/metadata/show-1/children" {
+					testCase.body(w, r)
+					return
+				}
+				http.NotFound(w, r)
+			}))
+			defer plex.Close()
+			config := Config{}
+			config.Plex.Host = plex.URL
+			app := &Application{config: config}
+			ctx := ContextWithAuthToken(context.Background(), "caller-token")
+			if testCase.name == "timeout" {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithTimeout(ctx, 20*time.Millisecond)
+				defer cancel()
+			}
+			results, err := app.GetLibraryMetadataChildren(ctx, "show-1")
+			if err == nil || results != nil {
+				t.Fatalf("results=%v err=%v; systemic failure returned partial success", results, err)
+			}
+			if testCase.name == "timeout" && !errors.Is(err, context.DeadlineExceeded) {
+				t.Fatalf("timeout error = %v", err)
+			}
+		})
+	}
+}
+
+func TestLibraryMetadataChildrenRejectsOversizedPagination(t *testing.T) {
+	plex := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/library/metadata/show-1" {
+			_, _ = io.WriteString(w, `{"MediaContainer":{"Metadata":[{"ratingKey":"show-1","type":"show","title":"Show"}]}}`)
+			return
+		}
+		if r.URL.Path == "/library/metadata/show-1/children" {
+			_, _ = io.WriteString(w, `{"MediaContainer":{"totalSize":101,"offset":0,"size":100,"Metadata":[]}}`)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer plex.Close()
+	config := Config{}
+	config.Plex.Host = plex.URL
+	app := &Application{config: config}
+	results, err := app.GetLibraryMetadataChildren(ContextWithAuthToken(context.Background(), "caller-token"), "show-1")
+	if err == nil || results != nil {
+		t.Fatalf("oversized page results=%v err=%v; expected explicit rejection", results, err)
+	}
+	var validationErr *sourceValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("oversized page error = %T %v, want validation error", err, err)
+	}
+}
+
+func TestLibraryPlayableMetadataRejectsMalformedIdentityAndIDs(t *testing.T) {
+	duration := 1000
+	goodPart := &components.Part{ID: 2, Duration: &duration, Key: "/library/parts/2/file"}
+	tests := []struct {
+		name  string
+		item  *components.Metadata
+		media *components.Media
+		part  *components.Part
+	}{
+		{name: "wrong rating key", item: &components.Metadata{RatingKey: stringPointer("other"), Type: "movie", Title: "Movie"}, media: &components.Media{ID: 1}, part: goodPart},
+		{name: "wrong type", item: &components.Metadata{RatingKey: stringPointer("movie-1"), Type: "show", Title: "Show"}, media: &components.Media{ID: 1}, part: goodPart},
+		{name: "missing title", item: &components.Metadata{RatingKey: stringPointer("movie-1"), Type: "movie"}, media: &components.Media{ID: 1}, part: goodPart},
+		{name: "zero media ID", item: &components.Metadata{RatingKey: stringPointer("movie-1"), Type: "movie", Title: "Movie"}, media: &components.Media{ID: 0}, part: goodPart},
+		{name: "zero part ID", item: &components.Metadata{RatingKey: stringPointer("movie-1"), Type: "movie", Title: "Movie"}, media: &components.Media{ID: 1}, part: &components.Part{Key: "/library/parts/0/file"}},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			if validPlayableLibraryMetadata(testCase.item, "movie-1", testCase.media, testCase.part) {
+				t.Fatal("malformed metadata was accepted as playable")
+			}
+			if _, _, err := resolveLibraryMetadataSource(testCase.item, 0, 0); err == nil {
+				t.Fatal("canonical resolver accepted malformed metadata")
+			}
+		})
+	}
+}
+
+func TestLibraryHierarchyAPIAuthStatusAndSafeErrorEnvelope(t *testing.T) {
+	var seenTokens []string
+	plex := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenTokens = append(seenTokens, r.Header.Get("X-Plex-Token"))
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/library/metadata/show-1" {
+			_, _ = io.WriteString(w, `{"MediaContainer":{"Metadata":[{"ratingKey":"show-1","type":"show","title":"Show"}]}}`)
+			return
+		}
+		if r.URL.Path == "/library/metadata/show-1/children" {
+			w.WriteHeader(http.StatusBadGateway)
+			_, _ = io.WriteString(w, "upstream detail must not leak")
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer plex.Close()
+	config := Config{}
+	config.Plex.Host = plex.URL
+	application := &Application{config: config}
+	api := &API{app: application}
+
+	unauthenticated := fiber.New()
+	unauthenticated.Get("/library/metadata/:ratingKey/children", api.getLibraryMetadataChildren)
+	unauthenticatedResponse, err := unauthenticated.Test(httptest.NewRequest(http.MethodGet, "/library/metadata/show-1/children", nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if unauthenticatedResponse.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated status = %d, want 401", unauthenticatedResponse.StatusCode)
+	}
+	_ = unauthenticatedResponse.Body.Close()
+
+	authenticated := fiber.New()
+	authenticated.Get("/library/metadata/:ratingKey/children", func(ctx fiber.Ctx) error {
+		ctx.SetUserContext(ContextWithUser(ContextWithAuthToken(context.Background(), "caller-a"), User{Uuid: "user-a"}))
+		return api.getLibraryMetadataChildren(ctx)
+	})
+	response, err := authenticated.Test(httptest.NewRequest(http.MethodGet, "/library/metadata/show-1/children", nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("systemic hierarchy status = %d, want 503", response.StatusCode)
+	}
+	var envelope struct {
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&envelope); err != nil {
+		t.Fatal(err)
+	}
+	if envelope.Error.Code != "metadata_unavailable" || strings.Contains(envelope.Error.Message, "upstream detail") {
+		t.Fatalf("unsafe hierarchy error envelope = %+v", envelope.Error)
+	}
+	if len(seenTokens) != 2 || seenTokens[0] != "caller-a" || seenTokens[1] != "caller-a" {
+		t.Fatalf("hierarchy calls used unexpected tokens: %v", seenTokens)
+	}
+}
+
+func TestLibraryHierarchyUsesCurrentCallerTokenForEachRequest(t *testing.T) {
+	var seenTokens []string
+	plex := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenTokens = append(seenTokens, r.Header.Get("X-Plex-Token"))
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/library/metadata/show-1" {
+			_, _ = io.WriteString(w, `{"MediaContainer":{"Metadata":[{"ratingKey":"show-1","type":"show","title":"Show"}]}}`)
+			return
+		}
+		if r.URL.Path == "/library/metadata/show-1/children" {
+			_, _ = io.WriteString(w, `{"MediaContainer":{"totalSize":0,"offset":0,"Metadata":[]}}`)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer plex.Close()
+	config := Config{}
+	config.Plex.Host = plex.URL
+	app := &Application{config: config}
+	for _, token := range []string{"caller-a", "caller-b"} {
+		if results, err := app.GetLibraryMetadataChildren(ContextWithAuthToken(context.Background(), token), "show-1"); err != nil || len(results) != 0 {
+			t.Fatalf("caller %s results=%v err=%v", token, results, err)
+		}
+	}
+	if len(seenTokens) != 4 || seenTokens[0] != "caller-a" || seenTokens[1] != "caller-a" || seenTokens[2] != "caller-b" || seenTokens[3] != "caller-b" {
+		t.Fatalf("cross-caller token sequence = %v", seenTokens)
+	}
+}

--- a/library_search_test.go
+++ b/library_search_test.go
@@ -313,6 +313,38 @@ func TestLibraryMetadataChildrenSeasonReturnsPlayableEpisodesWithoutRawPaths(t *
 	}
 }
 
+func TestLibraryMetadataChildrenTrustsValidatedListingContainment(t *testing.T) {
+	plex := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/library/metadata/season-1":
+			_, _ = io.WriteString(w, `{"MediaContainer":{"Metadata":[{"ratingKey":"season-1","type":"season","title":"Season 1","index":1}]}}`)
+		case "/library/metadata/season-1/children":
+			_, _ = io.WriteString(w, `{"MediaContainer":{"Metadata":[{"ratingKey":"episode-missing-parent","type":"episode","title":"Missing parent","parentRatingKey":"season-1","index":1},{"ratingKey":"episode-different-parent","type":"episode","title":"Different parent","parentRatingKey":"season-1","index":2},{"ratingKey":"episode-invalid-listing-parent","type":"episode","title":"Invalid listing parent","parentRatingKey":"other-season","index":3}]}}`)
+		case "/library/metadata/episode-missing-parent":
+			_, _ = io.WriteString(w, `{"MediaContainer":{"Metadata":[{"ratingKey":"episode-missing-parent","type":"episode","title":"Missing parent","Media":[{"id":101,"Part":[{"id":201,"duration":1000,"key":"/library/parts/201/file"}]}]}]}}`)
+		case "/library/metadata/episode-different-parent":
+			_, _ = io.WriteString(w, `{"MediaContainer":{"Metadata":[{"ratingKey":"episode-different-parent","type":"episode","title":"Different parent","parentRatingKey":"another-season","Media":[{"id":102,"Part":[{"id":202,"duration":1000,"key":"/library/parts/202/file"}]}]}]}}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer plex.Close()
+	config := Config{}
+	config.Plex.Host = plex.URL
+	app := &Application{config: config}
+	results, err := app.GetLibraryMetadataChildren(ContextWithAuthToken(context.Background(), "caller-token"), "season-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("listing containment results = %+v, want two valid episodes", results)
+	}
+	if results[0].RatingKey != "episode-missing-parent" || results[1].RatingKey != "episode-different-parent" {
+		t.Fatalf("unexpected listing containment results = %+v", results)
+	}
+}
+
 func TestLibraryMetadataChildrenSkipsInaccessibleEpisodesAndRejectsMovies(t *testing.T) {
 	plex := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/library_search_test.go
+++ b/library_search_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -124,6 +125,45 @@ func TestSearchLibraryPropagatesSystemicDetailFailures(t *testing.T) {
 				t.Fatalf("results=%v err=%v; systemic detail failure returned partial success", results, err)
 			}
 		})
+	}
+}
+
+func TestSearchLibraryDetailRefetchBudgetPreservesResolvedResults(t *testing.T) {
+	plex := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/hubs/search" {
+			var hubs strings.Builder
+			hubs.WriteString(`{"MediaContainer":{"Hub":[{"Metadata":[`)
+			for i := 1; i <= maxLibrarySearchRefetches+1; i++ {
+				if i > 1 {
+					hubs.WriteString(",")
+				}
+				_, _ = fmt.Fprintf(&hubs, `{"ratingKey":"abbreviated-%d","type":"movie","title":"Movie %d"}`, i, i)
+			}
+			hubs.WriteString(`]}]}}`)
+			_, _ = io.WriteString(w, hubs.String())
+			return
+		}
+		if strings.HasPrefix(r.URL.Path, "/library/metadata/abbreviated-") {
+			key := strings.TrimPrefix(r.URL.Path, "/library/metadata/")
+			_, _ = fmt.Fprintf(w, `{"MediaContainer":{"Metadata":[{"ratingKey":%q,"type":"movie","title":%q,"Media":[{"id":1,"Part":[{"id":2,"duration":1000,"key":"/library/parts/2/file"}]}]}]}}`, key, key)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer plex.Close()
+	config := Config{}
+	config.Plex.Host = plex.URL
+	app := &Application{config: config}
+	results, err := app.SearchLibrary(ContextWithAuthToken(context.Background(), "caller-token"), "movies")
+	if err != nil {
+		t.Fatalf("search returned detail-budget error: %v", err)
+	}
+	if len(results) != maxLibrarySearchRefetches {
+		t.Fatalf("resolved results = %d, want %d: %+v", len(results), maxLibrarySearchRefetches, results)
+	}
+	if results[0].RatingKey != "abbreviated-1" || results[len(results)-1].RatingKey != fmt.Sprintf("abbreviated-%d", maxLibrarySearchRefetches) {
+		t.Fatalf("unexpected resolved result prefix: first=%q last=%q", results[0].RatingKey, results[len(results)-1].RatingKey)
 	}
 }
 

--- a/library_search_test.go
+++ b/library_search_test.go
@@ -28,7 +28,7 @@ func TestSearchLibraryUsesCallerTokenFiltersAndRefetchesHubs(t *testing.T) {
 				t.Errorf("search query = %q", r.URL.Query().Get("query"))
 			}
 			_, _ = io.WriteString(w, `{"MediaContainer":{"Hub":[{"Metadata":[
-                {"ratingKey":"movie-1","type":"movie","title":"Space Movie","year":2024,"thumb":"/library/metadata/movie-1/thumb","Media":[{"id":11,"videoResolution":"1080","videoCodec":"h264","Part":[{"id":101,"key":"/library/parts/101/file","size":1234}]}]},
+                {"ratingKey":"movie-1","type":"movie","title":"Space Movie","year":2024,"thumb":"/library/metadata/movie-1/thumb","Media":[{"id":10,"Part":[{"id":100,"key":"/library/parts/100/file"}]},{"id":11,"videoResolution":"1080","videoCodec":"h264","Part":[{"id":1011,"duration":60000,"key":"/library/parts/1011/file","size":1234}]}]},
                 {"ratingKey":"show-1","type":"show","title":"Not clip-capable"},
                 {"ratingKey":"episode-1","type":"episode","title":"Pilot","grandparentTitle":"The Show","parentTitle":"Season 1","parentIndex":1,"index":1,"Media":[{"id":12,"Part":[{"id":102,"key":"/library/parts/102/file","duration":60000}]}]},
                 {"ratingKey":"movie-2","type":"movie","title":"Needs details"}
@@ -51,7 +51,7 @@ func TestSearchLibraryUsesCallerTokenFiltersAndRefetchesHubs(t *testing.T) {
 	if len(results) != 4 {
 		t.Fatalf("got %d results, want 4: %+v", len(results), results)
 	}
-	if results[0].RatingKey != "movie-1" || results[0].MediaID != 11 || results[0].PartID != 101 || results[0].FileSize != 1234 {
+	if results[0].RatingKey != "movie-1" || results[0].MediaID != 11 || results[0].PartID != 1011 || results[0].Duration != 60000 || results[0].FileSize != 1234 {
 		t.Fatalf("first result = %+v", results[0])
 	}
 	if results[1].RatingKey != "show-1" || results[1].Type != "show" || results[1].MediaID != 0 || results[1].PartID != 0 {
@@ -221,13 +221,20 @@ func TestExplicitPartRenderSkipsSessionStatusAndUsesCallerToken(t *testing.T) {
 }
 
 func TestMultipartSourceWithoutPartDurationIsRejected(t *testing.T) {
-	metadata := &components.Metadata{RatingKey: stringPointer("movie-1"), Type: "movie", Title: "Movie", Media: []components.Media{{ID: 1, Part: []components.Part{{ID: 2, Key: "/a"}, {ID: 3, Key: "/b"}}}}}
+	duration := 2000
+	metadata := &components.Metadata{RatingKey: stringPointer("movie-1"), Type: "movie", Title: "Movie", Media: []components.Media{
+		{ID: 1, Part: []components.Part{{ID: 2, Key: "/a"}, {ID: 3, Key: "/b"}}},
+		{ID: 4, Part: []components.Part{{ID: 5, Duration: &duration, Key: "/later"}}},
+	}}
 	media, part, err := resolveLibraryMetadataSource(metadata, 1, 2)
 	if err != nil {
 		t.Fatal(err)
 	}
+	if media.ID != 1 || part.ID != 2 {
+		t.Fatalf("explicit source resolved to later candidate: media=%d part=%d", media.ID, part.ID)
+	}
 	if _, err := selectedSourceDuration(media, part); err == nil {
-		t.Fatal("multipart source without selected part duration was accepted")
+		t.Fatal("explicit unsafe part was accepted despite a later valid version")
 	}
 }
 
@@ -250,7 +257,7 @@ func newHierarchyFixture(t *testing.T) *Application {
 		case "/library/metadata/season-1/children":
 			_, _ = io.WriteString(w, `{"MediaContainer":{"Metadata":[{"ratingKey":"episode-1","type":"episode","title":"Pilot","index":2,"parentIndex":1,"parentRatingKey":"season-1","parentTitle":"Season 1","grandparentRatingKey":"show-1","grandparentTitle":"The Show"}]}}`)
 		case "/library/metadata/episode-1":
-			_, _ = io.WriteString(w, `{"MediaContainer":{"Metadata":[{"ratingKey":"episode-1","type":"episode","title":"Pilot","index":2,"parentIndex":1,"parentRatingKey":"season-1","parentTitle":"Season 1","grandparentRatingKey":"show-1","grandparentTitle":"The Show","Media":[{"id":21,"duration":60000,"Part":[{"id":31,"duration":60000,"accessible":true,"exists":true,"key":"/library/parts/31/file","size":42}]}]}]}}`)
+			_, _ = io.WriteString(w, `{"MediaContainer":{"Metadata":[{"ratingKey":"episode-1","type":"episode","title":"Pilot","duration":180000,"index":2,"parentIndex":1,"parentRatingKey":"season-1","parentTitle":"Season 1","grandparentRatingKey":"show-1","grandparentTitle":"The Show","Media":[{"id":21,"Part":[{"id":31,"accessible":true,"exists":true,"key":"/library/parts/31/file"},{"id":32,"accessible":true,"exists":true,"key":"/library/parts/32/file"}]},{"id":22,"duration":120000,"Part":[{"id":33,"duration":60000,"accessible":true,"exists":true,"key":"/library/parts/33/file","size":42}]}]}]}}`)
 		default:
 			http.NotFound(w, r)
 		}
@@ -294,14 +301,14 @@ func TestLibraryMetadataChildrenSeasonReturnsPlayableEpisodesWithoutRawPaths(t *
 		t.Fatalf("episode results = %+v", episodes)
 	}
 	episode := episodes[0]
-	if episode.Type != "episode" || episode.RatingKey != "episode-1" || episode.MediaID != 21 || episode.PartID != 31 || episode.SeasonNumber == nil || *episode.SeasonNumber != 1 || episode.EpisodeNumber == nil || *episode.EpisodeNumber != 2 {
+	if episode.Type != "episode" || episode.RatingKey != "episode-1" || episode.MediaID != 22 || episode.PartID != 33 || episode.Duration != 60000 || episode.SeasonNumber == nil || *episode.SeasonNumber != 1 || episode.EpisodeNumber == nil || *episode.EpisodeNumber != 2 {
 		t.Fatalf("normalized episode = %+v", episode)
 	}
 	body, err := json.Marshal([]LibrarySearchResult{episode})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if strings.Contains(string(body), "/library/parts/31/file") {
+	if strings.Contains(string(body), "/library/parts/31/file") || strings.Contains(string(body), "/library/parts/33/file") {
 		t.Fatalf("hierarchy response exposed a raw file path: %s", body)
 	}
 }

--- a/library_search_test.go
+++ b/library_search_test.go
@@ -28,7 +28,7 @@ func TestSearchLibraryUsesCallerTokenFiltersAndRefetchesHubs(t *testing.T) {
 				t.Errorf("search query = %q", r.URL.Query().Get("query"))
 			}
 			_, _ = io.WriteString(w, `{"MediaContainer":{"Hub":[{"Metadata":[
-                {"ratingKey":"movie-1","type":"movie","title":"Space Movie","year":2024,"thumb":"/library/metadata/movie-1/thumb","Media":[{"id":10,"Part":[{"id":100,"key":"/library/parts/100/file"}]},{"id":11,"videoResolution":"1080","videoCodec":"h264","Part":[{"id":1011,"duration":60000,"key":"/library/parts/1011/file","size":1234}]}]},
+                {"ratingKey":"movie-1","type":"movie","title":"Space Movie","year":2024,"thumb":"/library/metadata/movie-1/thumb","Media":[{"id":10,"Part":[{"id":100,"key":"/library/parts/100/file"}]},{"id":11,"videoProfile":"main 10","videoResolution":"1080","videoCodec":"h264","Part":[{"id":1011,"duration":60000,"key":"/library/parts/1011/file","size":1234}]}]},
                 {"ratingKey":"show-1","type":"show","title":"Not clip-capable"},
                 {"ratingKey":"episode-1","type":"episode","title":"Pilot","grandparentTitle":"The Show","parentTitle":"Season 1","parentIndex":1,"index":1,"Media":[{"id":12,"Part":[{"id":102,"key":"/library/parts/102/file","duration":60000}]}]},
                 {"ratingKey":"movie-2","type":"movie","title":"Needs details"}
@@ -141,8 +141,9 @@ func TestLibrarySourceSelectionBindsPlayablePartForPreviewAndRender(t *testing.T
 	if spec.PartKey != "/library/parts/101/file" || spec.Title != "Library movie" {
 		t.Fatalf("render source snapshot = %+v", spec)
 	}
-	if _, _, err := selectLibraryMetadataSource(metadata, 100, true); err == nil {
-		t.Fatal("main-10 source was accepted")
+	main10Media, main10Part, err := selectLibraryMetadataSource(metadata, 100, true)
+	if err != nil || main10Media.ID != 10 || main10Part.ID != 100 {
+		t.Fatalf("main-10 explicit source was not accepted: media=%v part=%v err=%v", main10Media, main10Part, err)
 	}
 }
 
@@ -257,7 +258,7 @@ func newHierarchyFixture(t *testing.T) *Application {
 		case "/library/metadata/season-1/children":
 			_, _ = io.WriteString(w, `{"MediaContainer":{"Metadata":[{"ratingKey":"episode-1","type":"episode","title":"Pilot","index":2,"parentIndex":1,"parentRatingKey":"season-1","parentTitle":"Season 1","grandparentRatingKey":"show-1","grandparentTitle":"The Show"}]}}`)
 		case "/library/metadata/episode-1":
-			_, _ = io.WriteString(w, `{"MediaContainer":{"Metadata":[{"ratingKey":"episode-1","type":"episode","title":"Pilot","duration":180000,"index":2,"parentIndex":1,"parentRatingKey":"season-1","parentTitle":"Season 1","grandparentRatingKey":"show-1","grandparentTitle":"The Show","Media":[{"id":21,"Part":[{"id":31,"accessible":true,"exists":true,"key":"/library/parts/31/file"},{"id":32,"accessible":true,"exists":true,"key":"/library/parts/32/file"}]},{"id":22,"duration":120000,"Part":[{"id":33,"duration":60000,"accessible":true,"exists":true,"key":"/library/parts/33/file","size":42}]}]}]}}`)
+			_, _ = io.WriteString(w, `{"MediaContainer":{"Metadata":[{"ratingKey":"episode-1","type":"episode","title":"Pilot","duration":180000,"index":2,"parentIndex":1,"parentRatingKey":"season-1","parentTitle":"Season 1","grandparentRatingKey":"show-1","grandparentTitle":"The Show","Media":[{"id":21,"Part":[{"id":31,"accessible":true,"exists":true,"key":"/library/parts/31/file"},{"id":32,"accessible":true,"exists":true,"key":"/library/parts/32/file"}]},{"id":22,"duration":120000,"videoProfile":"main 10","Part":[{"id":33,"duration":60000,"accessible":true,"exists":true,"key":"/library/parts/33/file","size":42}]}]}]}}`)
 		default:
 			http.NotFound(w, r)
 		}

--- a/library_search_test.go
+++ b/library_search_test.go
@@ -51,8 +51,15 @@ func TestSearchLibraryUsesCallerTokenFiltersAndRefetchesHubs(t *testing.T) {
 	if len(results) != 4 {
 		t.Fatalf("got %d results, want 4: %+v", len(results), results)
 	}
-	if results[0].RatingKey != "movie-1" || results[0].MediaID != 11 || results[0].PartID != 1011 || results[0].Duration != 60000 || results[0].FileSize != 1234 {
+	if results[0].RatingKey != "movie-1" || results[0].MediaID != 11 || results[0].PartID != 1011 || results[0].Duration != 60000 || results[0].FileSize != 1234 || results[0].VideoProfile != "main 10" {
 		t.Fatalf("first result = %+v", results[0])
+	}
+	movieJSON, err := json.Marshal(results[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(movieJSON), `"videoProfile":"main 10"`) {
+		t.Fatalf("search result omitted video profile: %s", movieJSON)
 	}
 	if results[1].RatingKey != "show-1" || results[1].Type != "show" || results[1].MediaID != 0 || results[1].PartID != 0 {
 		t.Fatalf("show result = %+v", results[1])

--- a/render_jobs.go
+++ b/render_jobs.go
@@ -24,7 +24,6 @@ import (
 	"unicode/utf8"
 
 	"github.com/LukeHagar/plexgo/models/components"
-	"github.com/LukeHagar/plexgo/models/operations"
 	"github.com/gofiber/fiber/v3"
 	"github.com/google/uuid"
 )
@@ -57,6 +56,7 @@ const (
 type RenderJobCreateRequest struct {
 	RatingKey        string    `json:"ratingKey"`
 	MediaID          int64     `json:"mediaId"`
+	PartID           *int64    `json:"partId,omitempty"`
 	FromMs           int64     `json:"fromMs"`
 	ToMs             int64     `json:"toMs"`
 	SubtitleIndex    int       `json:"subtitleIndex"`
@@ -68,8 +68,10 @@ type RenderJobCreateRequest struct {
 
 type renderJobSpec struct {
 	OwnerUUID             string
+	SourceToken           string
 	RatingKey             string
 	MediaID               int64
+	PartID                int64
 	PartKey               string
 	Title                 string
 	FromMs                int64
@@ -919,39 +921,54 @@ func (a *API) createRenderJob(ctx fiber.Ctx) error {
 	if _, err := parseAudioMode(string(request.AudioMode)); err != nil {
 		return renderAPIErrorCode(ctx, http.StatusUnprocessableEntity, "validation_error", "audioMode is invalid")
 	}
-
-	sessions, err := a.app.GetSessions(ctx.UserContext())
-	if err != nil {
-		log.Printf("render job session validation failed: %s", redactedDiagnostic(err))
-		ctx.Set("Retry-After", "5")
-		return renderAPIErrorCode(ctx, http.StatusServiceUnavailable, "session_unavailable", "could not validate the requested session")
-	}
-	selection, err := selectPreviewSessionSource(sessions, request.RatingKey, request.MediaID, true)
-	if err != nil {
+	if err := validateRenderJobRequestFields(request); err != nil {
 		return renderAPIErrorCode(ctx, http.StatusUnprocessableEntity, "validation_error", err.Error())
 	}
-	if a.app.plexAdmin == nil {
-		ctx.Set("Retry-After", "5")
-		return renderAPIErrorCode(ctx, http.StatusServiceUnavailable, "metadata_unavailable", "could not validate the requested media")
+
+	var sessions []sessionMetadata
+	var selection previewSessionSelection
+	userScoped := request.PartID != nil
+	var metadataItem *components.Metadata
+	if userScoped {
+		metadataItem, err = a.app.getMetadataItem(ctx.UserContext(), request.RatingKey, true)
+		if err == nil {
+			media, part, sourceErr := resolveLibraryMetadataSource(metadataItem, request.MediaID, *request.PartID)
+			if sourceErr != nil {
+				err = sourceErr
+			} else {
+				selection = previewSessionSelection{mediaID: media.ID, partID: part.ID, duration: mediaDurationFromSource(media, part), selected: part.ID}
+			}
+		}
+	} else {
+		sessions, err = a.app.GetSessions(ctx.UserContext())
+		if err != nil {
+			log.Printf("render job session validation failed: %s", redactedDiagnostic(err))
+			ctx.Set("Retry-After", "5")
+			return renderAPIErrorCode(ctx, http.StatusServiceUnavailable, "session_unavailable", "could not validate the requested session")
+		}
+		selection, err = selectPreviewSessionSource(sessions, request.RatingKey, request.MediaID, true)
+		if err != nil {
+			return renderAPIErrorCode(ctx, http.StatusUnprocessableEntity, "validation_error", err.Error())
+		}
+		metadataItem, err = a.app.getMetadataItem(ctx.UserContext(), request.RatingKey, false)
 	}
-	libraryMetadata, err := a.app.plexAdmin.Content.GetMetadataItem(ctx.UserContext(), operations.GetMetadataItemRequest{
-		Ids: []string{request.RatingKey},
-	})
 	if err != nil {
 		log.Printf("render job library metadata validation failed: %s", redactedDiagnostic(err))
-		ctx.Set("Retry-After", "5")
-		return renderAPIErrorCode(ctx, http.StatusServiceUnavailable, "metadata_unavailable", "could not validate the requested media")
+		if !userScoped {
+			ctx.Set("Retry-After", "5")
+			return renderAPIErrorCode(ctx, http.StatusServiceUnavailable, "metadata_unavailable", "could not validate the requested media")
+		}
+		return renderSourceAPIError(ctx, err)
 	}
-	if libraryMetadata == nil || libraryMetadata.MediaContainerWithMetadata == nil || libraryMetadata.MediaContainerWithMetadata.MediaContainer == nil {
+	if metadataItem == nil {
 		return renderAPIErrorCode(ctx, http.StatusUnprocessableEntity, "validation_error", "requested media is unavailable")
 	}
-	metadataList := libraryMetadata.MediaContainerWithMetadata.MediaContainer.Metadata
-	if len(metadataList) == 0 {
-		return renderAPIErrorCode(ctx, http.StatusUnprocessableEntity, "validation_error", "requested media is unavailable")
-	}
-	spec, err := validateRenderJobRequestWithMetadataAndItem(request, *user, sessions, metadataList[0].Media, selection, &metadataList[0])
+	spec, err := validateRenderJobRequestWithMetadataAndItem(request, *user, sessions, metadataItem.Media, selection, metadataItem)
 	if err != nil {
 		return renderAPIErrorCode(ctx, http.StatusUnprocessableEntity, "validation_error", err.Error())
+	}
+	if userScoped {
+		spec.SourceToken = a.app.plexSourceToken(ctx.UserContext(), true)
 	}
 	job, err := a.app.renderJobs.enqueue(user.Uuid, spec)
 	if err != nil {
@@ -1188,6 +1205,9 @@ func (p renderPresentation) apply(spec *renderJobSpec) {
 }
 
 func validateRenderJobRequestWithMetadataAndItem(request RenderJobCreateRequest, user User, sessions []sessionMetadata, metadata []components.Media, selection previewSessionSelection, metadataItem *components.Metadata) (renderJobSpec, error) {
+	if err := validateRenderJobRequestFields(request); err != nil {
+		return renderJobSpec{}, err
+	}
 	audioMode, err := parseAudioMode(string(request.AudioMode))
 	if err != nil {
 		return renderJobSpec{}, errors.New("audioMode is invalid")
@@ -1195,42 +1215,19 @@ func validateRenderJobRequestWithMetadataAndItem(request RenderJobCreateRequest,
 	if user.Uuid == "" {
 		return renderJobSpec{}, errors.New("authenticated user is missing a stable id")
 	}
-	if request.RatingKey == "" || len(request.RatingKey) > 512 {
-		return renderJobSpec{}, errors.New("ratingKey is invalid")
-	}
-	if request.MediaID <= 0 {
-		return renderJobSpec{}, errors.New("mediaId is invalid")
-	}
-	if request.FromMs < 0 || request.ToMs < 0 || request.ToMs <= request.FromMs {
-		return renderJobSpec{}, errors.New("fromMs and toMs must be nonnegative and ordered")
-	}
-	if request.ToMs-request.FromMs > renderMaxDurationMs {
-		return renderJobSpec{}, fmt.Errorf("clip duration exceeds %d minutes", renderMaxDurationMs/60000)
-	}
-	if request.SubtitleIndex < -1 {
-		return renderJobSpec{}, errors.New("subtitleIndex is invalid")
-	}
 	if err := validateSubtitleOffsetMs(request.SubtitleOffsetMs); err != nil {
 		return renderJobSpec{}, err
 	}
-	if request.Height < 0 || request.Height > 2160 || request.Height > 0 && (request.Height < 144 || request.Height%2 != 0) {
-		return renderJobSpec{}, errors.New("height is invalid")
-	}
-	if request.QP < 0 || request.QP > 51 {
-		return renderJobSpec{}, errors.New("qp is invalid")
-	}
-
 	if metadata != nil {
 		previewMedia, previewPart, err := resolvePreviewMetadataSource(metadata, selection)
 		if err != nil {
 			return renderJobSpec{}, err
 		}
-		mediaDuration := int64(0)
-		if previewMedia.Duration != nil && *previewMedia.Duration > 0 {
-			mediaDuration = int64(*previewMedia.Duration)
-		} else if previewPart.Duration != nil && *previewPart.Duration > 0 {
-			mediaDuration = int64(*previewPart.Duration)
-		} else if selection.duration > 0 {
+		mediaDuration, durationErr := selectedSourceDuration(previewMedia, previewPart)
+		if durationErr != nil {
+			return renderJobSpec{}, durationErr
+		}
+		if mediaDuration == 0 && selection.duration > 0 {
 			mediaDuration = selection.duration
 		}
 		if mediaDuration > 0 && request.ToMs > mediaDuration {
@@ -1251,12 +1248,17 @@ func validateRenderJobRequestWithMetadataAndItem(request RenderJobCreateRequest,
 				return renderJobSpec{}, errors.New("subtitle codec is not supported")
 			}
 		}
+		sourceMediaID := request.MediaID
+		if sourceMediaID <= 0 {
+			sourceMediaID = previewMedia.ID
+		}
 		spec := renderJobSpec{
 			OwnerUUID:             user.Uuid,
 			RatingKey:             request.RatingKey,
-			MediaID:               request.MediaID,
+			MediaID:               sourceMediaID,
+			PartID:                previewPart.ID,
 			PartKey:               previewPart.Key,
-			Title:                 sessionTitle(sessions, request.RatingKey),
+			Title:                 sourceTitle(sessions, request.RatingKey, metadataItem),
 			FromMs:                request.FromMs,
 			ToMs:                  request.ToMs,
 			SubtitleIndex:         request.SubtitleIndex,
@@ -1292,10 +1294,12 @@ func validateRenderJobRequestWithMetadataAndItem(request RenderJobCreateRequest,
 					return renderJobSpec{}, errors.New("requested media has no playable part")
 				}
 				mediaDuration := int64(0)
-				if media.Duration != nil && *media.Duration > 0 {
+				if media.Duration != nil && *media.Duration > 0 && len(media.Part) <= 1 {
 					mediaDuration = int64(*media.Duration)
-				} else if session.Duration != nil && *session.Duration > 0 {
+				} else if session.Duration != nil && *session.Duration > 0 && len(media.Part) <= 1 {
 					mediaDuration = int64(*session.Duration)
+				} else if len(media.Part) > 1 {
+					return renderJobSpec{}, errors.New("multipart media requires a part duration")
 				}
 				if mediaDuration > 0 && request.ToMs > mediaDuration {
 					return renderJobSpec{}, errors.New("requested range exceeds the selected media duration")
@@ -1319,10 +1323,12 @@ func validateRenderJobRequestWithMetadataAndItem(request RenderJobCreateRequest,
 				if request.SubtitleIndex >= 0 && subtitleEmbeddedIndex < 0 {
 					return renderJobSpec{}, errors.New("subtitle codec is not supported")
 				}
+				partID, _ := sessionIDAsInt64(part.ID)
 				spec := renderJobSpec{
 					OwnerUUID:             user.Uuid,
 					RatingKey:             request.RatingKey,
 					MediaID:               request.MediaID,
+					PartID:                partID,
 					PartKey:               part.Key,
 					Title:                 session.Title,
 					FromMs:                request.FromMs,
@@ -1341,6 +1347,47 @@ func validateRenderJobRequestWithMetadataAndItem(request RenderJobCreateRequest,
 		}
 	}
 	return renderJobSpec{}, errors.New("requested media is not visible in the caller's sessions")
+}
+
+func validateRenderJobRequestFields(request RenderJobCreateRequest) error {
+	if request.RatingKey == "" || len(request.RatingKey) > 512 {
+		return errors.New("ratingKey is invalid")
+	}
+	if request.MediaID <= 0 && request.PartID == nil {
+		return errors.New("mediaId is invalid")
+	}
+	if request.PartID != nil && *request.PartID <= 0 {
+		return errors.New("partId is invalid")
+	}
+	if request.FromMs < 0 || request.ToMs < 0 || request.ToMs <= request.FromMs {
+		return errors.New("fromMs and toMs must be nonnegative and ordered")
+	}
+	if request.ToMs-request.FromMs > renderMaxDurationMs {
+		return fmt.Errorf("clip duration exceeds %d minutes", renderMaxDurationMs/60000)
+	}
+	if request.SubtitleIndex < -1 {
+		return errors.New("subtitleIndex is invalid")
+	}
+	if err := validateSubtitleOffsetMs(request.SubtitleOffsetMs); err != nil {
+		return err
+	}
+	if request.Height < 0 || request.Height > 2160 || request.Height > 0 && (request.Height < 144 || request.Height%2 != 0) {
+		return errors.New("height is invalid")
+	}
+	if request.QP < 0 || request.QP > 51 {
+		return errors.New("qp is invalid")
+	}
+	return nil
+}
+
+func sourceTitle(sessions []sessionMetadata, ratingKey string, metadata *components.Metadata) string {
+	if title := sessionTitle(sessions, ratingKey); title != "" {
+		return title
+	}
+	if metadata != nil {
+		return metadata.Title
+	}
+	return ""
 }
 
 func sessionTitle(sessions []sessionMetadata, ratingKey string) string {
@@ -1376,7 +1423,11 @@ func sessionValueMatchesID(value any, wanted int64) bool {
 }
 
 func (a *Application) executeRenderSpec(ctx context.Context, spec renderJobSpec, outputPartial string) error {
-	sourceURL := fmt.Sprintf("%s%s?X-Plex-Token=%s", a.config.Plex.Host, spec.PartKey, a.config.Plex.Token)
+	token := spec.SourceToken
+	if token == "" {
+		token = a.config.Plex.Token
+	}
+	sourceURL := fmt.Sprintf("%s%s?X-Plex-Token=%s", a.config.Plex.Host, spec.PartKey, token)
 	from := formatRenderTimestamp(spec.FromMs)
 	to := formatRenderTimestamp(spec.ToMs)
 	var subtitleFile string
@@ -1389,7 +1440,7 @@ func (a *Application) executeRenderSpec(ctx context.Context, spec renderJobSpec,
 				External:  true,
 			}
 			var err error
-			subtitleFile, err = a.prepareExternalSubtitle(ctx, source, spec.FromMs, spec.ToMs, spec.SubtitleOffsetMs)
+			subtitleFile, err = a.prepareExternalSubtitleWithToken(ctx, source, spec.FromMs, spec.ToMs, []int64{spec.SubtitleOffsetMs}, token)
 			if err != nil {
 				return newRenderStageFailure("subtitle", "subtitle_unavailable", err)
 			}


### PR DESCRIPTION
## Summary
- add caller-scoped Plex library search alongside active-session sources
- support show → season → episode selection before clipping, while movies remain directly selectable
- resolve safe playable media versions, including HEVC Main 10, and preserve partial search results when metadata refetches are capped
- show separate resolution, video codec/profile, and combined audio codec/channel metadata on source and clipping cards

## Validation
- go test ./... -count=1
- CI=true npx react-scripts test --watchAll=false
- npm run build
- git diff --check