### PR TITLE
Handle inconsistent Plex library metadata

### DIFF
--- a/application.go
+++ b/application.go
@@ -488,9 +488,6 @@ func (a *Application) plexSecurityUserToken(ctx context.Context) (components.Sec
 // use the token belonging to the caller; the configured administrator client
 // is retained for the existing active-session path.
 func (a *Application) getMetadataItem(ctx context.Context, ratingKey string, userScoped bool) (*components.Metadata, error) {
-	var response *operations.GetMetadataItemResponse
-	var err error
-	request := operations.GetMetadataItemRequest{Ids: []string{ratingKey}}
 	if userScoped {
 		if token := AuthTokenFromContext(ctx); token == nil || strings.TrimSpace(*token) == "" {
 			return nil, errors.New("caller-scoped Plex client is unavailable")
@@ -501,15 +498,45 @@ func (a *Application) getMetadataItem(ctx context.Context, ratingKey string, use
 		if a.plexAdmin == nil {
 			return nil, errors.New("Plex client is unavailable")
 		}
-		response, err = a.plexAdmin.Content.GetMetadataItem(ctx, request)
+		return a.getAdminMetadataItem(ctx, ratingKey)
 	}
+}
+
+// getAdminMetadataItem keeps the historical admin behavior (a missing
+// ratingKey is tolerated) while using the bounded library decoder rather than
+// the generated Plex client decoder.
+func (a *Application) getAdminMetadataItem(ctx context.Context, ratingKey string) (*components.Metadata, error) {
+	base, err := url.Parse(a.config.Plex.Host)
+	if err != nil || (base.Scheme != "http" && base.Scheme != "https") || base.Host == "" || base.User != nil {
+		return nil, errors.New("configured Plex origin is invalid")
+	}
+	base.Path = strings.TrimRight(base.Path, "/") + "/library/metadata/" + url.PathEscape(ratingKey)
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, base.String(), nil)
 	if err != nil {
 		return nil, err
 	}
-	if response == nil || response.MediaContainerWithMetadata == nil || response.MediaContainerWithMetadata.MediaContainer == nil || len(response.MediaContainerWithMetadata.MediaContainer.Metadata) == 0 {
+	request.Header.Set("X-Plex-Token", a.config.Plex.Token)
+	request.Header.Set("Accept", "application/json")
+	response, err := callerPlexHTTPClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("could not get Plex metadata: %w", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		return nil, &libraryHTTPError{status: response.StatusCode}
+	}
+	body, err := io.ReadAll(io.LimitReader(response.Body, maxLibraryResponseBytes))
+	if err != nil {
+		return nil, fmt.Errorf("could not read Plex metadata: %w", err)
+	}
+	var decoded plexMetadataResponse
+	if err := unmarshalPlexLibraryJSON(body, &decoded); err != nil {
+		return nil, fmt.Errorf("could not decode Plex metadata: %w", err)
+	}
+	if decoded.MediaContainer == nil || len(decoded.MediaContainer.Metadata) == 0 {
 		return nil, &sourceValidationError{message: "requested media is unavailable"}
 	}
-	metadata := response.MediaContainerWithMetadata.MediaContainer.Metadata[0]
+	metadata := decoded.MediaContainer.Metadata[0]
 	if metadata.RatingKey != nil && *metadata.RatingKey != "" && *metadata.RatingKey != ratingKey {
 		return nil, &sourceValidationError{message: "requested media is unavailable"}
 	}

--- a/library_search.go
+++ b/library_search.go
@@ -1,13 +1,17 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"net/url"
+	"reflect"
+	"strconv"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -147,7 +151,7 @@ func (a *Application) SearchLibrary(ctx context.Context, query string) ([]Librar
 		return nil, err
 	}
 	var search plexSearchResponse
-	if err := json.Unmarshal(body, &search); err != nil {
+	if err := unmarshalPlexLibraryJSON(body, &search); err != nil {
 		return nil, fmt.Errorf("could not decode Plex library search: %w", err)
 	}
 	if search.MediaContainer == nil {
@@ -496,7 +500,7 @@ func (a *Application) getLibraryChildren(ctx context.Context, ratingKey, token s
 		return nil, fmt.Errorf("could not read Plex library children: %w", err)
 	}
 	var response plexMetadataResponse
-	if err := json.Unmarshal(body, &response); err != nil {
+	if err := unmarshalPlexLibraryJSON(body, &response); err != nil {
 		return nil, fmt.Errorf("could not decode Plex library children: %w", err)
 	}
 	if response.MediaContainer == nil {
@@ -552,7 +556,7 @@ func (a *Application) getCallerMetadataItem(ctx context.Context, ratingKey, toke
 		return nil, fmt.Errorf("could not read Plex metadata: %w", err)
 	}
 	var decoded plexMetadataResponse
-	if err := json.Unmarshal(body, &decoded); err != nil {
+	if err := unmarshalPlexLibraryJSON(body, &decoded); err != nil {
 		return nil, fmt.Errorf("could not decode Plex metadata: %w", err)
 	}
 	if decoded.MediaContainer == nil {
@@ -573,4 +577,210 @@ func minInt(a, b int) int {
 		return a
 	}
 	return b
+}
+
+// unmarshalPlexLibraryJSON is the compatibility boundary for PMS library
+// responses. The generated Plex models use *bool for several flags, while PMS
+// versions also emit those flags as 0/1 or "0"/"1" and occasionally quote
+// numeric fields. Normalize only values whose reflected destination supports
+// the compatibility conversion; unknown properties retain normal JSON
+// semantics.
+func unmarshalPlexLibraryJSON(data []byte, target any) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		return err
+	}
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		if err == nil {
+			return errors.New("invalid JSON: multiple values")
+		}
+		return err
+	}
+
+	value, err := normalizePlexLibraryJSONValue(value, reflect.TypeOf(target), "")
+	if err != nil {
+		return err
+	}
+	normalized, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(normalized, target)
+}
+
+func normalizePlexLibraryJSONValue(value any, targetType reflect.Type, path string) (any, error) {
+	if targetType == nil || value == nil {
+		return value, nil
+	}
+	for targetType.Kind() == reflect.Pointer {
+		targetType = targetType.Elem()
+	}
+
+	if targetType.Kind() == reflect.Bool {
+		switch typed := value.(type) {
+		case bool:
+			return typed, nil
+		case string:
+			switch typed {
+			case "0":
+				return false, nil
+			case "1":
+				return true, nil
+			}
+		case json.Number:
+			switch typed.String() {
+			case "0":
+				return false, nil
+			case "1":
+				return true, nil
+			}
+		}
+		return nil, invalidPlexValueError(path, targetType, "bool or 0/1", value)
+	}
+
+	// A few generated Plex union types (for example SkipChildren and
+	// HasVoiceActivity) accept a bool or a string 0/1. Numeric 0/1 should enter
+	// the same bool branch without changing unrelated numeric enum fields.
+	if isPlexBooleanUnion(targetType) {
+		if number, ok := value.(json.Number); ok {
+			switch number.String() {
+			case "0":
+				return false, nil
+			case "1":
+				return true, nil
+			default:
+				return nil, invalidPlexValueError(path, targetType, "Plex boolean 0/1", value)
+			}
+		}
+		return value, nil
+	}
+
+	if stringValue, ok := value.(string); ok {
+		if number, ok := normalizeQuotedPlexNumber(stringValue, targetType); ok {
+			return number, nil
+		}
+		if isPlexNumericType(targetType) {
+			return nil, invalidPlexValueError(path, targetType, targetType.String(), value)
+		}
+	}
+
+	switch targetType.Kind() {
+	case reflect.Struct:
+		object, ok := value.(map[string]any)
+		if !ok {
+			return value, nil
+		}
+		for i := 0; i < targetType.NumField(); i++ {
+			field := targetType.Field(i)
+			jsonName := strings.Split(field.Tag.Get("json"), ",")[0]
+			if jsonName == "-" {
+				continue
+			}
+			if jsonName == "" {
+				jsonName = field.Name
+			}
+			fieldValue, ok := object[jsonName]
+			if !ok {
+				continue
+			}
+			normalized, err := normalizePlexLibraryJSONValue(fieldValue, field.Type, plexJSONPath(path, jsonName))
+			if err != nil {
+				return nil, err
+			}
+			object[jsonName] = normalized
+		}
+	case reflect.Slice, reflect.Array:
+		items, ok := value.([]any)
+		if !ok {
+			return value, nil
+		}
+		for i := range items {
+			normalized, err := normalizePlexLibraryJSONValue(items[i], targetType.Elem(), fmt.Sprintf("%s[%d]", path, i))
+			if err != nil {
+				return nil, err
+			}
+			items[i] = normalized
+		}
+	case reflect.Map:
+		items, ok := value.(map[string]any)
+		if !ok {
+			return value, nil
+		}
+		for key, item := range items {
+			normalized, err := normalizePlexLibraryJSONValue(item, targetType.Elem(), plexJSONPath(path, key))
+			if err != nil {
+				return nil, err
+			}
+			items[key] = normalized
+		}
+	}
+	return value, nil
+}
+
+func isPlexBooleanUnion(targetType reflect.Type) bool {
+	if targetType.Kind() != reflect.Struct {
+		return false
+	}
+	booleanField, ok := targetType.FieldByName("Boolean")
+	return ok && booleanField.Type == reflect.TypeOf((*bool)(nil))
+}
+
+func isPlexNumericType(targetType reflect.Type) bool {
+	switch targetType.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr,
+		reflect.Float32, reflect.Float64:
+		return true
+	default:
+		return false
+	}
+}
+
+func normalizeQuotedPlexNumber(value string, targetType reflect.Type) (json.Number, bool) {
+	if !isPlexNumericType(targetType) || value == "" {
+		return "", false
+	}
+	switch targetType.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		parsed, err := strconv.ParseInt(value, 10, targetType.Bits())
+		if err != nil {
+			return "", false
+		}
+		return json.Number(strconv.FormatInt(parsed, 10)), true
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		parsed, err := strconv.ParseUint(value, 10, targetType.Bits())
+		if err != nil {
+			return "", false
+		}
+		return json.Number(strconv.FormatUint(parsed, 10)), true
+	case reflect.Float32, reflect.Float64:
+		parsed, err := strconv.ParseFloat(value, targetType.Bits())
+		if err != nil || math.IsNaN(parsed) || math.IsInf(parsed, 0) {
+			return "", false
+		}
+		return json.Number(strconv.FormatFloat(parsed, 'g', -1, targetType.Bits())), true
+	}
+	return "", false
+}
+
+func invalidPlexValueError(path string, targetType reflect.Type, expected string, value any) error {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		encoded = []byte(fmt.Sprintf("%v", value))
+	}
+	if path == "" {
+		path = "$"
+	}
+	return fmt.Errorf("invalid Plex value at %s: expected %s, got %s", path, expected, encoded)
+}
+
+func plexJSONPath(parent, field string) string {
+	if parent == "" {
+		return field
+	}
+	return parent + "." + field
 }

--- a/library_search_test.go
+++ b/library_search_test.go
@@ -80,6 +80,104 @@ func TestSearchLibraryUsesCallerTokenFiltersAndRefetchesHubs(t *testing.T) {
 	}
 }
 
+func TestGetMetadataItemAdminUsesCompatibleDirectDecoder(t *testing.T) {
+	plex := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("X-Plex-Token"); got != "admin-token" {
+			t.Errorf("admin metadata token = %q, want admin-token", got)
+		}
+		if r.URL.Path != "/library/metadata/movie-1" {
+			t.Errorf("metadata path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"MediaContainer":{"Metadata":[{"ratingKey":"movie-1","type":"movie","title":"Admin movie","search":0}]}}`)
+	}))
+	defer plex.Close()
+	config := Config{}
+	config.Plex.Host = plex.URL
+	config.Plex.Token = "admin-token"
+	app := &Application{
+		config:    config,
+		plexAdmin: plexgo.New(plexgo.WithServerURL(plex.URL), plexgo.WithSecurity(config.Plex.Token)),
+	}
+
+	metadata, err := app.getMetadataItem(context.Background(), "movie-1", false)
+	if err != nil {
+		t.Fatalf("admin metadata lookup failed: %v", err)
+	}
+	if metadata == nil || metadata.RatingKey == nil || *metadata.RatingKey != "movie-1" || metadata.Title != "Admin movie" {
+		t.Fatalf("admin metadata = %+v", metadata)
+	}
+}
+
+func TestLibraryJSONCompatibilityAcceptsNumericBooleanFlagsInSearchAndMetadata(t *testing.T) {
+	var detailRequests int
+	plex := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/hubs/search":
+			_, _ = io.WriteString(w, `{"MediaContainer":{"Hub":[{"Metadata":[{"ratingKey":"movie-1","type":"movie","title":"Movie","search":0}]}]}}`)
+		case "/library/metadata/movie-1":
+			detailRequests++
+			_, _ = io.WriteString(w, `{"MediaContainer":{"Metadata":[{"ratingKey":"movie-1","type":"movie","title":"Movie","Media":[{"id":10,"has64bitOffsets":0,"Part":[{"id":20,"duration":1000,"accessible":1,"exists":"1","key":"/library/parts/20/file"}]}]}]}}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer plex.Close()
+	config := Config{}
+	config.Plex.Host = plex.URL
+	app := &Application{config: config}
+	ctx := ContextWithAuthToken(context.Background(), "caller-token")
+
+	results, err := app.SearchLibrary(ctx, "movie")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 || results[0].RatingKey != "movie-1" || results[0].MediaID != 10 || results[0].PartID != 20 {
+		t.Fatalf("numeric-flag search results = %+v", results)
+	}
+
+	if _, err := app.GetLibrarySource(ctx, "movie-1", 10, 20); err != nil {
+		t.Fatalf("numeric-flag metadata retrieval failed: %v", err)
+	}
+	if detailRequests != 2 {
+		t.Fatalf("detail requests = %d, want search refetch plus metadata retrieval", detailRequests)
+	}
+}
+
+func TestUnmarshalPlexLibraryJSONRejectsMalformedBooleanFlags(t *testing.T) {
+	for _, body := range []string{
+		`{"MediaContainer":{"Metadata":[{"ratingKey":"movie-1","Media":[{"Part":[{"accessible":2}]}]}]}}`,
+		`{"MediaContainer":{"Metadata":[{"ratingKey":"movie-1","Media":[{"Part":[{"accessible":"yes"}]}]}]}}`,
+	} {
+		var response plexMetadataResponse
+		if err := unmarshalPlexLibraryJSON([]byte(body), &response); err == nil {
+			t.Fatalf("malformed boolean flag %s was accepted", body)
+		}
+	}
+}
+
+func TestUnmarshalPlexLibraryJSONAcceptsQuotedMetadataMediaAndPartNumbers(t *testing.T) {
+	body := []byte(`{"MediaContainer":{"Metadata":[{"ratingKey":"movie-1","year":"2024","duration":"90000","Media":[{"id":"10","bitrate":"8000","Part":[{"id":"20","duration":"60000","size":"1234","key":"/library/parts/20/file"}]}]}]}}`)
+	var response plexMetadataResponse
+	if err := unmarshalPlexLibraryJSON(body, &response); err != nil {
+		t.Fatal(err)
+	}
+	metadata := response.MediaContainer.Metadata[0]
+	if metadata.Year == nil || *metadata.Year != 2024 || metadata.Duration == nil || *metadata.Duration != 90000 || metadata.Media[0].ID != 10 || metadata.Media[0].Bitrate == nil || *metadata.Media[0].Bitrate != 8000 || metadata.Media[0].Part[0].ID != 20 || metadata.Media[0].Part[0].Duration == nil || *metadata.Media[0].Part[0].Duration != 60000 || metadata.Media[0].Part[0].Size == nil || *metadata.Media[0].Part[0].Size != 1234 {
+		t.Fatalf("quoted numeric metadata = %+v", metadata)
+	}
+}
+
+func TestUnmarshalPlexLibraryJSONReportsQuotedNumericPath(t *testing.T) {
+	body := []byte(`{"MediaContainer":{"Metadata":[{"ratingKey":"movie-1","Media":[{"Part":[{"duration":"not-a-number"}]}]}]}}`)
+	var response plexMetadataResponse
+	err := unmarshalPlexLibraryJSON(body, &response)
+	if err == nil || !strings.Contains(err.Error(), "MediaContainer.Metadata[0].Media[0].Part[0].duration") || !strings.Contains(err.Error(), "expected int") || !strings.Contains(err.Error(), `got "not-a-number"`) {
+		t.Fatalf("quoted numeric error = %v", err)
+	}
+}
+
 func TestSearchLibraryRequiresCallerTokenAndValidQuery(t *testing.T) {
 	app := &Application{}
 	if _, err := app.SearchLibrary(context.Background(), "movie"); err == nil {


### PR DESCRIPTION
## Summary
- decode Plex numeric boolean flags and quoted numeric metadata fields at the library boundary
- use the compatibility decoder for administrator-backed preview metadata
- add regression coverage for search, metadata, and invalid wire values

## Testing
- go test -count=1 ./...