### PR TITLE
Add source-aware clip quality tiers

### DIFF
--- a/application.go
+++ b/application.go
@@ -165,6 +165,8 @@ func (u *sessionUser) UnmarshalJSON(data []byte) error {
 type sessionMedia struct {
 	ID              any           `json:"id"`
 	Duration        *int          `json:"duration,omitempty"`
+	Width           *int          `json:"width,omitempty"`
+	Height          *int          `json:"height,omitempty"`
 	Bitrate         *int          `json:"bitrate,omitempty"`
 	AudioCodec      *string       `json:"audioCodec,omitempty"`
 	AudioChannels   *int          `json:"audioChannels,omitempty"`

--- a/application_test.go
+++ b/application_test.go
@@ -1037,6 +1037,18 @@ func TestNVENCTextSubtitleArgs(t *testing.T) {
 	}
 }
 
+func TestNativeFFmpegFiltersDoNotContainZeroScale(t *testing.T) {
+	if got := scaleSoftwareFilter(0); got != "" {
+		t.Fatalf("native software filter = %q, want empty", got)
+	}
+	if got := scaleCUDAFilter(0); got != "" {
+		t.Fatalf("native CUDA filter = %q, want empty", got)
+	}
+	if got := scaleVAAPIFilter(0); strings.Contains(got, "scale_vaapi=-2:0") {
+		t.Fatalf("native VAAPI filter contains zero scale: %q", got)
+	}
+}
+
 func containsArg(args []string, want string) bool {
 	for _, arg := range args {
 		if arg == want {

--- a/ffmpeg.go
+++ b/ffmpeg.go
@@ -182,6 +182,27 @@ func configureNVENCTextSubtitle(inputArgs, outputArgs ffmpeg.KwArgs, subtitleFil
 	outputArgs["vf"] = vf
 }
 
+func scaleSoftwareFilter(height int) string {
+	if height <= 0 {
+		return ""
+	}
+	return fmt.Sprintf("scale=-2:%d", height)
+}
+
+func scaleCUDAFilter(height int) string {
+	if height <= 0 {
+		return ""
+	}
+	return fmt.Sprintf("scale_cuda=-2:%d", height)
+}
+
+func scaleVAAPIFilter(height int) string {
+	if height <= 0 {
+		return "scale_vaapi=format=nv12"
+	}
+	return fmt.Sprintf("scale_vaapi=format=nv12,scale_vaapi=-2:%d", height)
+}
+
 func configureMP4Output(outputArgs ffmpeg.KwArgs) {
 	outputArgs["f"] = "mp4"
 }
@@ -261,15 +282,14 @@ func DoFfmpeg(params FfmpegParams) (string, error) {
 	switch params.Codec {
 	case CodecH264VAAPI:
 		if params.SubtitleIndex >= 0 {
-			outputArgs["filter_complex"] = subtitleOverlayFilter(params.SubtitleIndex, params.SubtitleOffsetMs, fmt.Sprintf(",format=nv12,hwupload,scale_vaapi=format=nv12,scale_vaapi=-2:%d[out]", params.Height))
+			outputArgs["filter_complex"] = subtitleOverlayFilter(params.SubtitleIndex, params.SubtitleOffsetMs, ",format=nv12,hwupload,"+scaleVAAPIFilter(params.Height)+"[out]")
 			outputArgs["map"] = []string{"[out]", "0:a:0?"}
 			delete(inputArgs, "hwaccel_output_format")
 		} else if params.SubtitleFile != "" {
 			delete(inputArgs, "hwaccel_output_format")
-			outputArgs["vf"] = fmt.Sprintf("subtitles=%s,format=nv12,hwupload,scale_vaapi=format=nv12,scale_vaapi=-2:%d",
-				params.SubtitleFile, params.Height)
+			outputArgs["vf"] = fmt.Sprintf("subtitles=%s,format=nv12,hwupload,%s", params.SubtitleFile, scaleVAAPIFilter(params.Height))
 		} else {
-			outputArgs["vf"] = "hwupload,scale_vaapi=format=nv12,scale_vaapi=-2:" + strconv.Itoa(params.Height)
+			outputArgs["vf"] = "hwupload," + scaleVAAPIFilter(params.Height)
 		}
 		outputArgs["compression_level"] = "0"
 	case CodecH264NVENC:
@@ -297,14 +317,23 @@ func DoFfmpeg(params FfmpegParams) (string, error) {
 		fallthrough
 	default:
 		if params.SubtitleIndex >= 0 {
-			outputArgs["filter_complex"] = subtitleOverlayFilter(params.SubtitleIndex, params.SubtitleOffsetMs, fmt.Sprintf(",scale=-2:%d[out]", params.Height))
+			suffix := "[out]"
+			if filter := scaleSoftwareFilter(params.Height); filter != "" {
+				suffix = "," + filter + suffix
+			}
+			outputArgs["filter_complex"] = subtitleOverlayFilter(params.SubtitleIndex, params.SubtitleOffsetMs, suffix)
 			outputArgs["map"] = []string{"[out]", "0:a:0?"}
 		} else {
-			vf := "scale=-2:" + strconv.Itoa(params.Height)
+			vf := scaleSoftwareFilter(params.Height)
 			if params.SubtitleFile != "" {
-				vf += ",subtitles=" + params.SubtitleFile
+				if vf != "" {
+					vf += ","
+				}
+				vf += "subtitles=" + params.SubtitleFile
 			}
-			outputArgs["vf"] = vf
+			if vf != "" {
+				outputArgs["vf"] = vf
+			}
 		}
 		outputArgs["pix_fmt"] = "yuv420p"
 		outputArgs["crf"] = 23
@@ -457,39 +486,53 @@ func doFfmpegPreviewContext(ctx context.Context, fileURL, from, to string, subti
 	switch codec {
 	case CodecH264VAAPI:
 		if subtitleIndex >= 0 {
-			outputArgs["filter_complex"] = subtitleOverlayFilter(subtitleIndex, subtitleOffsetMs, fmt.Sprintf(",format=nv12,hwupload,scale_vaapi=format=nv12,scale_vaapi=-2:%d[out]", height))
+			outputArgs["filter_complex"] = subtitleOverlayFilter(subtitleIndex, subtitleOffsetMs, ",format=nv12,hwupload,"+scaleVAAPIFilter(height)+"[out]")
 			outputArgs["map"] = []string{"[out]", "0:a:0?"}
 			delete(inputArgs, "hwaccel_output_format")
 		} else if subtitleFile != "" {
 			delete(inputArgs, "hwaccel_output_format")
-			outputArgs["vf"] = fmt.Sprintf("subtitles=%s,format=nv12,hwupload,scale_vaapi=format=nv12,scale_vaapi=-2:%d",
-				subtitleFile, height)
+			outputArgs["vf"] = fmt.Sprintf("subtitles=%s,format=nv12,hwupload,%s", subtitleFile, scaleVAAPIFilter(height))
 		} else {
-			outputArgs["vf"] = "hwupload,scale_vaapi=format=nv12,scale_vaapi=-2:" + strconv.Itoa(height)
+			outputArgs["vf"] = "hwupload," + scaleVAAPIFilter(height)
 		}
 		outputArgs["compression_level"] = "0"
 	case CodecH264NVENC:
 		if subtitleIndex >= 0 {
-			outputArgs["filter_complex"] = subtitleOverlayFilter(subtitleIndex, subtitleOffsetMs, fmt.Sprintf(",hwupload_cuda,scale_cuda=-2:%d[out]", height))
+			if height > 0 {
+				outputArgs["filter_complex"] = subtitleOverlayFilter(subtitleIndex, subtitleOffsetMs, ",hwupload_cuda,"+scaleCUDAFilter(height)+"[out]")
+			} else {
+				outputArgs["filter_complex"] = subtitleOverlayFilter(subtitleIndex, subtitleOffsetMs, ",hwupload_cuda[out]")
+			}
 			outputArgs["map"] = []string{"[out]", "0:a:0?"}
 		} else if subtitleFile != "" {
 			configureNVENCTextSubtitle(inputArgs, outputArgs, subtitleFile, height)
 		} else {
 			inputArgs["hwaccel_output_format"] = "cuda"
-			outputArgs["vf"] = "scale_cuda=-2:" + strconv.Itoa(height)
+			if filter := scaleCUDAFilter(height); filter != "" {
+				outputArgs["vf"] = filter
+			}
 		}
 	case CodecLibx264:
 		fallthrough
 	default:
 		if subtitleIndex >= 0 {
-			outputArgs["filter_complex"] = subtitleOverlayFilter(subtitleIndex, subtitleOffsetMs, fmt.Sprintf(",scale=-2:%d[out]", height))
+			suffix := "[out]"
+			if filter := scaleSoftwareFilter(height); filter != "" {
+				suffix = "," + filter + suffix
+			}
+			outputArgs["filter_complex"] = subtitleOverlayFilter(subtitleIndex, subtitleOffsetMs, suffix)
 			outputArgs["map"] = []string{"[out]", "0:a:0?"}
 		} else {
-			vf := "scale=-2:" + strconv.Itoa(height)
+			vf := scaleSoftwareFilter(height)
 			if subtitleFile != "" {
-				vf += ",subtitles=" + subtitleFile
+				if vf != "" {
+					vf += ","
+				}
+				vf += "subtitles=" + subtitleFile
 			}
-			outputArgs["vf"] = vf
+			if vf != "" {
+				outputArgs["vf"] = vf
+			}
 		}
 		outputArgs["pix_fmt"] = "yuv420p"
 		outputArgs["crf"] = 23

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -9,8 +9,8 @@ import ClipLibrary from "./components/ClipLibrary";
 import ClipDetail from "./components/ClipDetail";
 import {stripSubtitleMarkup} from "./components/subtitle-markup";
 import {
-  buildRenderJobRequest, buildRenderJobRequestFromSpec, isTerminal, isActive, JOB_STATES, snapshotJobSpec, AUDIO_MODES,
-  getSourcePartId, validateLibraryResult,
+  buildRenderJobRequest, buildRenderJobRequestFromSpec, isTerminal, isActive, JOB_STATES, snapshotJobSpec, AUDIO_MODES, RENDER_RESOLUTIONS,
+  getSourcePartId, validateLibraryResult, getSafeResolution,
 } from "./components/render-jobs";
 import {
   isAbortError, millisToDuration, MIN_GAP_MS,
@@ -38,7 +38,7 @@ function libraryResultToSession(result) {
     // Library items have no live view offset — clips start at the beginning.
     viewOffset: 0,
     thumb: result.artwork || '',
-    Media: [{Part: [{id: String(result.mediaId)}], videoResolution: result.videoResolution || '', videoCodec: result.videoCodec || '', videoProfile: result.videoProfile || '', audioChannels: result.audioChannels || 0, audioCodec: result.audioCodec || ''}],
+    Media: [{Part: [{id: String(result.mediaId)}], height: result.height, videoResolution: result.videoResolution || '', videoCodec: result.videoCodec || '', videoProfile: result.videoProfile || '', audioChannels: result.audioChannels || 0, audioCodec: result.audioCodec || ''}],
     _sourceType: 'library',
     _partId: result.partId,
   }
@@ -231,6 +231,7 @@ function App() {
   const [playerError, setPlayerError] = useState(false)
   const [previewStale, setPreviewStale] = useState(false)
   const [audioMode, setAudioMode] = useState(AUDIO_MODES.STANDARD)
+  const [resolution, setResolution] = useState(RENDER_RESOLUTIONS.NATIVE)
 
   // --- Theater mode ---
   // Desktop-only view toggle: widens the preview rail (Container lg → xl) and
@@ -469,6 +470,7 @@ function App() {
       setStartPosition(initStart)
       setEndPosition(initEnd)
       setAudioMode(AUDIO_MODES.STANDARD)
+      setResolution(getSafeResolution(selectedSession?.Media?.[0]?.height))
       setSubtitleOffsetMs(0)
       setSubtitleStreams([])
       setSelectedSubtitle(-1)
@@ -772,12 +774,12 @@ function App() {
     setDownloadCompleted(false)
     networkRetryCountRef.current = 0
 
-    const spec = retrySpec || snapshotJobSpec(selectedSession, startPosition, endPosition, selectedSubtitle, subtitleStreams, audioMode, subtitleOffsetMs)
+    const spec = retrySpec || snapshotJobSpec(selectedSession, startPosition, endPosition, selectedSubtitle, subtitleStreams, audioMode, subtitleOffsetMs, resolution)
     let body
     try {
       body = JSON.stringify(retrySpec
         ? buildRenderJobRequestFromSpec(retrySpec)
-        : buildRenderJobRequest(selectedSession, startPosition, endPosition, selectedSubtitle, audioMode, subtitleOffsetMs))
+        : buildRenderJobRequest(selectedSession, startPosition, endPosition, selectedSubtitle, audioMode, subtitleOffsetMs, resolution))
     } catch (error) {
       setRenderState({
         status: JOB_STATES.FAILED,
@@ -836,7 +838,7 @@ function App() {
           downloadUrl: null, expiresAt: null, retryAfter: err?.retryAfter || null, clipId: null, shareUrl: null,
         })
       })
-  }, [selectedSession, startPosition, endPosition, selectedSubtitle, subtitleStreams, audioMode, subtitleOffsetMs, stopPolling])
+  }, [selectedSession, startPosition, endPosition, selectedSubtitle, subtitleStreams, audioMode, subtitleOffsetMs, resolution, stopPolling])
 
   // ---------------------------------------------------------------- render-job polling (ref-bound)
   const pollForJobRef = useRef(null)
@@ -1031,6 +1033,7 @@ function App() {
     setStartPosition(null)
     setEndPosition(null)
     setAudioMode(AUDIO_MODES.STANDARD)
+    setResolution(RENDER_RESOLUTIONS.NATIVE)
     setSubtitleOffsetMs(0)
     setTheaterMode(false)
     setTrimFlashKey(0)
@@ -1329,6 +1332,11 @@ const handleLibraryAuthRequired = useCallback(() => setNeedsAuth(true), [])
               onOpenClip={openClip}
               audioMode={audioMode}
               onAudioModeChange={setAudioMode}
+              resolution={resolution}
+              onResolutionChange={value => {
+                setResolution(value)
+                setControlsChangedSinceJob(true)
+              }}
               theaterMode={theaterMode}
               onToggleTheater={() => setTheaterMode(mode => !mode)}
               subtitleOffsetMs={subtitleOffsetMs}

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -3,7 +3,7 @@ import {act, fireEvent, render, screen} from '@testing-library/react';
 import App from './App';
 import TrimScrubber from './components/TrimScrubber';
 import {renderSubtitleMarkup, stripSubtitleMarkup} from './components/subtitle-markup';
-import {getAvailableResolutionChoices} from './components/render-jobs';
+import {getAvailableResolutionChoices, getSafeResolution, formatJobSpec, RENDER_RESOLUTIONS} from './components/render-jobs';
 
 const mockPlayerUrls = [];
 
@@ -193,8 +193,16 @@ test('quality choices never offer an upscale and fall back to native safely', ()
   expect(getAvailableResolutionChoices(1080).map(choice => choice.value)).toEqual(['1080p', '720p', '480p']);
   expect(getAvailableResolutionChoices(720).map(choice => choice.value)).toEqual(['720p', '480p']);
   expect(getAvailableResolutionChoices(480).map(choice => choice.value)).toEqual(['480p']);
-  expect(getAvailableResolutionChoices(360).map(choice => choice.value)).toEqual(['native']);
-  expect(getAvailableResolutionChoices(null).map(choice => choice.value)).toEqual(['native']);
+  expect(getAvailableResolutionChoices(360).map(choice => choice.value)).toEqual(['source-native']);
+  expect(getAvailableResolutionChoices(null).map(choice => choice.value)).toEqual(['source-native']);
+  expect(getSafeResolution(360)).toBe(RENDER_RESOLUTIONS.SOURCE_NATIVE);
+  expect(getSafeResolution(null)).toBe(RENDER_RESOLUTIONS.SOURCE_NATIVE);
+});
+
+test('submitted quality formatting distinguishes Native from legacy Extra high', () => {
+  const base = {fromMs: 0, toMs: 1000, clipDuration: 1000, subtitleLabel: 'None', audioMode: 'standard'};
+  expect(formatJobSpec({...base, resolution: 'source-native'}).quality).toBe('Native');
+  expect(formatJobSpec({...base, resolution: 'native'}).quality).toBe('Extra high');
 });
 
 afterEach(() => {
@@ -1211,6 +1219,7 @@ test('render jobs keep an immutable submitted spec separate from edited controls
   });
   expect(screen.getByText('Submitted clip')).toBeInTheDocument();
   expect(screen.getByText('00:00:00 – 00:01:00')).toBeInTheDocument();
+  expect(screen.getAllByText('High').length).toBeGreaterThanOrEqual(2);
   expect(screen.getAllByText('X track')).toHaveLength(2);
 
   const end = screen.getByRole('textbox', {name: 'End time as hours minutes seconds milliseconds'});

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -3,6 +3,7 @@ import {act, fireEvent, render, screen} from '@testing-library/react';
 import App from './App';
 import TrimScrubber from './components/TrimScrubber';
 import {renderSubtitleMarkup, stripSubtitleMarkup} from './components/subtitle-markup';
+import {getAvailableResolutionChoices} from './components/render-jobs';
 
 const mockPlayerUrls = [];
 
@@ -23,11 +24,11 @@ jest.mock('react-player', () => {
 const sessions = [
   {
     ratingKey: 'A', type: 'movie', title: 'Alpha', year: 2024, viewOffset: 0, duration: 120000,
-    User: {title: 'viewer'}, Media: [{Part: [{id: '101'}]}],
+    User: {title: 'viewer'}, Media: [{height: 1080, Part: [{id: '101'}]}],
   },
   {
     ratingKey: 'B', type: 'movie', title: 'Beta', year: 2024, viewOffset: 5000, duration: 120000,
-    User: {title: 'viewer'}, Media: [{Part: [{id: '202'}]}],
+    User: {title: 'viewer'}, Media: [{height: 720, Part: [{id: '202'}]}],
   },
 ];
 
@@ -187,6 +188,14 @@ function textStreams() {
     {index: 1, type: 'text', codec: 'webvtt', displayTitle: 'Y track'},
   ];
 }
+
+test('quality choices never offer an upscale and fall back to native safely', () => {
+  expect(getAvailableResolutionChoices(1080).map(choice => choice.value)).toEqual(['1080p', '720p', '480p']);
+  expect(getAvailableResolutionChoices(720).map(choice => choice.value)).toEqual(['720p', '480p']);
+  expect(getAvailableResolutionChoices(480).map(choice => choice.value)).toEqual(['480p']);
+  expect(getAvailableResolutionChoices(360).map(choice => choice.value)).toEqual(['native']);
+  expect(getAvailableResolutionChoices(null).map(choice => choice.value)).toEqual(['native']);
+});
 
 afterEach(() => {
   jest.useRealTimers();
@@ -448,6 +457,31 @@ test('dialogue audio mode updates the preview URL and render payload', async () 
   fireEvent.click(screen.getByRole('button', {name: 'Render clip'}));
   const createRequest = requestFor(pending, url => url === '/render-jobs');
   expect(JSON.parse(createRequest.options.body)).toMatchObject({audioMode: 'dialogue'});
+});
+
+test('selected resolution preset is sent in the render-job payload', async () => {
+  const pending = installFetch();
+  render(<App/>);
+  await flush();
+  await selectSession('Alpha');
+  fireEvent.click(screen.getByRole('button', {name: 'Medium quality'}));
+  fireEvent.click(screen.getByRole('button', {name: 'Render clip'}));
+  const createRequest = requestFor(pending, url => url === '/render-jobs');
+  expect(JSON.parse(createRequest.options.body)).toMatchObject({resolution: '720p'});
+});
+
+test('quality controls reflect the selected source height', async () => {
+  const pending = installFetch();
+  render(<App/>);
+  await flush();
+  await selectSession('Alpha');
+
+  expect(screen.getByRole('button', {name: 'High quality'})).toBeInTheDocument();
+  expect(screen.getByRole('button', {name: 'Medium quality'})).toBeInTheDocument();
+  expect(screen.getByRole('button', {name: 'Low quality'})).toBeInTheDocument();
+  expect(screen.queryByRole('button', {name: 'Extra high quality'})).not.toBeInTheDocument();
+  expect(screen.getByText('Choose the output quality for your clip without upscaling.')).toBeInTheDocument();
+  void pending;
 });
 
 test('changing sessions resets audio mode to standard', async () => {
@@ -1108,7 +1142,7 @@ test('render-job POST body and queued/running/succeeded polling produce a saniti
   expect(createRequest.options.headers['Content-Type']).toBe('application/json');
   expect(JSON.parse(createRequest.options.body)).toEqual({
     ratingKey: 'A', mediaId: 101, fromMs: 0, toMs: 60000, subtitleIndex: -1, audioMode: 'standard',
-    subtitleOffsetMs: 0,
+    subtitleOffsetMs: 0, resolution: '1080p',
   });
 
   await resolveRequestWith(createRequest, {id: 'job-1', status: 'queued'}, {status: 202});
@@ -1203,7 +1237,7 @@ test('retryable render failures resubmit the immutable full submitted payload', 
   const submittedBody = JSON.parse(firstCreate.options.body);
   expect(submittedBody).toEqual({
     ratingKey: 'A', mediaId: 101, fromMs: 0, toMs: 60000, subtitleIndex: 0, audioMode: 'dialogue',
-    subtitleOffsetMs: 0,
+    subtitleOffsetMs: 0, resolution: '1080p',
   });
 
   await resolveRequestWith(firstCreate, {id: 'job-retry', status: 'queued'}, {status: 202});
@@ -1886,13 +1920,13 @@ test('a successful render surfaces the saved clip via Open in library without lo
 const libraryResults = [
   {
     ratingKey: 'L1', mediaId: 5001, partId: 6001, type: 'movie',
-    title: 'Library Movie', year: 2023, duration: 5400000,
+    title: 'Library Movie', year: 2023, duration: 5400000, height: 1080,
     artwork: '/thumb/L1', videoResolution: '1080', audioChannels: 6,
   },
   {
     ratingKey: 'L2', mediaId: 5002, partId: 6002, type: 'episode',
     title: 'Pilot', grandparentTitle: 'Library Show', seasonNumber: 1, episodeNumber: 1,
-    duration: 2700000, artwork: '/thumb/L2', videoResolution: '720', audioChannels: 2,
+    duration: 2700000, artwork: '/thumb/L2', height: 720, videoResolution: '720', audioChannels: 2,
   },
 ];
 
@@ -2096,7 +2130,7 @@ test('selecting a library result opens the workspace and passes partId through s
   const createRequest = requestFor(pending, url => url === '/render-jobs');
   expect(JSON.parse(createRequest.options.body)).toMatchObject({
     ratingKey: 'L1', mediaId: 5001, partId: 6001,
-    fromMs: 0, toMs: 60000, subtitleIndex: 0, audioMode: 'standard', subtitleOffsetMs: 0,
+    fromMs: 0, toMs: 60000, subtitleIndex: 0, audioMode: 'standard', subtitleOffsetMs: 0, resolution: '1080p',
   });
 });
 
@@ -2141,7 +2175,7 @@ test('retry render from a library source resubmits the immutable spec with partI
   const submittedBody = JSON.parse(firstCreate.options.body);
   expect(submittedBody).toEqual({
     ratingKey: 'L1', mediaId: 5001, partId: 6001,
-    fromMs: 0, toMs: 60000, subtitleIndex: 0, audioMode: 'standard', subtitleOffsetMs: 0,
+    fromMs: 0, toMs: 60000, subtitleIndex: 0, audioMode: 'standard', subtitleOffsetMs: 0, resolution: '1080p',
   });
 
   await resolveRequestWith(firstCreate, {id: 'job-lib-retry', status: 'queued'}, {status: 202});
@@ -2186,7 +2220,7 @@ test('changing from a library source back to an active session omits partId (act
   const createRequest = requestFor(pending, url => url === '/render-jobs');
   expect(JSON.parse(createRequest.options.body)).toEqual({
     ratingKey: 'A', mediaId: 101, fromMs: 0, toMs: 60000,
-    subtitleIndex: 0, audioMode: 'standard', subtitleOffsetMs: 0,
+    subtitleIndex: 0, audioMode: 'standard', subtitleOffsetMs: 0, resolution: '1080p',
   });
   expect(JSON.parse(createRequest.options.body)).not.toHaveProperty('partId');
 });

--- a/frontend/src/components/ClipWorkspace.js
+++ b/frontend/src/components/ClipWorkspace.js
@@ -4,6 +4,7 @@ import PlayerPane from "./PlayerPane";
 import TrimScrubber from "./TrimScrubber";
 import SubtitlePanel from "./SubtitlePanel";
 import RenderJobBar from "./RenderJobBar";
+import {getSourceMediaHeight} from "./render-jobs";
 
 // Two-pane workspace shell. CSS grid (.cs-workspace) reflows to one column
 // below 960px — no duplicate DOM trees per breakpoint. Theater mode collapses
@@ -19,7 +20,7 @@ export default function ClipWorkspace({
   renderState, jobSpec, controlsChangedSinceJob,
   onCreateJob, onDownloadJob, onRetryJob, onRetryPoll, onCreateNewJob,
   onOpenClip,
-  audioMode, onAudioModeChange,
+  audioMode, onAudioModeChange, resolution, onResolutionChange,
   theaterMode, onToggleTheater,
               subtitleOffsetMs, onSubtitleOffsetChange,
               subtitle, ...subProps
@@ -77,6 +78,8 @@ export default function ClipWorkspace({
           <RenderJobBar
             startPosition={startPosition} endPosition={endPosition} selectedSubtitle={subtitle}
             audioMode={audioMode} onAudioModeChange={onAudioModeChange}
+            sourceMediaHeight={getSourceMediaHeight(session)}
+            resolution={resolution} onResolutionChange={onResolutionChange}
             renderState={renderState} jobSpec={jobSpec} controlsChangedSinceJob={controlsChangedSinceJob}
             onCreateJob={onCreateJob} onDownload={onDownloadJob} onRetry={onRetryJob}
             onRetryPoll={onRetryPoll} onCreateNew={onCreateNewJob} onOpenClip={onOpenClip}

--- a/frontend/src/components/RenderJobBar.js
+++ b/frontend/src/components/RenderJobBar.js
@@ -55,6 +55,8 @@ export default function RenderJobBar({
             sx={{borderColor: 'rgba(255,255,255,0.18)', color: 'text.secondary', fontFamily: 'var(--cs-mono-font)'}}/>
           <Chip size="small" label={spec.subtitle} variant="outlined"
             sx={{borderColor: 'rgba(255,255,255,0.18)', color: 'text.secondary'}}/>
+          <Chip size="small" label={spec.quality} variant="outlined"
+            sx={{borderColor: 'rgba(255,255,255,0.18)', color: 'text.secondary'}}/>
           <Chip size="small" label={spec.audioMode} variant="outlined"
             sx={{borderColor: 'rgba(255,255,255,0.18)', color: 'text.secondary'}}/>
           {spec.subtitleOffsetMs !== 0 && (

--- a/frontend/src/components/RenderJobBar.js
+++ b/frontend/src/components/RenderJobBar.js
@@ -1,6 +1,6 @@
-import {Box, Button, Chip, CircularProgress, FormControl, InputLabel, MenuItem, Select, Typography} from "@mui/material";
+import {Box, Button, Chip, CircularProgress, FormControl, InputLabel, MenuItem, Select, ToggleButton, ToggleButtonGroup, Typography} from "@mui/material";
 import {millisToDuration} from "../utils";
-import {JOB_STATES, jobErrorMessage, jobStatusLabel, formatExpiry, formatJobSpec, isTransportError, AUDIO_MODE_CHOICES} from "./render-jobs";
+import {JOB_STATES, jobErrorMessage, jobStatusLabel, formatExpiry, formatJobSpec, isTransportError, AUDIO_MODE_CHOICES, getAvailableResolutionChoices} from "./render-jobs";
 
 // Render-job bar. Displays the immutable submitted spec so the user always
 // knows what the current output corresponds to. Separates transport/polling
@@ -12,7 +12,7 @@ import {JOB_STATES, jobErrorMessage, jobStatusLabel, formatExpiry, formatJobSpec
 // Sticky on mobile, inline on desktop (handled via .cs-sticky-download CSS).
 export default function RenderJobBar({
   startPosition, endPosition, selectedSubtitle,
-  audioMode, onAudioModeChange,
+  audioMode, onAudioModeChange, resolution, onResolutionChange, sourceMediaHeight,
   renderState, jobSpec, controlsChangedSinceJob,
   onCreateJob, onDownload, onRetry, onRetryPoll, onCreateNew,
   onOpenClip,
@@ -32,6 +32,8 @@ export default function RenderJobBar({
   const showNewRender = hasJob && !busy && controlsChangedSinceJob
   const isRenderFailure = status === JOB_STATES.FAILED && error && !isTransportError(error)
   const isTransportFailure = status === JOB_STATES.FAILED && error && isTransportError(error)
+  const resolutionChoices = getAvailableResolutionChoices(sourceMediaHeight)
+  const nativeOnly = sourceMediaHeight == null || sourceMediaHeight < 480
 
   return (
     <Box className="cs-sticky-download" sx={{px: {xs: 1.5, sm: 2, md: 0}, py: {xs: 1.25, md: 0}, mt: {xs: 2.5, md: 2}}}>
@@ -66,8 +68,45 @@ export default function RenderJobBar({
         </Box>
       )}
 
-      {/* Audio mode control — always visible alongside the render controls */}
+      {/* Output controls — always visible alongside the render controls */}
       <Box sx={{display: 'flex', alignItems: 'flex-end', gap: {xs: 1, sm: 2}, flexWrap: 'wrap', mb: 1.25}}>
+        <Box sx={{flex: {xs: '1 1 100%', md: '1 1 100%'}, minWidth: 0}}>
+          <Typography id="resolution-select-label" variant="overline" sx={{color: 'text.secondary', display: 'block', lineHeight: 1, mb: 0.8}}>
+            Quality
+          </Typography>
+          <ToggleButtonGroup
+            value={resolution}
+            exclusive
+            onChange={(_, value) => value && onResolutionChange(value)}
+            aria-labelledby="resolution-select-label"
+            size="small"
+            sx={{
+              // A two-up grid on phones gives the tier names enough room to
+              // remain scannable; larger screens retain the compact four-up rail.
+              display: 'grid', gridTemplateColumns: {xs: `repeat(${Math.min(2, resolutionChoices.length)}, minmax(0, 1fr))`, sm: `repeat(${resolutionChoices.length}, minmax(0, 1fr))`}, width: '100%',
+              border: '1px solid rgba(255,255,255,0.1)', borderRadius: 2, overflow: 'hidden',
+              '& .MuiToggleButtonGroup-grouped': {border: 0, borderRadius: '0 !important', minHeight: {xs: 48, sm: 54}},
+              '& .MuiToggleButtonGroup-grouped + .MuiToggleButtonGroup-grouped': {borderLeft: '1px solid rgba(255,255,255,0.08)'},
+              '& .MuiToggleButtonGroup-grouped:nth-of-type(odd)': {borderLeft: {xs: '0 !important', sm: undefined}},
+              '& .MuiToggleButtonGroup-grouped:nth-of-type(n + 3)': {borderTop: {xs: '1px solid rgba(255,255,255,0.08)', sm: 0}},
+              '& .Mui-selected': {backgroundColor: 'rgba(255,115,0,0.18) !important', color: '#ffd9b0', boxShadow: 'inset 0 -2px 0 #ff7300'},
+            }}
+          >
+            {resolutionChoices.map(choice => (
+              <ToggleButton key={choice.value} value={choice.value} aria-label={`${nativeOnly && choice.value === 'native' ? 'Native' : choice.label} quality`} sx={{textTransform: 'none', px: {xs: 1, sm: 0.5}}}>
+                <Box sx={{lineHeight: 1.05}}>
+                  <Typography component="span" sx={{display: 'block', fontSize: '0.82rem', fontWeight: 700}}>{nativeOnly && choice.value === 'native' ? 'Native' : choice.label}</Typography>
+                  <Typography component="span" variant="caption" sx={{display: {xs: 'none', sm: 'block'}, color: 'text.secondary', fontSize: '0.64rem'}}>{nativeOnly && choice.value === 'native' ? 'Source' : choice.detail}</Typography>
+                </Box>
+              </ToggleButton>
+            ))}
+          </ToggleButtonGroup>
+          <Typography variant="caption" sx={{color: 'text.disabled', display: 'block', mt: 0.6}}>
+            {nativeOnly
+              ? (sourceMediaHeight == null ? 'Source dimensions unavailable — native output only.' : 'Source is below 480p — native output only.')
+              : 'Choose the output quality for your clip without upscaling.'}
+          </Typography>
+        </Box>
         <FormControl size="small" sx={{flex: {xs: '1 1 100%', sm: '1 1 200px'}, minWidth: 0}}>
           <InputLabel id="audio-mode-select">Audio mode</InputLabel>
           <Select

--- a/frontend/src/components/render-jobs.js
+++ b/frontend/src/components/render-jobs.js
@@ -19,6 +19,43 @@ export const AUDIO_MODES = {
   DIALOGUE_NORMALIZED: 'dialogue_normalized',
 }
 
+export const RENDER_RESOLUTIONS = {
+  NATIVE: 'native',
+  P1080: '1080p',
+  P720: '720p',
+  P480: '480p',
+}
+
+// Quality tiers are ordered from highest to lowest. Native is the safe
+// fallback when the source is below the lowest tier or its dimensions are
+// unavailable; it does not request an upscale.
+export const RESOLUTION_CHOICES = [
+  {value: RENDER_RESOLUTIONS.NATIVE, label: 'Extra high', detail: '4K', targetHeight: 2160},
+  {value: RENDER_RESOLUTIONS.P1080, label: 'High', detail: '1080', targetHeight: 1080},
+  {value: RENDER_RESOLUTIONS.P720, label: 'Medium', detail: '720', targetHeight: 720},
+  {value: RENDER_RESOLUTIONS.P480, label: 'Low', detail: '480', targetHeight: 480},
+]
+
+export function getSourceMediaHeight(session) {
+  const height = Number(session?.Media?.[0]?.height)
+  return Number.isFinite(height) && height > 0 ? height : null
+}
+
+export function getAvailableResolutionChoices(sourceHeight) {
+  const height = Number(sourceHeight)
+  if (!Number.isFinite(height) || height <= 0 || height < 480) return [RESOLUTION_CHOICES[0]]
+  return RESOLUTION_CHOICES.filter(choice => (
+    choice.value === RENDER_RESOLUTIONS.NATIVE
+      ? height >= choice.targetHeight
+      : choice.targetHeight <= height
+  ))
+}
+
+export function getSafeResolution(sourceHeight) {
+  const choices = getAvailableResolutionChoices(sourceHeight)
+  return choices[0].value
+}
+
 // User-facing labels and descriptions for each audio mode.
 export const AUDIO_MODE_CHOICES = [
   {
@@ -53,7 +90,7 @@ export function audioModeLabel(value) {
 // partId throws here rather than silently omitting the field — the backend
 // requires partId to resolve an explicit library source, so a silent omission
 // would route the request through the wrong (session-based) path.
-export function buildRenderJobRequest(session, startPosition, endPosition, selectedSubtitle, audioMode, subtitleOffsetMs) {
+export function buildRenderJobRequest(session, startPosition, endPosition, selectedSubtitle, audioMode, subtitleOffsetMs, resolution) {
   const mediaId = normalizeMediaId(session?.Media?.[0]?.Part?.[0]?.id)
   if (mediaId == null) throw new Error('The selected media part has an invalid media ID.')
   const body = {
@@ -64,6 +101,7 @@ export function buildRenderJobRequest(session, startPosition, endPosition, selec
     subtitleIndex: selectedSubtitle,
     audioMode: audioMode || AUDIO_MODES.STANDARD,
     subtitleOffsetMs: clampSubtitleOffsetMs(subtitleOffsetMs),
+    resolution: resolution || RENDER_RESOLUTIONS.NATIVE,
   }
   if (session?._sourceType === 'library') {
     const partId = normalizePartId(session._partId)
@@ -85,6 +123,7 @@ export function buildRenderJobRequestFromSpec(spec) {
     subtitleIndex: spec.subtitleIndex,
     audioMode: spec.audioMode || AUDIO_MODES.STANDARD,
     subtitleOffsetMs: clampSubtitleOffsetMs(spec?.subtitleOffsetMs),
+    resolution: spec?.resolution || RENDER_RESOLUTIONS.NATIVE,
   }
   // A library-source spec carries its partId; re-render must preserve it.
   // Reject (rather than silently omit) if the spec claims to be a library
@@ -149,7 +188,7 @@ export function isTransportError(error) {
 // Snapshot an immutable submitted spec for display. This is captured at job
 // creation time and never mutated — it represents what was actually submitted,
 // not the current (possibly edited) controls.
-export function snapshotJobSpec(session, startPosition, endPosition, selectedSubtitle, streams, audioMode, subtitleOffsetMs) {
+export function snapshotJobSpec(session, startPosition, endPosition, selectedSubtitle, streams, audioMode, subtitleOffsetMs, resolution) {
   const stream = selectedSubtitle >= 0 ? streams.find(s => s.index === selectedSubtitle) : null
   const offsetMs = clampSubtitleOffsetMs(subtitleOffsetMs)
   return {
@@ -170,6 +209,7 @@ export function snapshotJobSpec(session, startPosition, endPosition, selectedSub
     audioMode: audioMode || AUDIO_MODES.STANDARD,
     subtitleOffsetMs: offsetMs,
     subtitleOffsetLabel: `Offset ${formatSubtitleOffsetMs(offsetMs)}`,
+    resolution: resolution || RENDER_RESOLUTIONS.NATIVE,
   }
 }
 

--- a/frontend/src/components/render-jobs.js
+++ b/frontend/src/components/render-jobs.js
@@ -21,6 +21,7 @@ export const AUDIO_MODES = {
 
 export const RENDER_RESOLUTIONS = {
   NATIVE: 'native',
+  SOURCE_NATIVE: 'source-native',
   P1080: '1080p',
   P720: '720p',
   P480: '480p',
@@ -36,6 +37,8 @@ export const RESOLUTION_CHOICES = [
   {value: RENDER_RESOLUTIONS.P480, label: 'Low', detail: '480', targetHeight: 480},
 ]
 
+const SOURCE_NATIVE_CHOICE = {value: RENDER_RESOLUTIONS.SOURCE_NATIVE, label: 'Native', detail: 'Source', targetHeight: 0}
+
 export function getSourceMediaHeight(session) {
   const height = Number(session?.Media?.[0]?.height)
   return Number.isFinite(height) && height > 0 ? height : null
@@ -43,7 +46,7 @@ export function getSourceMediaHeight(session) {
 
 export function getAvailableResolutionChoices(sourceHeight) {
   const height = Number(sourceHeight)
-  if (!Number.isFinite(height) || height <= 0 || height < 480) return [RESOLUTION_CHOICES[0]]
+  if (!Number.isFinite(height) || height <= 0 || height < 480) return [SOURCE_NATIVE_CHOICE]
   return RESOLUTION_CHOICES.filter(choice => (
     choice.value === RENDER_RESOLUTIONS.NATIVE
       ? height >= choice.targetHeight
@@ -54,6 +57,25 @@ export function getAvailableResolutionChoices(sourceHeight) {
 export function getSafeResolution(sourceHeight) {
   const choices = getAvailableResolutionChoices(sourceHeight)
   return choices[0].value
+}
+
+// `native` is the legacy Extra high wire value; only source-native is Native.
+export function resolutionLabel(value) {
+  switch (value) {
+    case RENDER_RESOLUTIONS.SOURCE_NATIVE: return 'Native'
+    case RENDER_RESOLUTIONS.NATIVE:
+    case '2160p':
+    case '4k':
+    case '4K':
+    case 'extra-high': return 'Extra high'
+    case RENDER_RESOLUTIONS.P1080:
+    case 'high': return 'High'
+    case RENDER_RESOLUTIONS.P720:
+    case 'medium': return 'Medium'
+    case RENDER_RESOLUTIONS.P480:
+    case 'low': return 'Low'
+    default: return 'Native'
+  }
 }
 
 // User-facing labels and descriptions for each audio mode.
@@ -263,6 +285,7 @@ export function formatJobSpec(spec) {
     duration: millisToDuration(spec.clipDuration),
     subtitle: spec.subtitleLabel,
     audioMode: audioModeLabel(spec.audioMode),
+    quality: resolutionLabel(spec.resolution),
     subtitleOffsetMs: clampSubtitleOffsetMs(spec?.subtitleOffsetMs),
     subtitleOffsetLabel: `Offset ${formatSubtitleOffsetMs(spec?.subtitleOffsetMs)}`,
   }

--- a/render_jobs.go
+++ b/render_jobs.go
@@ -107,20 +107,25 @@ const (
 	// the highest quality tier. It is intentionally retained for wire
 	// compatibility; it means Extra high/4K, not an unconditional native
 	// output request.
-	RenderResolutionNative    = "native"
-	RenderResolution2160p     = "2160p"
-	RenderResolution1080p     = "1080p"
-	RenderResolution720p      = "720p"
-	RenderResolution480p      = "480p"
-	RenderResolutionExtraHigh = "extra-high"
-	RenderResolutionHigh      = "high"
-	RenderResolutionMedium    = "medium"
-	RenderResolutionLow       = "low"
+	RenderResolutionNative = "native"
+	// RenderResolutionSourceNative requests source dimensions. RenderResolutionNative
+	// remains the legacy Extra high/4K wire value for compatibility.
+	RenderResolutionSourceNative = "source-native"
+	RenderResolution2160p        = "2160p"
+	RenderResolution1080p        = "1080p"
+	RenderResolution720p         = "720p"
+	RenderResolution480p         = "480p"
+	RenderResolutionExtraHigh    = "extra-high"
+	RenderResolutionHigh         = "high"
+	RenderResolutionMedium       = "medium"
+	RenderResolutionLow          = "low"
 )
 
 func renderResolutionTarget(resolution string) (int, error) {
 	switch resolution {
 	case "":
+		return 0, nil
+	case RenderResolutionSourceNative:
 		return 0, nil
 	case RenderResolutionNative, RenderResolution2160p, "4k", "4K", RenderResolutionExtraHigh:
 		return 2160, nil

--- a/render_jobs.go
+++ b/render_jobs.go
@@ -54,16 +54,19 @@ const (
 )
 
 type RenderJobCreateRequest struct {
-	RatingKey        string    `json:"ratingKey"`
-	MediaID          int64     `json:"mediaId"`
-	PartID           *int64    `json:"partId,omitempty"`
-	FromMs           int64     `json:"fromMs"`
-	ToMs             int64     `json:"toMs"`
-	SubtitleIndex    int       `json:"subtitleIndex"`
-	SubtitleOffsetMs int64     `json:"subtitleOffsetMs"`
-	Height           int       `json:"height"`
-	QP               int       `json:"qp"`
-	AudioMode        AudioMode `json:"audioMode"`
+	RatingKey        string `json:"ratingKey"`
+	MediaID          int64  `json:"mediaId"`
+	PartID           *int64 `json:"partId,omitempty"`
+	FromMs           int64  `json:"fromMs"`
+	ToMs             int64  `json:"toMs"`
+	SubtitleIndex    int    `json:"subtitleIndex"`
+	SubtitleOffsetMs int64  `json:"subtitleOffsetMs"`
+	Resolution       string `json:"resolution"`
+	// Height is retained for compatibility with older clients. New clients
+	// should use Resolution so the server can cap presets to the source tier.
+	Height    int       `json:"height"`
+	QP        int       `json:"qp"`
+	AudioMode AudioMode `json:"audioMode"`
 }
 
 type renderJobSpec struct {
@@ -84,6 +87,7 @@ type renderJobSpec struct {
 	SubtitleCodec         string
 	SubtitleFormat        string
 	SubtitleEmbeddedIndex int
+	Resolution            string
 	Height                int
 	QP                    int
 	AudioMode             AudioMode
@@ -96,6 +100,72 @@ type renderJobSpec struct {
 	EpisodeNumber         *int
 	EpisodeTitle          string
 	ThumbnailURL          string
+}
+
+const (
+	// RenderResolutionNative is the identifier used by existing clients for
+	// the highest quality tier. It is intentionally retained for wire
+	// compatibility; it means Extra high/4K, not an unconditional native
+	// output request.
+	RenderResolutionNative    = "native"
+	RenderResolution2160p     = "2160p"
+	RenderResolution1080p     = "1080p"
+	RenderResolution720p      = "720p"
+	RenderResolution480p      = "480p"
+	RenderResolutionExtraHigh = "extra-high"
+	RenderResolutionHigh      = "high"
+	RenderResolutionMedium    = "medium"
+	RenderResolutionLow       = "low"
+)
+
+func renderResolutionTarget(resolution string) (int, error) {
+	switch resolution {
+	case "":
+		return 0, nil
+	case RenderResolutionNative, RenderResolution2160p, "4k", "4K", RenderResolutionExtraHigh:
+		return 2160, nil
+	case RenderResolution1080p:
+		return 1080, nil
+	case RenderResolutionHigh:
+		return 1080, nil
+	case RenderResolution720p:
+		return 720, nil
+	case RenderResolutionMedium:
+		return 720, nil
+	case RenderResolution480p:
+		return 480, nil
+	case RenderResolutionLow:
+		return 480, nil
+	default:
+		return 0, fmt.Errorf("resolution is invalid")
+	}
+}
+
+// resolveRenderHeight applies a loose quality tier policy. A source whose
+// height is within 20% of the requested tier is left native to avoid an
+// unnecessary resize. Sources above that range are scaled down to the tier;
+// sources below it are left native so a request can never upscale media.
+// Returning zero is also the safe fallback when source dimensions are
+// unavailable.
+func resolveRenderHeight(resolution string, sourceHeight int) (int, error) {
+	target, err := renderResolutionTarget(resolution)
+	if err != nil || target == 0 {
+		return target, err
+	}
+	if sourceHeight <= 0 {
+		return 0, nil
+	}
+	// Compare without floating point or multiplication of untrusted source
+	// dimensions: [80%, 120%] is [target-target/5, target+target/5].
+	lower := target - target/5
+	upper := target + target/5
+	if sourceHeight >= lower && sourceHeight <= upper {
+		return 0, nil
+	}
+	if sourceHeight > target {
+		return target, nil
+	}
+	return 0, nil
 }
 
 type renderJobError struct {
@@ -1248,6 +1318,10 @@ func validateRenderJobRequestWithMetadataAndItem(request RenderJobCreateRequest,
 				return renderJobSpec{}, errors.New("subtitle codec is not supported")
 			}
 		}
+		height, err := resolveRequestRenderHeight(request, mediaHeight(previewMedia))
+		if err != nil {
+			return renderJobSpec{}, err
+		}
 		sourceMediaID := request.MediaID
 		if sourceMediaID <= 0 {
 			sourceMediaID = previewMedia.ID
@@ -1269,7 +1343,8 @@ func validateRenderJobRequestWithMetadataAndItem(request RenderJobCreateRequest,
 			SubtitleCodec:         subtitle.Codec,
 			SubtitleFormat:        subtitle.Format,
 			SubtitleEmbeddedIndex: subtitle.EmbeddedIndex,
-			Height:                request.Height,
+			Resolution:            normalizedRenderResolution(request),
+			Height:                height,
 			QP:                    request.QP,
 			AudioMode:             audioMode,
 		}
@@ -1323,6 +1398,10 @@ func validateRenderJobRequestWithMetadataAndItem(request RenderJobCreateRequest,
 				if request.SubtitleIndex >= 0 && subtitleEmbeddedIndex < 0 {
 					return renderJobSpec{}, errors.New("subtitle codec is not supported")
 				}
+				height, err := resolveRequestRenderHeight(request, sessionMediaHeight(media))
+				if err != nil {
+					return renderJobSpec{}, err
+				}
 				partID, _ := sessionIDAsInt64(part.ID)
 				spec := renderJobSpec{
 					OwnerUUID:             user.Uuid,
@@ -1337,7 +1416,8 @@ func validateRenderJobRequestWithMetadataAndItem(request RenderJobCreateRequest,
 					SubtitleOffsetMs:      request.SubtitleOffsetMs,
 					SubtitlePGS:           subtitlePGS,
 					SubtitleEmbeddedIndex: subtitleEmbeddedIndex,
-					Height:                request.Height,
+					Resolution:            normalizedRenderResolution(request),
+					Height:                height,
 					QP:                    request.QP,
 					AudioMode:             audioMode,
 				}
@@ -1371,6 +1451,12 @@ func validateRenderJobRequestFields(request RenderJobCreateRequest) error {
 	if err := validateSubtitleOffsetMs(request.SubtitleOffsetMs); err != nil {
 		return err
 	}
+	if _, err := renderResolutionTarget(request.Resolution); err != nil {
+		return err
+	}
+	if request.Resolution != "" && request.Height != 0 {
+		return errors.New("resolution and height cannot both be specified")
+	}
 	if request.Height < 0 || request.Height > 2160 || request.Height > 0 && (request.Height < 144 || request.Height%2 != 0) {
 		return errors.New("height is invalid")
 	}
@@ -1378,6 +1464,34 @@ func validateRenderJobRequestFields(request RenderJobCreateRequest) error {
 		return errors.New("qp is invalid")
 	}
 	return nil
+}
+
+func normalizedRenderResolution(request RenderJobCreateRequest) string {
+	if request.Resolution == "" {
+		return ""
+	}
+	return request.Resolution
+}
+
+func resolveRequestRenderHeight(request RenderJobCreateRequest, sourceHeight int) (int, error) {
+	if request.Resolution != "" {
+		return resolveRenderHeight(request.Resolution, sourceHeight)
+	}
+	return request.Height, nil
+}
+
+func mediaHeight(media *components.Media) int {
+	if media != nil && media.Height != nil && *media.Height > 0 {
+		return *media.Height
+	}
+	return 0
+}
+
+func sessionMediaHeight(media sessionMedia) int {
+	if media.Height != nil && *media.Height > 0 {
+		return *media.Height
+	}
+	return 0
 }
 
 func sourceTitle(sessions []sessionMetadata, ratingKey string, metadata *components.Metadata) string {

--- a/render_jobs_test.go
+++ b/render_jobs_test.go
@@ -63,6 +63,8 @@ func TestRenderResolutionTiersPreserveNearbySourcesWithoutUpscaling(t *testing.T
 		{RenderResolution480p, 360, 0},
 		{RenderResolution480p, 480, 0},
 		{RenderResolution480p, 600, 480},
+		{RenderResolutionSourceNative, 360, 0},
+		{RenderResolutionSourceNative, 0, 0},
 	}
 	for _, test := range tests {
 		got, err := resolveRenderHeight(test.resolution, test.source)
@@ -73,7 +75,7 @@ func TestRenderResolutionTiersPreserveNearbySourcesWithoutUpscaling(t *testing.T
 }
 
 func TestRenderResolutionValidationAllowsCompatibleTierIdentifiers(t *testing.T) {
-	for _, resolution := range []string{"", RenderResolutionNative, RenderResolution2160p, "4k", RenderResolutionExtraHigh, RenderResolution1080p, RenderResolutionHigh, RenderResolution720p, RenderResolutionMedium, RenderResolution480p, RenderResolutionLow} {
+	for _, resolution := range []string{"", RenderResolutionNative, RenderResolutionSourceNative, RenderResolution2160p, "4k", RenderResolutionExtraHigh, RenderResolution1080p, RenderResolutionHigh, RenderResolution720p, RenderResolutionMedium, RenderResolution480p, RenderResolutionLow} {
 		if err := validateRenderJobRequestFields(RenderJobCreateRequest{RatingKey: "movie", MediaID: 1, FromMs: 0, ToMs: 1, SubtitleIndex: -1, Resolution: resolution}); err != nil {
 			t.Errorf("resolution %q rejected: %v", resolution, err)
 		}

--- a/render_jobs_test.go
+++ b/render_jobs_test.go
@@ -42,6 +42,49 @@ func TestRenderJobValidationRejectsSubtitleOffsetOutsideRange(t *testing.T) {
 	}
 }
 
+func TestRenderResolutionTiersPreserveNearbySourcesWithoutUpscaling(t *testing.T) {
+	tests := []struct {
+		resolution string
+		source     int
+		want       int
+	}{
+		{RenderResolutionNative, 2160, 0},
+		{RenderResolutionNative, 2500, 0},
+		{RenderResolutionNative, 2600, 2160},
+		{RenderResolution2160p, 1080, 0},
+		{RenderResolution1080p, 2160, 1080},
+		{RenderResolution1080p, 1280, 0},
+		{RenderResolution1080p, 1300, 1080},
+		{RenderResolution1080p, 720, 0},
+		{RenderResolution720p, 1080, 720},
+		{RenderResolution720p, 850, 0},
+		{RenderResolution720p, 900, 720},
+		{RenderResolution720p, 480, 0},
+		{RenderResolution480p, 360, 0},
+		{RenderResolution480p, 480, 0},
+		{RenderResolution480p, 600, 480},
+	}
+	for _, test := range tests {
+		got, err := resolveRenderHeight(test.resolution, test.source)
+		if err != nil || got != test.want {
+			t.Errorf("resolveRenderHeight(%q, %d) = %d, %v; want %d", test.resolution, test.source, got, err, test.want)
+		}
+	}
+}
+
+func TestRenderResolutionValidationAllowsCompatibleTierIdentifiers(t *testing.T) {
+	for _, resolution := range []string{"", RenderResolutionNative, RenderResolution2160p, "4k", RenderResolutionExtraHigh, RenderResolution1080p, RenderResolutionHigh, RenderResolution720p, RenderResolutionMedium, RenderResolution480p, RenderResolutionLow} {
+		if err := validateRenderJobRequestFields(RenderJobCreateRequest{RatingKey: "movie", MediaID: 1, FromMs: 0, ToMs: 1, SubtitleIndex: -1, Resolution: resolution}); err != nil {
+			t.Errorf("resolution %q rejected: %v", resolution, err)
+		}
+	}
+	for _, resolution := range []string{"2160", "720", "native-ish"} {
+		if err := validateRenderJobRequestFields(RenderJobCreateRequest{RatingKey: "movie", MediaID: 1, FromMs: 0, ToMs: 1, SubtitleIndex: -1, Resolution: resolution}); err == nil {
+			t.Errorf("resolution %q was accepted", resolution)
+		}
+	}
+}
+
 func TestFfmpegRenderOutputForcesMP4Muxer(t *testing.T) {
 	args := ffmpeg.KwArgs{}
 	configureMP4Output(args)


### PR DESCRIPTION
## Summary
- add source-aware Extra high, High, Medium, and Low clip quality choices
- preserve native output near a selected tier and never upscale
- hide unsupported tiers and improve mobile quality-control layout

## Validation
- go test ./...
- CI=true npm test -- --watchAll=false