### PR TITLE
Add canonical workspace deep links

### DIFF
--- a/api.go
+++ b/api.go
@@ -76,6 +76,7 @@ func NewAPI(config Config, app *Application) (*API, error) {
 
 	api.http.Get("/sessions", api.getSessions, api.authMiddleware)
 	api.http.Get("/library/search", api.searchLibrary, api.authMiddlewareJSON)
+	api.http.Get("/library/source/:ratingKey", api.getLibrarySource, api.authMiddlewareJSON)
 	api.http.Get("/library/metadata/:ratingKey/children", api.getLibraryMetadataChildren, api.authMiddlewareJSON)
 	api.http.Get("/thumb", api.thumb, api.authMiddleware)
 	api.http.Get("/streams/:ratingKey", api.getStreams, api.authMiddleware)
@@ -350,6 +351,28 @@ func (a *API) getLibraryMetadataChildren(ctx fiber.Ctx) error {
 	return ctx.JSON(results)
 }
 
+func (a *API) getLibrarySource(ctx fiber.Ctx) error {
+	ratingKey, err := validateLibraryRatingKey(ctx.Params("ratingKey"))
+	if err != nil {
+		return renderAPIErrorCode(ctx, http.StatusUnprocessableEntity, "validation_error", "ratingKey is invalid")
+	}
+	token := AuthTokenFromContext(ctx.UserContext())
+	if UserFromContext(ctx.UserContext()) == nil || token == nil || strings.TrimSpace(*token) == "" {
+		return renderAPIError(ctx, http.StatusUnauthorized, "authentication required")
+	}
+	mediaID, partID, err := parseRequiredLibrarySourceQuery(ctx)
+	if err != nil {
+		return renderAPIErrorCode(ctx, http.StatusUnprocessableEntity, "validation_error", err.Error())
+	}
+	result, err := a.app.GetLibrarySource(ctx.UserContext(), ratingKey, mediaID, partID)
+	if err != nil {
+		log.Printf("library source failed: %s", redactedDiagnostic(err))
+		return renderLibrarySourceAPIError(ctx, err)
+	}
+	ctx.Set("Cache-Control", "no-store")
+	return ctx.JSON(result)
+}
+
 func (a *API) getStreams(ctx fiber.Ctx) error {
 	ratingKeyStr := ctx.Params("ratingKey")
 	if ratingKeyStr == "" || len(ratingKeyStr) > 512 {
@@ -386,6 +409,28 @@ func parseSourceQuery(ctx fiber.Ctx) (string, string, error) {
 	return mediaID, partID, nil
 }
 
+func parseRequiredLibrarySourceQuery(ctx fiber.Ctx) (int64, int64, error) {
+	mediaIDStr, partIDStr, err := parseSourceQuery(ctx)
+	if err != nil {
+		return 0, 0, err
+	}
+	if mediaIDStr == "" {
+		return 0, 0, errors.New("mediaId is required")
+	}
+	if partIDStr == "" {
+		return 0, 0, errors.New("partId is required")
+	}
+	mediaID, err := strconv.ParseInt(mediaIDStr, 10, 64)
+	if err != nil || mediaID <= 0 {
+		return 0, 0, errors.New("mediaId is invalid")
+	}
+	partID, err := strconv.ParseInt(partIDStr, 10, 64)
+	if err != nil || partID <= 0 {
+		return 0, 0, errors.New("partId is invalid")
+	}
+	return mediaID, partID, nil
+}
+
 func plexMetadataStatus(err error) int {
 	var sdkErr *sdkerrors.SDKError
 	if errors.As(err, &sdkErr) {
@@ -408,6 +453,21 @@ func renderLibraryHierarchyAPIError(ctx fiber.Ctx, err error) error {
 		return renderAPIErrorCode(ctx, http.StatusNotFound, "not_found", "requested library item is unavailable")
 	}
 	return renderAPIErrorCode(ctx, http.StatusServiceUnavailable, "metadata_unavailable", "could not load the library hierarchy")
+}
+
+func renderLibrarySourceAPIError(ctx fiber.Ctx, err error) error {
+	var validationErr *sourceValidationError
+	if errors.As(err, &validationErr) {
+		return renderAPIErrorCode(ctx, http.StatusUnprocessableEntity, "validation_error", validationErr.Error())
+	}
+	status := plexMetadataStatus(err)
+	if status == http.StatusUnauthorized || status == http.StatusForbidden || status == http.StatusNotFound {
+		return renderAPIErrorCode(ctx, http.StatusNotFound, "not_found", "requested library source is unavailable")
+	}
+	if status == 0 || status >= 500 {
+		return renderAPIErrorCode(ctx, http.StatusServiceUnavailable, "metadata_unavailable", "could not load the library source")
+	}
+	return renderAPIErrorCode(ctx, http.StatusUnprocessableEntity, "validation_error", "requested library source is unavailable")
 }
 
 func normalizeSourceError(err error) error {

--- a/application.go
+++ b/application.go
@@ -514,6 +514,44 @@ func (a *Application) getMetadataItem(ctx context.Context, ratingKey string, use
 	return &metadata, nil
 }
 
+// GetLibrarySource resolves one caller-visible library Media/Part pair and
+// reduces it to the stable LibrarySearchResult contract. The explicit IDs are
+// required to keep a deep link bound to exactly the source it names.
+func (a *Application) GetLibrarySource(ctx context.Context, ratingKey string, mediaID, partID int64) (LibrarySearchResult, error) {
+	ratingKey, err := validateLibraryRatingKey(ratingKey)
+	if err != nil {
+		return LibrarySearchResult{}, err
+	}
+	if mediaID <= 0 {
+		return LibrarySearchResult{}, errors.New("mediaId is invalid")
+	}
+	if partID <= 0 {
+		return LibrarySearchResult{}, errors.New("partId is invalid")
+	}
+	token := AuthTokenFromContext(ctx)
+	if token == nil || strings.TrimSpace(*token) == "" {
+		return LibrarySearchResult{}, errors.New("missing auth token")
+	}
+
+	sourceCtx, cancel := context.WithTimeout(ctx, librarySearchTimeout)
+	defer cancel()
+	metadata, err := a.getMetadataItem(sourceCtx, ratingKey, true)
+	if err != nil {
+		return LibrarySearchResult{}, err
+	}
+	media, part, err := resolveLibraryMetadataSource(metadata, mediaID, partID)
+	if err != nil {
+		return LibrarySearchResult{}, err
+	}
+	duration, err := selectedSourceDuration(media, part)
+	if err != nil {
+		return LibrarySearchResult{}, err
+	}
+	result := librarySearchResultFromMetadata(metadata, media, part)
+	result.Duration = duration
+	return result, nil
+}
+
 func (a *Application) plexSourceToken(ctx context.Context, userScoped bool) string {
 	if userScoped {
 		if token := AuthTokenFromContext(ctx); token != nil && strings.TrimSpace(*token) != "" {

--- a/application.go
+++ b/application.go
@@ -548,7 +548,12 @@ func (a *Application) GetLibrarySource(ctx context.Context, ratingKey string, me
 		return LibrarySearchResult{}, err
 	}
 	result := librarySearchResultFromMetadata(metadata, media, part)
-	result.Duration = duration
+	// Keep the discovery formatter's title-duration fallback when the selected
+	// source does not carry its own duration. In particular, a single-part
+	// source may only expose duration on the top-level metadata item.
+	if duration > 0 {
+		result.Duration = duration
+	}
 	return result, nil
 }
 

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -171,6 +171,8 @@ function App() {
   // workspace state (selectedSession, render job, etc.) is retained across
   // navigation so the render workflow is never disrupted.
   const [view, setView] = useState(() => viewFromHash(window.location.hash))
+  const activeJobRef = useRef(false)
+  const selectedSessionRef = useRef(null)
 
   // Hash navigation is deliberately kept outside the workspace state. The
   // browser owns the history entries, while this listener makes back/forward
@@ -178,6 +180,24 @@ function App() {
   useEffect(() => {
     const syncViewToHash = () => {
       const nextView = viewFromHash(window.location.hash)
+
+      // An active render owns its source workspace. History navigation must
+      // not hydrate a different source over it or strand the running job.
+      const activeSession = selectedSessionRef.current
+      if (
+        activeJobRef.current &&
+        nextView.name === 'workspace' &&
+        activeSession &&
+        !sessionMatchesWorkspace(activeSession, nextView)
+      ) {
+        const canonicalView = workspaceViewForSession(activeSession)
+        if (canonicalView) {
+          setView(canonicalView)
+          window.history.replaceState(null, '', hashForView(canonicalView))
+          return
+        }
+      }
+
       setView(nextView)
 
       // Invalid routes resolve to the canonical home URL without adding a
@@ -204,6 +224,7 @@ function App() {
 
   // --- Active clip state ---
   const [selectedSession, setSelectedSession] = useState(null)
+  selectedSessionRef.current = selectedSession
   const [startPosition, setStartPosition] = useState(null)
   const [endPosition, setEndPosition] = useState(null)
   const [playerUrl, setPlayerUrl] = useState(null)
@@ -391,7 +412,7 @@ function App() {
     // Session polling is gated to the home view: the library and clip detail
     // views don't need live session data, and polling in the background
     // would compete for the network and surface stale workspace alerts.
-    const pickerVisible = view.name === 'home' && !selectedSession && !needsAuth && documentVisible
+    const pickerVisible = view.name === 'home' && !needsAuth && documentVisible
     if (!pickerVisible) {
       stopSessionRefresh()
       return undefined
@@ -966,6 +987,7 @@ function App() {
 
   // ---------------------------------------------------------------- session switching (blocked during active job)
   const jobIsActive = isActive(renderState.status)
+  activeJobRef.current = jobIsActive
 
   // ---------------------------------------------------------------- hash navigation
   const navigateTo = useCallback((nextView, replace = false) => {
@@ -1058,6 +1080,15 @@ const handleLibraryAuthRequired = useCallback(() => setNeedsAuth(true), [])
     workspaceHydrationControllerRef.current = null
 
     if (view.name !== 'workspace') return undefined
+    if (
+      activeJobRef.current &&
+      selectedSession &&
+      !sessionMatchesWorkspace(selectedSession, view)
+    ) {
+      const canonicalView = workspaceViewForSession(selectedSession)
+      if (canonicalView) navigateTo(canonicalView, true)
+      return undefined
+    }
     if (selectedSession && sessionMatchesWorkspace(selectedSession, view)) {
       stopSessionRefresh()
       return undefined

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -82,6 +82,87 @@ const SESSION_REFRESH_INTERVAL_MS = 10000
 const MAX_NETWORK_RETRIES = 5
 const EXPIRY_TICK_MS = 1000
 
+function viewFromHash(hash) {
+  if (!hash || hash === '#' || hash === '#/') return {name: 'home'}
+  if (hash === '#/clips') return {name: 'library'}
+
+  const workspaceMatch = hash.match(/^#\/workspace\/([^/?#]+)\?mediaId=([1-9]\d*)(?:&partId=([1-9]\d*))?$/)
+  if (workspaceMatch) {
+    try {
+      const ratingKey = decodeURIComponent(workspaceMatch[1])
+      const mediaId = Number(workspaceMatch[2])
+      const partId = workspaceMatch[3] == null ? null : Number(workspaceMatch[3])
+      if (ratingKey && isPositiveSafeInteger(mediaId) && (partId == null || isPositiveSafeInteger(partId))) {
+        return {name: 'workspace', ratingKey, mediaId, partId}
+      }
+    } catch {
+      // Fall through to the canonical home route for malformed escapes.
+    }
+    return {name: 'home'}
+  }
+
+  const clipPrefix = '#/clips/'
+  if (!hash.startsWith(clipPrefix)) return {name: 'home'}
+
+  const encodedClipId = hash.slice(clipPrefix.length)
+  if (!encodedClipId || encodedClipId.includes('/')) return {name: 'home'}
+  try {
+    const clipId = decodeURIComponent(encodedClipId)
+    return clipId ? {name: 'clip', clipId} : {name: 'home'}
+  } catch {
+    return {name: 'home'}
+  }
+}
+
+function isPositiveSafeInteger(value) {
+  return Number.isSafeInteger(value) && value > 0
+}
+
+function hashForView(view) {
+  if (view.name === 'library') return '#/clips'
+  if (view.name === 'clip' && view.clipId) return `#/clips/${encodeURIComponent(view.clipId)}`
+  if (view.name === 'workspace' && view.ratingKey && isPositiveSafeInteger(view.mediaId)) {
+    const partParam = view.partId != null && isPositiveSafeInteger(view.partId) ? `&partId=${view.partId}` : ''
+    return `#/workspace/${encodeURIComponent(view.ratingKey)}?mediaId=${view.mediaId}${partParam}`
+  }
+  return '#/'
+}
+
+function workspaceViewForSession(session) {
+  const ratingKey = session?.ratingKey
+  const mediaId = Number(session?.Media?.[0]?.Part?.[0]?.id)
+  if (typeof ratingKey !== 'string' || !ratingKey || !isPositiveSafeInteger(mediaId)) return null
+  const view = {name: 'workspace', ratingKey, mediaId, partId: null}
+  if (session?._sourceType === 'library') {
+    const partId = Number(session._partId)
+    if (!isPositiveSafeInteger(partId)) return null
+    view.partId = partId
+  }
+  return view
+}
+
+function sessionMatchesWorkspace(session, workspace) {
+  if (!session || !workspace || String(session.ratingKey) !== workspace.ratingKey) return false
+  const mediaId = Number(session?.Media?.[0]?.Part?.[0]?.id)
+  if (mediaId !== workspace.mediaId) return false
+  if (workspace.partId == null) return session._sourceType !== 'library'
+  return session._sourceType === 'library' && Number(session._partId) === workspace.partId
+}
+
+function authRequiredError() {
+  const error = new Error('Authentication required.')
+  error.code = 'auth'
+  return error
+}
+
+async function fetchWorkspaceSessions(signal) {
+  const response = await fetch('/sessions', {redirect: 'manual', signal})
+  if (response.type === 'opaqueredirect' || response.status === 401 || response.status === 403) {
+    throw authRequiredError()
+  }
+  return safeJsonArray(response)
+}
+
 function App() {
   // --- Navigation view ---
   // Smallest suitable routing: an in-app view state instead of a router
@@ -89,7 +170,32 @@ function App() {
   // renders the saved-clip library; 'clip' renders a single clip detail. The
   // workspace state (selectedSession, render job, etc.) is retained across
   // navigation so the render workflow is never disrupted.
-  const [view, setView] = useState({name: 'home'})
+  const [view, setView] = useState(() => viewFromHash(window.location.hash))
+
+  // Hash navigation is deliberately kept outside the workspace state. The
+  // browser owns the history entries, while this listener makes back/forward
+  // navigation update the rendered view without disturbing the workspace.
+  useEffect(() => {
+    const syncViewToHash = () => {
+      const nextView = viewFromHash(window.location.hash)
+      setView(nextView)
+
+      // Invalid routes resolve to the canonical home URL without adding a
+      // second history entry for the malformed hash.
+      const canonicalHash = hashForView(nextView)
+      if (window.location.hash !== canonicalHash) {
+        window.history.replaceState(null, '', canonicalHash)
+      }
+    }
+
+    syncViewToHash()
+    window.addEventListener('hashchange', syncViewToHash)
+    window.addEventListener('popstate', syncViewToHash)
+    return () => {
+      window.removeEventListener('hashchange', syncViewToHash)
+      window.removeEventListener('popstate', syncViewToHash)
+    }
+  }, [])
 
   // --- Session list ---
   const [sessions, setSessions] = useState(null)
@@ -160,6 +266,7 @@ function App() {
   const sessionRefreshActiveRef = useRef(false)
   const sessionRefreshRunnerRef = useRef(null)
   const sessionsHaveDataRef = useRef(false)
+  const workspaceHydrationControllerRef = useRef(null)
 
   // ---------------------------------------------------------------- render-job cleanup
   const stopPolling = useCallback(() => {
@@ -860,6 +967,15 @@ function App() {
   // ---------------------------------------------------------------- session switching (blocked during active job)
   const jobIsActive = isActive(renderState.status)
 
+  // ---------------------------------------------------------------- hash navigation
+  const navigateTo = useCallback((nextView, replace = false) => {
+    setView(nextView)
+    const nextHash = hashForView(nextView)
+    if (window.location.hash === nextHash) return
+    if (replace) window.history.replaceState(null, '', nextHash)
+    else window.location.hash = nextHash
+  }, [])
+
   const handleChangeSession = useCallback(() => {
     // Blocked during active jobs — all session-change affordances are
     // disabled so a successful download cannot disappear.
@@ -893,12 +1009,19 @@ function App() {
     setSubtitleOffsetMs(0)
     setTheaterMode(false)
     setTrimFlashKey(0)
-  }, [jobIsActive, stopPolling, stopSessionRefresh])
+    navigateTo({name: 'home'})
+  }, [jobIsActive, navigateTo, stopPolling, stopSessionRefresh])
 
   const handleSelectSession = useCallback((session) => {
+    const workspaceView = workspaceViewForSession(session)
+    if (!workspaceView) {
+      console.warn('Rejected active session without a canonical workspace identity:', session)
+      return
+    }
     stopSessionRefresh()
     setSelectedSession(session)
-  }, [stopSessionRefresh])
+    navigateTo(workspaceView)
+  }, [navigateTo, stopSessionRefresh])
 
 // Library result selection — normalize the backend LibrarySearchResult into
 // the session-shaped object the workspace expects, then route through the
@@ -914,8 +1037,10 @@ const handleSelectLibraryResult = useCallback((result) => {
     return
   }
   stopSessionRefresh()
-  setSelectedSession(libraryResultToSession(result))
-}, [stopSessionRefresh])
+  const session = libraryResultToSession(result)
+  setSelectedSession(session)
+  navigateTo(workspaceViewForSession(session))
+}, [navigateTo, stopSessionRefresh])
 
 // Stable auth-required handler for the library search panel. setNeedsAuth is
 // stable (useState setter), so this callback keeps a stable identity across
@@ -923,15 +1048,97 @@ const handleSelectLibraryResult = useCallback((result) => {
 // polling never re-fires a library search.
 const handleLibraryAuthRequired = useCallback(() => setNeedsAuth(true), [])
 
+  // ---------------------------------------------------------------- workspace deep-link hydration
+  // A workspace URL is only a source identity. Trim, subtitle, audio, and job
+  // state intentionally stay in React state rather than becoming shareable
+  // URL state. Reuse an already-selected matching source when navigating back
+  // to a workspace; otherwise hydrate it from the authoritative backend lane.
+  useEffect(() => {
+    workspaceHydrationControllerRef.current?.abort()
+    workspaceHydrationControllerRef.current = null
+
+    if (view.name !== 'workspace') return undefined
+    if (selectedSession && sessionMatchesWorkspace(selectedSession, view)) {
+      stopSessionRefresh()
+      return undefined
+    }
+
+    const controller = new AbortController()
+    workspaceHydrationControllerRef.current = controller
+    let current = true
+
+    const failToHome = (error) => {
+      if (!current || controller.signal.aborted || isAbortError(error)) return
+      if (error?.code === 'auth') {
+        setNeedsAuth(true)
+        stopSessionRefresh()
+      }
+      navigateTo({name: 'home'}, true)
+    }
+
+    const hydrate = async () => {
+      try {
+        let session
+        if (view.partId == null) {
+          const liveSessions = await fetchWorkspaceSessions(controller.signal)
+          session = liveSessions.find(candidate => sessionMatchesWorkspace(candidate, view))
+          if (!session) throw new Error('The active session is no longer available.')
+        } else {
+          const response = await fetch(
+            `/library/source/${encodeURIComponent(view.ratingKey)}?mediaId=${view.mediaId}&partId=${view.partId}`,
+            {redirect: 'manual', signal: controller.signal}
+          )
+          if (response.type === 'opaqueredirect' || response.status === 401 || response.status === 403) {
+            throw authRequiredError()
+          }
+          if (!response.ok) throw new Error(`Could not load this library source (${response.status}).`)
+          const result = await response.json()
+          const validationError = validateLibraryResult(result)
+          if (validationError) throw new Error(validationError)
+          if (
+            String(result.ratingKey) !== view.ratingKey ||
+            Number(result.mediaId) !== view.mediaId ||
+            Number(result.partId) !== view.partId
+          ) {
+            throw new Error('The requested library source is no longer available.')
+          }
+          session = libraryResultToSession(result)
+        }
+
+        if (!current || controller.signal.aborted) return
+        stopSessionRefresh()
+        setSelectedSession(session)
+      } catch (error) {
+        failToHome(error)
+      }
+    }
+
+    hydrate()
+    return () => {
+      current = false
+      controller.abort()
+      if (workspaceHydrationControllerRef.current === controller) {
+        workspaceHydrationControllerRef.current = null
+      }
+    }
+  }, [
+    navigateTo, selectedSession, stopSessionRefresh,
+    view.name, view.ratingKey, view.mediaId, view.partId,
+  ])
+
   // ---------------------------------------------------------------- clip library navigation
-  const openLibrary = useCallback(() => setView({name: 'library'}), [])
-  const openClip = useCallback((clipId) => setView({name: 'clip', clipId}), [])
-  const goHome = useCallback(() => setView({name: 'home'}), [])
+  const openLibrary = useCallback(() => navigateTo({name: 'library'}), [navigateTo])
+  const openClip = useCallback((clipId) => navigateTo({name: 'clip', clipId}), [navigateTo])
+  const goHome = useCallback(() => navigateTo({name: 'home'}), [navigateTo])
+  const goBackFromLibrary = useCallback(() => {
+    const workspaceView = workspaceViewForSession(selectedSession)
+    navigateTo(workspaceView || {name: 'home'})
+  }, [navigateTo, selectedSession])
   const handleClipDeleted = useCallback(() => {
     // After deleting from the detail view, return to the library (which
     // re-fetches and reconciles).
-    setView({name: 'library'})
-  }, [])
+    navigateTo({name: 'library'})
+  }, [navigateTo])
 
   // ---------------------------------------------------------------- cleanup on unmount
   useEffect(() => {
@@ -944,6 +1151,7 @@ const handleLibraryAuthRequired = useCallback(() => setNeedsAuth(true), [])
   // ---------------------------------------------------------------- render
   const sessionsLoading = sessions === null && !sessionsError && !needsAuth
   const changeSessionDisabledReason = 'Finish or cancel the active render before changing sessions'
+  const workspaceVisible = view.name === 'workspace'
 
   // Reference expiryTick so the countdown re-renders without affecting logic.
   void expiryTick
@@ -991,7 +1199,7 @@ const handleLibraryAuthRequired = useCallback(() => setNeedsAuth(true), [])
       </Box>
 
       <Box component="main" sx={{flex: 1, py: {xs: 2, md: 3}, position: 'relative', zIndex: 2}}>
-        <Container className="cs-main-container" maxWidth={selectedSession && theaterMode && view.name === 'home' ? 'xl' : 'lg'}>
+        <Container className="cs-main-container" maxWidth={selectedSession && theaterMode && workspaceVisible ? 'xl' : 'lg'}>
           {needsAuth ? (
             <Stack spacing={2} alignItems="center" className="cs-rise" sx={{py: 5, textAlign: 'center'}}>
               <Typography variant="h4">Connect CutScene to Plex</Typography>
@@ -1005,7 +1213,7 @@ const handleLibraryAuthRequired = useCallback(() => setNeedsAuth(true), [])
           ) : view.name === 'library' ? (
             <ClipLibrary
               onOpenClip={openClip}
-              onBack={goHome}
+              onBack={goBackFromLibrary}
               hasActiveWorkspace={Boolean(selectedSession)}
             />
           ) : view.name === 'clip' ? (
@@ -1014,7 +1222,7 @@ const handleLibraryAuthRequired = useCallback(() => setNeedsAuth(true), [])
               onBack={openLibrary}
               onDeleted={handleClipDeleted}
             />
-          ) : !selectedSession ? (
+          ) : view.name !== 'workspace' || !selectedSession ? (
             <Stack spacing={4} className="cs-rise">
               <Box>
                 <Typography variant="overline" className="cs-section-label" sx={{color: '#ff7300'}}>
@@ -1091,7 +1299,7 @@ const handleLibraryAuthRequired = useCallback(() => setNeedsAuth(true), [])
         </Container>
       </Box>
 
-      {playerError && selectedSession && view.name === 'home' && (
+      {playerError && selectedSession && workspaceVisible && (
         <Container maxWidth="lg" sx={{pb: 2, position: 'relative', zIndex: 2}}>
           <Typography variant="caption" sx={{color: '#ffb4a8'}} role="alert">
             Preview failed to load. Adjust the trim or change the session to retry.
@@ -1099,7 +1307,7 @@ const handleLibraryAuthRequired = useCallback(() => setNeedsAuth(true), [])
         </Container>
       )}
 
-      {downloadCompleted && view.name === 'home' && (
+      {downloadCompleted && workspaceVisible && (
         <Container maxWidth="lg" sx={{pb: 2, position: 'relative', zIndex: 2}}>
           <Typography variant="caption" sx={{color: '#7fd391'}} role="status">
             Download started — check your browser downloads.

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -191,6 +191,7 @@ function textStreams() {
 afterEach(() => {
   jest.useRealTimers();
   jest.restoreAllMocks();
+  window.history.replaceState(null, '', '#/');
   Object.defineProperty(document, 'visibilityState', {configurable: true, value: 'visible'});
   mockPlayerUrls.length = 0;
 });
@@ -200,7 +201,7 @@ beforeAll(() => {
 });
 
 test('subtitle stream discovery sends the selected media part ID URL-encoded', async () => {
-  const mediaId = 'part/101?segment=2';
+  const mediaId = '101';
   const selectedSessions = sessions.map(session => session.ratingKey === 'A'
     ? {...session, Media: [{Part: [{id: mediaId}]}]}
     : session
@@ -1132,7 +1133,7 @@ test('render-job POST body and queued/running/succeeded polling produce a saniti
   expect(screen.queryByRole('link', {name: 'Download clip'})).not.toBeInTheDocument();
 });
 
-test('invalid media IDs fail clearly without posting an invalid render payload', async () => {
+test('invalid active media IDs stay on the canonical picker without starting workspace work', async () => {
   const invalidSessions = sessions.map(session => session.ratingKey === 'A'
     ? {...session, Media: [{Part: [{id: '101.5'}]}]}
     : session
@@ -1142,10 +1143,11 @@ test('invalid media IDs fail clearly without posting an invalid render payload',
   await flush();
   await selectSession('Alpha');
 
-  fireEvent.click(screen.getByRole('button', {name: 'Render clip'}));
-
+  expect(window.location.hash).toBe('#/');
+  expect(screen.getByText('Pick something to clip')).toBeInTheDocument();
+  expect(screen.queryByText('Now clipping')).not.toBeInTheDocument();
+  expect(pending.some(request => request.url.startsWith('/streams/'))).toBe(false);
   expect(pending.some(request => request.url === '/render-jobs')).toBe(false);
-  expect(screen.getByRole('alert')).toHaveTextContent('invalid media ID');
 });
 
 test('render jobs keep an immutable submitted spec separate from edited controls', async () => {
@@ -1670,6 +1672,120 @@ test('navigating to the clip library pauses session polling (no /sessions fetche
   expect(sessionRequests.length).toBe(sessionsBefore + 1);
 });
 
+test('selecting an active session serializes its canonical workspace URL', async () => {
+  installFetch(response(sessions));
+  render(<App/>);
+  await flush();
+
+  await selectSession('Alpha');
+
+  expect(window.location.hash).toBe('#/workspace/A?mediaId=101');
+  expect(screen.getByText('Now clipping')).toBeInTheDocument();
+});
+
+test('workspace selection followed by browser back or home shows the picker at #/', async () => {
+  const pending = installFetch(response(sessions));
+  render(<App/>);
+  await flush();
+  await selectSession('Alpha');
+
+  expect(window.location.hash).toBe('#/workspace/A?mediaId=101');
+  expect(screen.getByText('Now clipping')).toBeInTheDocument();
+
+  await act(async () => {
+    const changed = new Promise(resolve => window.addEventListener('hashchange', resolve, {once: true}));
+    window.history.back();
+    await changed;
+  });
+  await flush();
+
+  expect(window.location.hash).toBe('#/');
+  expect(screen.getByText('Pick something to clip')).toBeInTheDocument();
+  expect(screen.queryByText('Now clipping')).not.toBeInTheDocument();
+
+  await selectSession('Alpha');
+  fireEvent.click(screen.getByRole('button', {name: 'CutScene home'}));
+  await flush();
+  expect(window.location.hash).toBe('#/');
+  expect(screen.getByText('Pick something to clip')).toBeInTheDocument();
+
+  fireEvent.click(screen.getByRole('button', {name: 'Clips'}));
+  await flush();
+  await resolveRequest(requestFor(pending, url => url === '/clips'), {clips: [], isAdmin: false});
+  fireEvent.click(screen.getByRole('button', {name: 'Back to editing'}));
+  await flush();
+  expect(window.location.hash).toBe('#/workspace/A?mediaId=101');
+  expect(screen.getByText('Now clipping')).toBeInTheDocument();
+});
+
+test('an active workspace deep link hydrates only the matching live media part', async () => {
+  window.history.replaceState(null, '', '#/workspace/A?mediaId=101');
+  const pending = installFetch(response(sessions));
+  render(<App/>);
+  await flush();
+
+  expect(screen.getByText('Now clipping')).toBeInTheDocument();
+  expect(screen.getByText('Alpha')).toBeInTheDocument();
+  expect(window.location.hash).toBe('#/workspace/A?mediaId=101');
+  expect(requestFor(pending, url => url === '/streams/A?mediaId=101')).toBeDefined();
+});
+
+test('initial clip deep links are rendered from the hash', async () => {
+  window.history.replaceState(null, '', '#/clips/deep-link');
+  const pending = installFetch();
+  render(<App/>);
+  await flush();
+
+  const detailReq = requestFor(pending, url => url === '/clips/deep-link');
+  await resolveRequest(detailReq, {
+    id: 'deep-link', title: 'Deep linked clip', ratingKey: 'A', mediaId: 101,
+    fromMs: 0, toMs: 60000, createdAt: '2026-08-01T12:00:00.000Z',
+    shareUrl: 'https://clips.example.test/shared/deep-link',
+    downloadUrl: '/clips/deep-link/download',
+    publicDownloadUrl: 'https://clips.example.test/shared/deep-link',
+    canDelete: false, isAdmin: false,
+  });
+
+  expect(screen.getByText('Deep linked clip')).toBeInTheDocument();
+  expect(window.location.hash).toBe('#/clips/deep-link');
+});
+
+test('in-app hash navigation updates history and browser back/forward restores views', async () => {
+  const pending = installFetch();
+  render(<App/>);
+  await flush();
+
+  fireEvent.click(screen.getByRole('button', {name: 'Clips'}));
+  await flush();
+  expect(window.location.hash).toBe('#/clips');
+  await resolveRequest(requestFor(pending, url => url === '/clips'), {clips: [], isAdmin: false});
+  expect(screen.getByText('No saved clips yet.')).toBeInTheDocument();
+
+  fireEvent.click(screen.getByRole('button', {name: 'Back to sessions'}));
+  await flush();
+  expect(window.location.hash).toBe('#/');
+  expect(screen.getByText('Pick something to clip')).toBeInTheDocument();
+
+  await act(async () => {
+    const changed = new Promise(resolve => window.addEventListener('hashchange', resolve, {once: true}));
+    window.history.back();
+    await changed;
+  });
+  await flush();
+  expect(window.location.hash).toBe('#/clips');
+  await resolveRequest(requestFor(pending, url => url === '/clips', 1), {clips: [], isAdmin: false});
+  expect(screen.getByText('No saved clips yet.')).toBeInTheDocument();
+
+  await act(async () => {
+    const changed = new Promise(resolve => window.addEventListener('hashchange', resolve, {once: true}));
+    window.history.forward();
+    await changed;
+  });
+  await flush();
+  expect(window.location.hash).toBe('#/');
+  expect(screen.getByText('Pick something to clip')).toBeInTheDocument();
+});
+
 test('a successful render surfaces the saved clip via Open in library without losing the transient download', async () => {
   jest.useFakeTimers();
   const pending = installFetch();
@@ -1741,6 +1857,21 @@ const libraryResults = [
     duration: 2700000, artwork: '/thumb/L2', videoResolution: '720', audioChannels: 2,
   },
 ];
+
+test('a library workspace deep link hydrates through the explicit source endpoint', async () => {
+  window.history.replaceState(null, '', '#/workspace/L1?mediaId=5001&partId=6001');
+  const pending = installFetch();
+  render(<App/>);
+  await flush();
+
+  const sourceRequest = requestFor(pending, url => url.startsWith('/library/source/'));
+  expect(sourceRequest.url).toBe('/library/source/L1?mediaId=5001&partId=6001');
+  await resolveRequest(sourceRequest, libraryResults[0]);
+
+  expect(window.location.hash).toBe('#/workspace/L1?mediaId=5001&partId=6001');
+  expect(screen.getByText('From your Plex library')).toBeInTheDocument();
+  expect(requestFor(pending, url => url === '/streams/L1?mediaId=5001&partId=6001')).toBeDefined();
+});
 
 function librarySearchRequest(pending, occurrence = 0) {
   return requestFor(pending, url => url.startsWith('/library/search?query='), occurrence);
@@ -1886,6 +2017,7 @@ test('selecting a library result opens the workspace and passes partId through s
   await flush();
 
   // The workspace opens with the library source context.
+  expect(window.location.hash).toBe('#/workspace/L1?mediaId=5001&partId=6001');
   expect(screen.getByText('Now clipping')).toBeInTheDocument();
   expect(screen.getByText('From your Plex library')).toBeInTheDocument();
   expect(screen.getByText('Library Movie')).toBeInTheDocument();

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -1683,6 +1683,32 @@ test('selecting an active session serializes its canonical workspace URL', async
   expect(screen.getByText('Now clipping')).toBeInTheDocument();
 });
 
+test('active render rejects a different workspace hash and keeps polling the active source', async () => {
+  const pending = installFetch();
+  render(<App/>);
+  await flush();
+  await selectSession('Alpha');
+
+  fireEvent.click(screen.getByRole('button', {name: 'Render clip'}));
+  const createRequest = requestFor(pending, url => url === '/render-jobs');
+  await resolveRequestWith(createRequest, {id: 'job-route-guard', status: 'queued'}, {status: 202});
+  const poll = requestFor(pending, url => url === '/render-jobs/job-route-guard');
+  await resolveRequest(poll, {id: 'job-route-guard', status: 'running'});
+
+  await act(async () => {
+    const changed = new Promise(resolve => window.addEventListener('hashchange', resolve, {once: true}));
+    window.location.hash = '#/workspace/B?mediaId=202';
+    await changed;
+  });
+  await flush();
+
+  expect(window.location.hash).toBe('#/workspace/A?mediaId=101');
+  expect(screen.getByText('Alpha')).toBeInTheDocument();
+  expect(screen.getByText('Rendering')).toBeInTheDocument();
+  expect(poll.options.signal.aborted).toBe(false);
+  expect(pending.some(request => request.url.startsWith('/streams/B'))).toBe(false);
+});
+
 test('workspace selection followed by browser back or home shows the picker at #/', async () => {
   const pending = installFetch(response(sessions));
   render(<App/>);
@@ -1871,6 +1897,26 @@ test('a library workspace deep link hydrates through the explicit source endpoin
   expect(window.location.hash).toBe('#/workspace/L1?mediaId=5001&partId=6001');
   expect(screen.getByText('From your Plex library')).toBeInTheDocument();
   expect(requestFor(pending, url => url === '/streams/L1?mediaId=5001&partId=6001')).toBeDefined();
+});
+
+test('returning home after library workspace hydration restarts session loading', async () => {
+  window.history.replaceState(null, '', '#/workspace/L1?mediaId=5001&partId=6001');
+  const {sessionRequests, pending} = installTrackedSessionsFetch();
+  render(<App/>);
+  await flush();
+
+  const sourceRequest = requestFor(pending, url => url === '/library/source/L1?mediaId=5001&partId=6001');
+  await resolveRequest(sourceRequest, libraryResults[0]);
+  expect(screen.getByText('From your Plex library')).toBeInTheDocument();
+
+  fireEvent.click(screen.getByRole('button', {name: 'CutScene home'}));
+  await flush();
+  expect(window.location.hash).toBe('#/');
+  expect(sessionRequests).toHaveLength(1);
+
+  await resolveRequest(sessionRequests[0], sessions);
+  expect(screen.getByText('Pick something to clip')).toBeInTheDocument();
+  expect(screen.queryByText('Loading sessions…')).not.toBeInTheDocument();
 });
 
 function librarySearchRequest(pending, occurrence = 0) {

--- a/library_search_test.go
+++ b/library_search_test.go
@@ -655,3 +655,97 @@ func TestLibraryHierarchyUsesCurrentCallerTokenForEachRequest(t *testing.T) {
 		t.Fatalf("cross-caller token sequence = %v", seenTokens)
 	}
 }
+
+func TestGetLibrarySourceResolvesOneCallerSourceAndNormalizesIt(t *testing.T) {
+	plex := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/library/metadata/movie-1" {
+			http.NotFound(w, r)
+			return
+		}
+		if got := r.Header.Get("X-Plex-Token"); got != "caller-token" {
+			t.Errorf("metadata token = %q, want caller-token", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"MediaContainer":{"Metadata":[{"ratingKey":"movie-1","type":"movie","title":"Library movie","year":2024,"thumb":"/library/metadata/movie-1/thumb","Media":[{"id":10,"duration":120000,"Part":[{"id":100,"duration":120000,"key":"/library/parts/100/file"}]},{"id":11,"duration":90000,"videoResolution":"4k","videoCodec":"hevc","videoProfile":"main 10","audioCodec":"eac3","audioChannels":6,"container":"mkv","bitrate":8000,"width":3840,"height":2160,"Part":[{"id":101,"duration":60000,"key":"/library/parts/101/file","size":9876}]}]}]}}`)
+	}))
+	defer plex.Close()
+	config := Config{}
+	config.Plex.Host = plex.URL
+	app := &Application{config: config}
+
+	result, err := app.GetLibrarySource(ContextWithAuthToken(context.Background(), "caller-token"), "movie-1", 11, 101)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.RatingKey != "movie-1" || result.MediaID != 11 || result.PartID != 101 || result.Title != "Library movie" || result.Type != "movie" || result.Duration != 60000 {
+		t.Fatalf("normalized source identity = %+v", result)
+	}
+	if result.Year == nil || *result.Year != 2024 || result.Artwork != "/library/metadata/movie-1/thumb" || result.VideoResolution != "4k" || result.VideoCodec != "hevc" || result.VideoProfile != "main 10" || result.AudioCodec != "eac3" || result.AudioChannels != 6 || result.Container != "mkv" || result.Bitrate != 8000 || result.Width != 3840 || result.Height != 2160 || result.FileSize != 9876 {
+		t.Fatalf("normalized source metadata = %+v", result)
+	}
+	body, err := json.Marshal(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(body), "/library/parts/101/file") {
+		t.Fatalf("source response exposed a raw file path: %s", body)
+	}
+	if _, err := app.GetLibrarySource(ContextWithAuthToken(context.Background(), "caller-token"), "movie-1", 11, 100); err == nil {
+		t.Fatal("source resolver accepted a part belonging to another media")
+	}
+}
+
+func TestLibrarySourceAPIUsesAuthValidationAndNotFoundConventions(t *testing.T) {
+	plex := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer plex.Close()
+	config := Config{}
+	config.Plex.Host = plex.URL
+	api := &API{app: &Application{config: config}}
+
+	unauthenticated := fiber.New()
+	unauthenticated.Get("/library/source/:ratingKey", api.getLibrarySource)
+	response, err := unauthenticated.Test(httptest.NewRequest(http.MethodGet, "/library/source/movie-1?mediaId=11&partId=101", nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if response.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated status = %d, want 401", response.StatusCode)
+	}
+	_ = response.Body.Close()
+
+	validated := fiber.New()
+	validated.Get("/library/source/:ratingKey", func(ctx fiber.Ctx) error {
+		ctx.SetUserContext(ContextWithUser(ContextWithAuthToken(context.Background(), "caller-token"), User{Uuid: "user-a"}))
+		return api.getLibrarySource(ctx)
+	})
+	response, err = validated.Test(httptest.NewRequest(http.MethodGet, "/library/source/movie-1?mediaId=0&partId=101", nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if response.StatusCode != http.StatusUnprocessableEntity {
+		t.Fatalf("invalid source status = %d, want 422", response.StatusCode)
+	}
+	_ = response.Body.Close()
+
+	response, err = validated.Test(httptest.NewRequest(http.MethodGet, "/library/source/movie-1?mediaId=11&partId=101", nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusNotFound {
+		t.Fatalf("missing source status = %d, want 404", response.StatusCode)
+	}
+	var envelope struct {
+		Error struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&envelope); err != nil {
+		t.Fatal(err)
+	}
+	if envelope.Error.Code != "not_found" {
+		t.Fatalf("missing source error code = %q, want not_found", envelope.Error.Code)
+	}
+}

--- a/library_search_test.go
+++ b/library_search_test.go
@@ -695,6 +695,29 @@ func TestGetLibrarySourceResolvesOneCallerSourceAndNormalizesIt(t *testing.T) {
 	}
 }
 
+func TestGetLibrarySourcePreservesTitleDurationFallback(t *testing.T) {
+	plex := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/library/metadata/movie-duration" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"MediaContainer":{"Metadata":[{"ratingKey":"movie-duration","type":"movie","title":"Title duration only","duration":75000,"Media":[{"id":21,"Part":[{"id":31,"key":"/library/parts/31/file"}]}]}]}}`)
+	}))
+	defer plex.Close()
+	config := Config{}
+	config.Plex.Host = plex.URL
+	app := &Application{config: config}
+
+	result, err := app.GetLibrarySource(ContextWithAuthToken(context.Background(), "caller-token"), "movie-duration", 21, 31)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Duration != 75000 {
+		t.Fatalf("duration = %d, want title-level duration 75000: %+v", result.Duration, result)
+	}
+}
+
 func TestLibrarySourceAPIUsesAuthValidationAndNotFoundConventions(t *testing.T) {
 	plex := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)


### PR DESCRIPTION
## Summary
- add hash-based navigation for home, saved clips, and canonical workspaces
- restore active-session and library sources from stable workspace URLs
- add an authenticated exact library-source resolver

## Verification
- go test ./...
- npm test -- --watchAll=false --runInBand --testPathPattern=src/App.test.js