### PR TITLE
Support configurable embedding contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,8 +142,9 @@ CutScene includes an optional semantic-search proof of concept with shared pgvec
 
 - NVIDIA: Hugging Face Text Embeddings Inference (TEI), `BAAI/bge-base-en-v1.5`, service `tei`.
 - AMD: vLLM ROCm, `BAAI/bge-base-en-v1.5`, service `embeddings`.
+- Qwen/NVIDIA: vLLM OpenAI-compatible pooling endpoint, `Qwen/Qwen3-Embedding-0.6B`, service `embeddings`.
 
-Neither PostgreSQL nor the embedding service publishes a host port; CutScene reaches both over Compose's private network. The shared [docker-compose.semantic-search.yaml](docker-compose.semantic-search.yaml) contains PostgreSQL only. Do not combine the NVIDIA and AMD overlays.
+Neither PostgreSQL nor the embedding service publishes a host port; CutScene reaches both over Compose's private network. The shared [docker-compose.semantic-search.yaml](docker-compose.semantic-search.yaml) contains PostgreSQL only. Do not combine the NVIDIA, AMD, and Qwen overlays.
 
 #### NVIDIA prerequisites and startup
 
@@ -187,6 +188,44 @@ docker compose -f docker-compose.yaml -f docker-compose.semantic-search.yaml -f 
 ```
 
 Wait for `postgres` and the selected embedding service (`tei` for NVIDIA or `embeddings` for AMD) to report `healthy` before indexing. The model loads during startup, so the embedding healthcheck can take a while. For example, inspect the shared database health with `pg_isready -U cutscene -d cutscene` in the `postgres` container and inspect the selected service with its `/health` endpoint. The sample `semantic_search.postgres_dsn` uses the internal POC service name and a non-production password; keep it synchronized with `POSTGRES_PASSWORD` and do not reuse it outside this local setup.
+
+#### Intentional Qwen corpus rebuild
+
+Changing from the legacy BGE corpus to Qwen is an explicit destructive rebuild of derived subtitle search data. It clears private/shared chunks, source fingerprints, shared sections, and index-job state, then changes both pgvector columns and records the new contract. It does not delete Plex media or clips. There is no silent reindex: omit the flag and startup fails closed when the configured contract or vector schema does not match.
+
+Use [docker-compose.semantic-search.qwen.yaml](docker-compose.semantic-search.qwen.yaml), not either BGE overlay. It starts the current vLLM OpenAI image with the pooling runner and `embed` pooler task required for Qwen embeddings.
+
+1. Stop the current CutScene/BGE stack without removing volumes. This stops active indexing and removes the prior BGE embedding container so it cannot retain the GPU:
+
+   ```sh
+   docker compose -f docker-compose.yaml -f docker-compose.semantic-search.yaml -f docker-compose.semantic-search.nvidia.yaml down
+   # Use the AMD overlay instead if that is your current BGE setup.
+   ```
+
+2. Change `config.yaml` to use the OpenAI-compatible Qwen service and enable the one-time rebuild (keep the PostgreSQL DSN and URL appropriate for your deployment):
+
+```yaml
+semantic_search:
+  enabled: true
+  postgres_dsn: postgresql://cutscene:cutscene-poc@postgres:5432/cutscene?sslmode=disable
+  embeddings_provider: openai
+  embeddings_url: http://embeddings:8000
+  embeddings_model: Qwen/Qwen3-Embedding-0.6B
+  embeddings_dimensions: 1024
+  embeddings_profile: qwen
+  embeddings_rebuild: true
+```
+
+3. Start the Qwen stack and wait for its health checks:
+
+   ```sh
+   docker compose -f docker-compose.yaml -f docker-compose.semantic-search.yaml -f docker-compose.semantic-search.qwen.yaml up -d
+   docker compose -f docker-compose.yaml -f docker-compose.semantic-search.yaml -f docker-compose.semantic-search.qwen.yaml ps
+   ```
+
+The rebuild holds a PostgreSQL advisory lock and commits schema/data reset atomically. After a successful startup, set `embeddings_rebuild: false` (or remove it) and restart; the persisted matching contract makes subsequent startup idempotent. If the rebuild fails, the transaction rolls back and the prior corpus/contract remains intact. A legacy BGE installation without a contract record is bootstrapped without clearing data.
+
+The rebuild intentionally leaves the subtitle corpus empty. Start a new whole-library index after the restart: the server owner does this once for shared-corpus mode; every user indexes their own library in private mode. Search returns no old results until that indexing completes.
 
 #### Move the semantic-search database from a desktop to a NAS
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -28,6 +28,16 @@ semantic_search:
   postgres_dsn: postgresql://cutscene:cutscene-poc@postgres:5432/cutscene?sslmode=disable
   embeddings_provider: tei
   embeddings_url: http://tei:80
+  # Phase 1 contract. Omit these for legacy BGE 768 compatibility; an
+  # explicit model/profile/dimension is recommended for new deployments.
+  embeddings_model: BAAI/bge-base-en-v1.5
+  embeddings_dimensions: 768
+  embeddings_profile: bge
+  # Set true only for an intentional destructive derived-data corpus rebuild.
+  # It is safely ignored when the persisted contract already matches.
+  embeddings_rebuild: false
+  # Optional model revision/checkpoint identifier, included in the contract.
+  # embeddings_model_revision: 2024-01
   # AMD alternative: use the AMD overlay instead, then change the two lines
   # above to:
   # embeddings_provider: openai

--- a/config_test.go
+++ b/config_test.go
@@ -80,6 +80,17 @@ func TestFFmpegConcurrencyConfig(t *testing.T) {
 	}
 }
 
+func TestEmbeddingContractConfigDefaultsAndOverrides(t *testing.T) {
+	defaults := loadConfigForTest(t, "plex:\n  host: http://plex\n")
+	if defaults.SemanticSearch.EmbeddingsModel != openAIEmbeddingModel || defaults.SemanticSearch.EmbeddingsDimensions != subtitleEmbeddingDimensions || defaults.SemanticSearch.EmbeddingsProfile != embeddingProfileBGE {
+		t.Fatalf("embedding defaults = %+v", defaults.SemanticSearch)
+	}
+	configured := loadConfigForTest(t, "plex:\n  host: http://plex\nsemantic_search:\n  embeddings_model: custom/model\n  embeddings_dimensions: 1024\n  embeddings_profile: qwen\n  embeddings_model_revision: rev-1\n  embeddings_rebuild: true\n")
+	if configured.SemanticSearch.EmbeddingsModel != "custom/model" || configured.SemanticSearch.EmbeddingsDimensions != 1024 || configured.SemanticSearch.EmbeddingsProfile != embeddingProfileQwen || configured.SemanticSearch.EmbeddingsModelRevision != "rev-1" || !configured.SemanticSearch.EmbeddingsRebuild {
+		t.Fatalf("configured embedding contract = %+v", configured.SemanticSearch)
+	}
+}
+
 func TestDurableStorageConfig(t *testing.T) {
 	config := loadConfigForTest(t, "plex:\n  host: http://plex\n"+
 		"storage:\n  root: /srv/cutscene\n  database: metadata.sqlite3\n")

--- a/docker-compose.semantic-search.qwen.yaml
+++ b/docker-compose.semantic-search.qwen.yaml
@@ -1,0 +1,38 @@
+# NVIDIA Qwen embedding overlay. Use with docker-compose.yaml and
+# docker-compose.semantic-search.yaml. Do not combine it with the BGE NVIDIA
+# or AMD embedding overlays.
+services:
+  cutscene:
+    depends_on:
+      embeddings:
+        condition: service_healthy
+
+  embeddings:
+    image: vllm/vllm-openai:latest
+    command:
+      - Qwen/Qwen3-Embedding-0.6B
+      - --runner
+      - pooling
+      - --pooler-config.task
+      - embed
+      - --host
+      - 0.0.0.0
+      - --port
+      - "8000"
+    gpus: all
+    ipc: host
+    environment:
+      NVIDIA_VISIBLE_DEVICES: all
+      NVIDIA_DRIVER_CAPABILITIES: compute,utility
+      HF_HOME: /data/huggingface
+    volumes:
+      - semantic-search-qwen-huggingface-cache:/data/huggingface
+    healthcheck:
+      test: ["CMD-SHELL", "curl --fail --silent http://localhost:8000/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 60s
+
+volumes:
+  semantic-search-qwen-huggingface-cache:

--- a/docker-compose.semantic-search.yaml
+++ b/docker-compose.semantic-search.yaml
@@ -1,6 +1,7 @@
 # Shared semantic-search infrastructure. Combine this file with exactly one of
-# docker-compose.semantic-search.nvidia.yaml or
-# docker-compose.semantic-search.amd.yaml. Neither backend service publishes
+# docker-compose.semantic-search.nvidia.yaml,
+# docker-compose.semantic-search.amd.yaml, or
+# docker-compose.semantic-search.qwen.yaml. Neither backend service publishes
 # a host port; CutScene reaches it over Compose's private network.
 services:
   cutscene:

--- a/main.go
+++ b/main.go
@@ -34,12 +34,17 @@ type Config struct {
 }
 
 type SemanticSearchConfig struct {
-	PostgresDSN        string `mapstructure:"postgres_dsn"`
-	EmbeddingsURL      string `mapstructure:"embeddings_url"`
-	EmbeddingsProvider string `mapstructure:"embeddings_provider"`
-	EmbeddingsAPIKey   string `mapstructure:"embeddings_api_key"`
-	Enabled            bool   `mapstructure:"enabled"`
-	SharedCorpus       bool   `mapstructure:"shared_corpus"`
+	PostgresDSN             string `mapstructure:"postgres_dsn"`
+	EmbeddingsURL           string `mapstructure:"embeddings_url"`
+	EmbeddingsProvider      string `mapstructure:"embeddings_provider"`
+	EmbeddingsAPIKey        string `mapstructure:"embeddings_api_key"`
+	EmbeddingsModel         string `mapstructure:"embeddings_model"`
+	EmbeddingsDimensions    int    `mapstructure:"embeddings_dimensions"`
+	EmbeddingsProfile       string `mapstructure:"embeddings_profile"`
+	EmbeddingsModelRevision string `mapstructure:"embeddings_model_revision"`
+	EmbeddingsRebuild       bool   `mapstructure:"embeddings_rebuild"`
+	Enabled                 bool   `mapstructure:"enabled"`
+	SharedCorpus            bool   `mapstructure:"shared_corpus"`
 }
 
 func loadConfig() (*Config, error) {
@@ -58,6 +63,9 @@ func loadConfig() (*Config, error) {
 	cfg.SemanticSearch.EmbeddingsProvider, err = normalizeEmbeddingsProvider(cfg.SemanticSearch.EmbeddingsProvider)
 	if err != nil {
 		return nil, fmt.Errorf("semantic_search.embeddings_provider: %w", err)
+	}
+	if err := normalizeSemanticEmbeddingConfig(&cfg.SemanticSearch); err != nil {
+		return nil, err
 	}
 
 	return &cfg, nil

--- a/subtitle_search.go
+++ b/subtitle_search.go
@@ -11,6 +11,8 @@ import (
 	"fmt"
 	"html"
 	"io"
+	"log"
+	"math"
 	"net/http"
 	"net/url"
 	"os"
@@ -24,13 +26,16 @@ import (
 
 	"github.com/LukeHagar/plexgo/models/components"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 	pgvector "github.com/pgvector/pgvector-go"
 	pgxvector "github.com/pgvector/pgvector-go/pgx"
 )
 
 const (
-	subtitleEmbeddingDimensions            = 768
+	currentSubtitleSchemaDimensions        = 768 // Legacy/bootstrap schema dimension; rebuilds may alter both vector columns.
+	maxEmbeddingDimensions                 = 16000
+	subtitleEmbeddingDimensions            = currentSubtitleSchemaDimensions
 	subtitleEmbeddingBatchSize             = 32
 	maxSharedSubtitleCandidates            = 200
 	maxSharedSubtitleSourceChecks          = 100
@@ -96,10 +101,254 @@ func releaseSubtitleSemaphore(semaphore chan struct{}) {
 type subtitleSearchStore struct {
 	pool           *pgxpool.Pool
 	embeddings     *teiClient
+	contract       embeddingContract
 	bulkEmbeddings chan struct{}
 	bulkWrites     chan struct{}
 	trackLocks     keyedSubtitleLocks
 	jobMu          sync.Mutex
+}
+
+const subtitleVectorColumnQuery = `
+SELECT c.relname,
+       EXISTS (
+           SELECT 1 FROM pg_attribute ea
+           WHERE ea.attrelid = c.oid AND ea.attname = 'embedding' AND NOT ea.attisdropped
+       ) AS has_embedding,
+       COALESCE((
+           SELECT ea.atttypmod FROM pg_attribute ea
+           WHERE ea.attrelid = c.oid AND ea.attname = 'embedding' AND NOT ea.attisdropped
+       ), -1) AS typmod,
+       COALESCE((
+           SELECT format_type(ea.atttypid, -1) FROM pg_attribute ea
+           WHERE ea.attrelid = c.oid AND ea.attname = 'embedding' AND NOT ea.attisdropped
+       ), '') AS data_type
+FROM pg_class c
+JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE n.nspname = current_schema()
+  AND c.relname IN ('subtitle_chunks', 'subtitle_shared_chunks')
+  AND c.relkind IN ('r', 'p')`
+
+type subtitleVectorColumn struct {
+	Table        string
+	TableExists  bool
+	HasEmbedding bool
+	Typmod       int32
+	DataType     string
+}
+
+func validateSubtitleVectorColumns(columns []subtitleVectorColumn, expectedDimensions ...int) error {
+	expected := currentSubtitleSchemaDimensions
+	if len(expectedDimensions) > 0 {
+		expected = expectedDimensions[0]
+	}
+	for _, column := range columns {
+		if !column.TableExists {
+			continue
+		}
+		if !column.HasEmbedding {
+			return fmt.Errorf("semantic_search table %s has no embedding column; corpus rebuild required", column.Table)
+		}
+		if column.DataType != "vector" && column.DataType != "public.vector" {
+			return fmt.Errorf("semantic_search table %s embedding type is %q, want vector; corpus rebuild required", column.Table, column.DataType)
+		}
+		if column.Typmod != int32(expected) {
+			return fmt.Errorf("semantic_search table %s embedding typmod is %d, want %d; corpus rebuild required", column.Table, column.Typmod, expected)
+		}
+	}
+	return nil
+}
+
+func inspectSubtitleVectorColumns(ctx context.Context, pool *pgxpool.Pool) ([]subtitleVectorColumn, error) {
+	return inspectSubtitleVectorColumnsWith(ctx, pool)
+}
+
+type subtitleRowsQueryer interface {
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+}
+
+type subtitleRowQueryer interface {
+	QueryRow(context.Context, string, ...any) pgx.Row
+}
+
+func inspectSubtitleVectorColumnsWith(ctx context.Context, queryer subtitleRowsQueryer) ([]subtitleVectorColumn, error) {
+	rows, err := queryer.Query(ctx, subtitleVectorColumnQuery)
+	if err != nil {
+		return nil, errors.New("could not inspect subtitle vector schema")
+	}
+	defer rows.Close()
+	columns := make([]subtitleVectorColumn, 0, 2)
+	for rows.Next() {
+		var column subtitleVectorColumn
+		if err := rows.Scan(&column.Table, &column.HasEmbedding, &column.Typmod, &column.DataType); err != nil {
+			return nil, errors.New("could not inspect subtitle vector schema")
+		}
+		column.TableExists = true
+		columns = append(columns, column)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, errors.New("could not inspect subtitle vector schema")
+	}
+	return columns, nil
+}
+
+type persistedEmbeddingContract struct {
+	embeddingContract
+	Generation int64
+	State      string
+}
+
+func loadEmbeddingContract(ctx context.Context, queryer subtitleRowQueryer) (*persistedEmbeddingContract, error) {
+	var record persistedEmbeddingContract
+	err := queryer.QueryRow(ctx, `SELECT contract_hash, provider, model, model_revision, dimensions, profile, template_version, index_version, generation, state FROM subtitle_embedding_contract WHERE singleton_id=1`).Scan(
+		&record.Hash, &record.Provider, &record.Model, &record.Revision, &record.Dimensions, &record.Profile, &record.TemplateVersion, &record.IndexVersion, &record.Generation, &record.State)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, errors.New("could not read semantic search embedding contract")
+	}
+	return &record, nil
+}
+
+func embeddingContractsMatch(configured embeddingContract, persisted *persistedEmbeddingContract) bool {
+	if persisted == nil || persisted.State != "ready" {
+		return false
+	}
+	return configured.Hash == persisted.Hash && configured.Provider == persisted.Provider && configured.Model == persisted.Model &&
+		configured.Revision == persisted.Revision && configured.Dimensions == persisted.Dimensions && configured.Profile == persisted.Profile &&
+		configured.TemplateVersion == persisted.TemplateVersion && configured.IndexVersion == persisted.IndexVersion
+}
+
+func validateRebuildColumns(columns []subtitleVectorColumn) error {
+	seen := make(map[string]bool, len(columns))
+	for _, column := range columns {
+		if !column.TableExists || !column.HasEmbedding || (column.DataType != "vector" && column.DataType != "public.vector") {
+			return fmt.Errorf("semantic_search table %s is not an alterable vector table; corpus rebuild required", column.Table)
+		}
+		seen[column.Table] = true
+	}
+	for _, table := range []string{"subtitle_chunks", "subtitle_shared_chunks"} {
+		if !seen[table] {
+			return fmt.Errorf("semantic_search table %s is missing; corpus rebuild required", table)
+		}
+	}
+	return nil
+}
+
+func validateExistingSubtitleVectorTypes(columns []subtitleVectorColumn) error {
+	for _, column := range columns {
+		if !column.TableExists {
+			continue
+		}
+		if !column.HasEmbedding || (column.DataType != "vector" && column.DataType != "public.vector") {
+			return fmt.Errorf("semantic_search table %s has an incompatible embedding column; corpus rebuild required", column.Table)
+		}
+	}
+	return nil
+}
+
+func embeddingVectorAlterStatements(dimensions int) ([]string, error) {
+	if dimensions < 1 || dimensions > maxEmbeddingDimensions {
+		return nil, fmt.Errorf("embedding dimensions %d are outside the safe DDL range", dimensions)
+	}
+	return []string{
+		fmt.Sprintf("ALTER TABLE subtitle_chunks ALTER COLUMN embedding TYPE vector(%d) USING embedding::vector", dimensions),
+		fmt.Sprintf("ALTER TABLE subtitle_shared_chunks ALTER COLUMN embedding TYPE vector(%d) USING embedding::vector", dimensions),
+	}, nil
+}
+
+func persistEmbeddingContract(ctx context.Context, execer interface {
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+}, contract embeddingContract, generation int64) error {
+	_, err := execer.Exec(ctx, `INSERT INTO subtitle_embedding_contract (singleton_id, contract_hash, provider, model, model_revision, dimensions, profile, template_version, index_version, generation, state, updated_at) VALUES (1,$1,$2,$3,$4,$5,$6,$7,$8,$9,'ready',NOW()) ON CONFLICT (singleton_id) DO UPDATE SET contract_hash=EXCLUDED.contract_hash, provider=EXCLUDED.provider, model=EXCLUDED.model, model_revision=EXCLUDED.model_revision, dimensions=EXCLUDED.dimensions, profile=EXCLUDED.profile, template_version=EXCLUDED.template_version, index_version=EXCLUDED.index_version, generation=EXCLUDED.generation, state=EXCLUDED.state, updated_at=EXCLUDED.updated_at`, contract.Hash, contract.Provider, contract.Model, contract.Revision, contract.Dimensions, contract.Profile, contract.TemplateVersion, contract.IndexVersion, generation)
+	return err
+}
+
+type subtitleDBBeginner interface {
+	Begin(context.Context) (pgx.Tx, error)
+}
+
+func bootstrapLegacyEmbeddingContract(ctx context.Context, db subtitleDBBeginner, contract embeddingContract) error {
+	tx, err := db.Begin(ctx)
+	if err != nil {
+		return errors.New("could not begin semantic search contract bootstrap")
+	}
+	defer tx.Rollback(ctx)
+	if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock(hashtextextended('cutscene.semantic_embedding_rebuild', 0))`); err != nil {
+		return errors.New("could not lock semantic search contract")
+	}
+	existing, err := loadEmbeddingContract(ctx, tx)
+	if err != nil {
+		return err
+	}
+	if existing == nil {
+		if err := persistEmbeddingContract(ctx, tx, contract, 1); err != nil {
+			return errors.New("could not persist semantic search embedding contract")
+		}
+	}
+	return tx.Commit(ctx)
+}
+
+func rebuildEmbeddingCorpus(ctx context.Context, db subtitleDBBeginner, contract embeddingContract) error {
+	alterStatements, err := embeddingVectorAlterStatements(contract.Dimensions)
+	if err != nil {
+		return err
+	}
+	tx, err := db.Begin(ctx)
+	if err != nil {
+		return errors.New("could not begin semantic search corpus rebuild")
+	}
+	defer tx.Rollback(ctx)
+	if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock(hashtextextended('cutscene.semantic_embedding_rebuild', 0))`); err != nil {
+		return errors.New("could not acquire semantic search corpus rebuild lock")
+	}
+	columns, err := inspectSubtitleVectorColumnsWith(ctx, tx)
+	if err != nil {
+		return err
+	}
+	if err := validateRebuildColumns(columns); err != nil {
+		return err
+	}
+	existing, err := loadEmbeddingContract(ctx, tx)
+	if err != nil {
+		return err
+	}
+	if existing != nil && embeddingContractsMatch(contract, existing) && validateSubtitleVectorColumns(columns, contract.Dimensions) == nil {
+		return tx.Commit(ctx)
+	}
+	for _, statement := range []string{
+		"DROP INDEX IF EXISTS subtitle_chunks_embedding_hnsw_idx",
+		"DROP INDEX IF EXISTS subtitle_shared_chunks_embedding_idx",
+		"TRUNCATE TABLE subtitle_chunks, subtitle_shared_chunks, subtitle_index_sources, subtitle_shared_sources, subtitle_shared_sections, subtitle_index_jobs, subtitle_embedding_contract",
+	} {
+		if _, err := tx.Exec(ctx, statement); err != nil {
+			return errors.New("could not reset semantic search corpus")
+		}
+	}
+	for _, statement := range alterStatements {
+		if _, err := tx.Exec(ctx, statement); err != nil {
+			return errors.New("could not alter semantic search vector dimensions")
+		}
+	}
+	for _, statement := range []string{
+		"CREATE INDEX subtitle_chunks_embedding_hnsw_idx ON subtitle_chunks USING hnsw (embedding vector_cosine_ops)",
+		"CREATE INDEX subtitle_shared_chunks_embedding_idx ON subtitle_shared_chunks USING hnsw (embedding vector_cosine_ops)",
+	} {
+		if _, err := tx.Exec(ctx, statement); err != nil {
+			return errors.New("could not recreate semantic search vector indexes")
+		}
+	}
+	generation := int64(1)
+	if existing != nil && existing.Generation >= generation {
+		generation = existing.Generation + 1
+	}
+	if err := persistEmbeddingContract(ctx, tx, contract, generation); err != nil {
+		return errors.New("could not persist rebuilt semantic search embedding contract")
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return errors.New("could not commit semantic search corpus rebuild")
+	}
+	return nil
 }
 
 type keyedSubtitleLocks struct {
@@ -140,7 +389,123 @@ const (
 	embeddingsProviderTEI    = "tei"
 	embeddingsProviderOpenAI = "openai"
 	openAIEmbeddingModel     = "BAAI/bge-base-en-v1.5"
+	qwenEmbeddingModel       = "Qwen/Qwen3-Embedding-0.6B"
+	embeddingProfileBGE      = "bge"
+	embeddingProfileQwen     = "qwen"
+	embeddingTemplateVersion = "embedding-template-v1"
 )
+
+type embeddingContract struct {
+	Provider        string
+	Model           string
+	Revision        string
+	Dimensions      int
+	Profile         string
+	TemplateVersion string
+	IndexVersion    string
+	Hash            string
+}
+
+var legacyEmbeddingContract = embeddingContract{
+	Provider: embeddingsProviderTEI, Model: openAIEmbeddingModel,
+	Dimensions: subtitleEmbeddingDimensions, Profile: embeddingProfileBGE,
+	TemplateVersion: embeddingTemplateVersion, IndexVersion: subtitleSearchIndexVersion,
+}
+
+func isLegacyEmbeddingContract(contract embeddingContract) bool {
+	legacyProvider := contract.Provider == embeddingsProviderTEI || contract.Provider == embeddingsProviderOpenAI
+	return legacyProvider &&
+		contract.Model == legacyEmbeddingContract.Model &&
+		contract.Dimensions == legacyEmbeddingContract.Dimensions &&
+		contract.Profile == legacyEmbeddingContract.Profile &&
+		strings.TrimSpace(contract.Revision) == ""
+}
+
+func normalizeSemanticEmbeddingConfig(cfg *SemanticSearchConfig) error {
+	if cfg == nil {
+		return errors.New("semantic_search embedding configuration is unavailable")
+	}
+	provider, err := normalizeEmbeddingsProvider(cfg.EmbeddingsProvider)
+	if err != nil {
+		return fmt.Errorf("semantic_search.embeddings_provider: %w", err)
+	}
+	cfg.EmbeddingsProvider = provider
+	profile := strings.ToLower(strings.TrimSpace(cfg.EmbeddingsProfile))
+	if profile == "" {
+		profile = embeddingProfileBGE
+		log.Printf("semantic_search.embeddings_profile is omitted; defaulting to %q (BGE compatibility; configure explicitly)", profile)
+	}
+	profile, err = normalizeEmbeddingProfile(profile)
+	if err != nil {
+		return fmt.Errorf("semantic_search.embeddings_profile: %w", err)
+	}
+	cfg.EmbeddingsProfile = profile
+	cfg.EmbeddingsModel = strings.TrimSpace(cfg.EmbeddingsModel)
+	if cfg.EmbeddingsModel == "" {
+		if profile == embeddingProfileQwen {
+			cfg.EmbeddingsModel = qwenEmbeddingModel
+		} else {
+			cfg.EmbeddingsModel = openAIEmbeddingModel
+		}
+		log.Printf("semantic_search.embeddings_model is omitted; defaulting to %q (legacy BGE compatibility)", cfg.EmbeddingsModel)
+	}
+	if cfg.EmbeddingsDimensions == 0 {
+		if profile == embeddingProfileQwen {
+			cfg.EmbeddingsDimensions = 1024
+		} else {
+			cfg.EmbeddingsDimensions = subtitleEmbeddingDimensions
+		}
+		log.Printf("semantic_search.embeddings_dimensions is omitted; defaulting to %d", cfg.EmbeddingsDimensions)
+	}
+	if cfg.EmbeddingsDimensions < 1 || cfg.EmbeddingsDimensions > maxEmbeddingDimensions {
+		return fmt.Errorf("semantic_search.embeddings_dimensions must be between 1 and %d", maxEmbeddingDimensions)
+	}
+	return nil
+}
+
+func normalizeEmbeddingProfile(value string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "bge", "bge-v1", "bge_v1":
+		return embeddingProfileBGE, nil
+	case "qwen", "qwen-v1", "qwen_v1":
+		return embeddingProfileQwen, nil
+	default:
+		return "", fmt.Errorf("unsupported embedding profile %q (want bge or qwen)", value)
+	}
+}
+
+func newEmbeddingContract(cfg SemanticSearchConfig) (embeddingContract, error) {
+	if err := normalizeSemanticEmbeddingConfig(&cfg); err != nil {
+		return embeddingContract{}, err
+	}
+	contract := embeddingContract{
+		Provider: cfg.EmbeddingsProvider, Model: cfg.EmbeddingsModel,
+		Revision: strings.TrimSpace(cfg.EmbeddingsModelRevision), Dimensions: cfg.EmbeddingsDimensions,
+		Profile: cfg.EmbeddingsProfile, TemplateVersion: embeddingTemplateVersion,
+		IndexVersion: subtitleSearchIndexVersion,
+	}
+	contract.Hash = embeddingContractHash(contract)
+	return contract, nil
+}
+
+func embeddingContractHash(contract embeddingContract) string {
+	hash := sha256.New()
+	_, _ = fmt.Fprintf(hash, "embedding-contract-v1|provider:%s|model:%s|revision:%s|dimensions:%d|profile:%s|template:%s|index:%s",
+		contract.Provider, contract.Model, contract.Revision, contract.Dimensions, contract.Profile, contract.TemplateVersion, contract.IndexVersion)
+	return hex.EncodeToString(hash.Sum(nil))
+}
+
+func (contract embeddingContract) documentInput(prefix, dialogue string) string {
+	return subtitleEmbeddingInputForProfile(contract.Profile, prefix, dialogue)
+}
+
+func (contract embeddingContract) queryInput(query string) string {
+	query = strings.TrimSpace(query)
+	if contract.Profile == embeddingProfileQwen {
+		return "Instruct: Given a query, retrieve relevant passages\nQuery: " + query
+	}
+	return bgeQueryInstruction + query
+}
 
 const subtitleSearchSchema = `
 CREATE EXTENSION IF NOT EXISTS vector;
@@ -257,21 +622,34 @@ CREATE TABLE IF NOT EXISTS subtitle_shared_chunks (
 CREATE INDEX IF NOT EXISTS subtitle_shared_chunks_text_idx ON subtitle_shared_chunks USING GIN (text_search);
 CREATE INDEX IF NOT EXISTS subtitle_shared_chunks_embedding_idx ON subtitle_shared_chunks USING hnsw (embedding vector_cosine_ops);
 ALTER TABLE subtitle_shared_sections ADD COLUMN IF NOT EXISTS ready BOOLEAN NOT NULL DEFAULT FALSE;
+CREATE TABLE IF NOT EXISTS subtitle_embedding_contract (
+    singleton_id SMALLINT PRIMARY KEY CHECK (singleton_id = 1),
+    contract_hash TEXT NOT NULL,
+    provider TEXT NOT NULL,
+    model TEXT NOT NULL,
+    model_revision TEXT NOT NULL,
+    dimensions INTEGER NOT NULL,
+    profile TEXT NOT NULL,
+    template_version TEXT NOT NULL,
+    index_version TEXT NOT NULL,
+    generation BIGINT NOT NULL,
+    state TEXT NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
 `
 
 const subtitleSearchIndexVersion = "subtitle-index-v4-chunk-400-cast-clean-text"
 
 func newSubtitleSearchStore(ctx context.Context, cfg SemanticSearchConfig) (*subtitleSearchStore, error) {
-	provider, err := normalizeEmbeddingsProvider(cfg.EmbeddingsProvider)
+	contract, err := newEmbeddingContract(cfg)
 	if err != nil {
 		return nil, err
+	}
+	if !isLegacyEmbeddingContract(contract) && !cfg.EmbeddingsRebuild && strings.TrimSpace(cfg.PostgresDSN) == "" {
+		return nil, fmt.Errorf("semantic_search embedding contract %s is not the persisted legacy BGE contract; corpus rebuild required; set semantic_search.embeddings_rebuild: true to perform the destructive corpus rebuild", contract.Hash)
 	}
 	if strings.TrimSpace(cfg.PostgresDSN) == "" {
 		return nil, errors.New("semantic_search.postgres_dsn is required when semantic search is enabled")
-	}
-	embeddings, err := newEmbeddingClient(cfg.EmbeddingsURL, provider, cfg.EmbeddingsAPIKey)
-	if err != nil {
-		return nil, err
 	}
 	poolConfig, err := pgxpool.ParseConfig(cfg.PostgresDSN)
 	if err != nil {
@@ -286,9 +664,84 @@ func newSubtitleSearchStore(ctx context.Context, cfg SemanticSearchConfig) (*sub
 		pool.Close()
 		return nil, errors.New("could not connect to semantic search database")
 	}
+	existingColumns, err := inspectSubtitleVectorColumns(ctx, pool)
+	if err != nil {
+		pool.Close()
+		return nil, err
+	}
+	if err := validateExistingSubtitleVectorTypes(existingColumns); err != nil {
+		pool.Close()
+		return nil, err
+	}
+	if !cfg.EmbeddingsRebuild && validateSubtitleVectorColumns(existingColumns, contract.Dimensions) != nil {
+		pool.Close()
+		return nil, fmt.Errorf("semantic_search vector schema does not match configured contract; corpus rebuild required; set semantic_search.embeddings_rebuild: true")
+	}
 	if _, err := pool.Exec(ctx, subtitleSearchSchema); err != nil {
 		pool.Close()
 		return nil, errors.New("could not initialize semantic search schema")
+	}
+	columns, err := inspectSubtitleVectorColumns(ctx, pool)
+	if err != nil {
+		pool.Close()
+		return nil, err
+	}
+	persisted, err := loadEmbeddingContract(ctx, pool)
+	if err != nil {
+		pool.Close()
+		return nil, err
+	}
+	schemaMatches := validateSubtitleVectorColumns(columns, contract.Dimensions) == nil
+	contractMatches := embeddingContractsMatch(contract, persisted)
+	needRebuild := !schemaMatches || !contractMatches
+	if persisted == nil && isLegacyEmbeddingContract(contract) && schemaMatches {
+		needRebuild = false
+	}
+	if needRebuild && !cfg.EmbeddingsRebuild {
+		pool.Close()
+		return nil, fmt.Errorf("semantic_search embedding contract or vector schema does not match configured contract %s; corpus rebuild required; set semantic_search.embeddings_rebuild: true to perform the destructive corpus rebuild", contract.Hash)
+	}
+	embeddings, err := newEmbeddingClientWithContract(cfg.EmbeddingsURL, contract, cfg.EmbeddingsAPIKey)
+	if err != nil {
+		pool.Close()
+		return nil, err
+	}
+	if err := embeddings.probe(ctx); err != nil {
+		pool.Close()
+		return nil, fmt.Errorf("semantic_search embedding contract probe failed for model %q/profile %q/dimensions %d: %w", contract.Model, contract.Profile, contract.Dimensions, err)
+	}
+	if needRebuild {
+		if err := rebuildEmbeddingCorpus(ctx, pool, contract); err != nil {
+			pool.Close()
+			return nil, err
+		}
+	} else if persisted == nil {
+		if err := bootstrapLegacyEmbeddingContract(ctx, pool, contract); err != nil {
+			pool.Close()
+			return nil, err
+		}
+		if cfg.EmbeddingsRebuild {
+			log.Printf("semantic_search.embeddings_rebuild is enabled but the legacy corpus has no contract; initialized legacy contract without resetting data")
+		}
+	} else if cfg.EmbeddingsRebuild {
+		log.Printf("semantic_search.embeddings_rebuild is enabled but contract %s already matches; no corpus reset performed", contract.Hash)
+	}
+	columns, err = inspectSubtitleVectorColumns(ctx, pool)
+	if err != nil {
+		pool.Close()
+		return nil, err
+	}
+	if err := validateSubtitleVectorColumns(columns, contract.Dimensions); err != nil {
+		pool.Close()
+		return nil, err
+	}
+	persisted, err = loadEmbeddingContract(ctx, pool)
+	if err != nil || !embeddingContractsMatch(contract, persisted) {
+		pool.Close()
+		if err != nil {
+			return nil, err
+		}
+		return nil, errors.New("semantic_search embedding contract was not committed")
 	}
 	pool.Close()
 	poolConfig.AfterConnect = func(ctx context.Context, conn *pgx.Conn) error {
@@ -302,7 +755,7 @@ func newSubtitleSearchStore(ctx context.Context, cfg SemanticSearchConfig) (*sub
 		pool.Close()
 		return nil, errors.New("could not connect to semantic search database")
 	}
-	return &subtitleSearchStore{pool: pool, embeddings: embeddings, bulkEmbeddings: make(chan struct{}, 1), bulkWrites: make(chan struct{}, 1)}, nil
+	return &subtitleSearchStore{pool: pool, embeddings: embeddings, contract: contract, bulkEmbeddings: make(chan struct{}, 1), bulkWrites: make(chan struct{}, 1)}, nil
 }
 
 func (s *subtitleSearchStore) close() {
@@ -395,10 +848,13 @@ func chunkSubtitleEntries(entries []SubtitleEntry) []subtitleChunk {
 }
 
 type teiClient struct {
-	url      string
-	provider string
-	apiKey   string
-	client   *http.Client
+	url        string
+	provider   string
+	model      string
+	dimensions int
+	profile    string
+	apiKey     string
+	client     *http.Client
 }
 
 func newTEIClient(rawURL string) (*teiClient, error) {
@@ -419,16 +875,20 @@ func normalizeEmbeddingsProvider(value string) (string, error) {
 }
 
 func newEmbeddingClient(rawURL, provider, apiKey string) (*teiClient, error) {
+	contract, err := newEmbeddingContract(SemanticSearchConfig{EmbeddingsProvider: provider})
+	if err != nil {
+		return nil, err
+	}
+	return newEmbeddingClientWithContract(rawURL, contract, apiKey)
+}
+
+func newEmbeddingClientWithContract(rawURL string, contract embeddingContract, apiKey string) (*teiClient, error) {
 	parsed, err := url.Parse(strings.TrimSpace(rawURL))
 	if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Host == "" || parsed.User != nil {
 		return nil, errors.New("semantic_search.embeddings_url must be an HTTP(S) URL")
 	}
-	provider, err = normalizeEmbeddingsProvider(provider)
-	if err != nil {
-		return nil, err
-	}
 	parsed.Path = strings.TrimRight(parsed.Path, "/")
-	if provider == embeddingsProviderTEI {
+	if contract.Provider == embeddingsProviderTEI {
 		if !strings.HasSuffix(parsed.Path, "/embed") {
 			parsed.Path += "/embed"
 		}
@@ -439,17 +899,53 @@ func newEmbeddingClient(rawURL, provider, apiKey string) (*teiClient, error) {
 			parsed.Path += "/v1/embeddings"
 		}
 	}
-	return &teiClient{url: parsed.String(), provider: provider, apiKey: strings.TrimSpace(apiKey), client: &http.Client{Timeout: 30 * time.Second}}, nil
+	return &teiClient{url: parsed.String(), provider: contract.Provider, model: contract.Model, dimensions: contract.Dimensions, profile: contract.Profile, apiKey: strings.TrimSpace(apiKey), client: &http.Client{Timeout: 30 * time.Second}}, nil
 }
 
-func validateEmbeddings(embeddings [][]float32, expected int) error {
+func validateEmbeddings(embeddings [][]float32, expected int, dimensions ...int) error {
+	expectedDimensions := subtitleEmbeddingDimensions
+	if len(dimensions) > 0 {
+		expectedDimensions = dimensions[0]
+	}
+	return validateEmbeddingsForDimension(embeddings, expected, expectedDimensions)
+}
+
+func validateEmbeddingsForDimension(embeddings [][]float32, expected, dimensions int) error {
 	if len(embeddings) != expected {
 		return fmt.Errorf("embedding response count %d does not match request count %d", len(embeddings), expected)
 	}
 	for i, embedding := range embeddings {
-		if len(embedding) != subtitleEmbeddingDimensions {
-			return fmt.Errorf("embedding %d has dimension %d, want %d", i, len(embedding), subtitleEmbeddingDimensions)
+		if len(embedding) != dimensions {
+			return fmt.Errorf("embedding %d has dimension %d, want %d", i, len(embedding), dimensions)
 		}
+		for _, value := range embedding {
+			if math.IsNaN(float64(value)) || math.IsInf(float64(value), 0) {
+				return fmt.Errorf("embedding %d contains a non-finite value", i)
+			}
+		}
+	}
+	return nil
+}
+
+func (c *teiClient) probe(ctx context.Context) error {
+	embeddings, err := c.embed(ctx, []string{"embedding contract probe"})
+	if err != nil {
+		return err
+	}
+	if len(embeddings) != 1 || len(embeddings[0]) != c.dimensions {
+		return errors.New("probe response count or dimension mismatch")
+	}
+	nonzero := false
+	for _, value := range embeddings[0] {
+		if math.IsNaN(float64(value)) || math.IsInf(float64(value), 0) {
+			return errors.New("probe response contains a non-finite value")
+		}
+		if value != 0 {
+			nonzero = true
+		}
+	}
+	if !nonzero {
+		return errors.New("probe response is an all-zero vector")
 	}
 	return nil
 }
@@ -503,7 +999,7 @@ func (c *teiClient) embed(ctx context.Context, inputs []string) ([][]float32, er
 		}
 		embeddings = wrapped.Embeddings
 	}
-	if err := validateEmbeddings(embeddings, len(inputs)); err != nil {
+	if err := validateEmbeddingsForDimension(embeddings, len(inputs), c.dimensions); err != nil {
 		return nil, err
 	}
 	return embeddings, nil
@@ -515,7 +1011,8 @@ type openAIEmbeddingItem struct {
 }
 
 type openAIEmbeddingResponse struct {
-	Data []openAIEmbeddingItem `json:"data"`
+	Model string                `json:"model"`
+	Data  []openAIEmbeddingItem `json:"data"`
 }
 
 func (c *teiClient) embedOpenAI(ctx context.Context, inputs []string) ([][]float32, error) {
@@ -523,7 +1020,7 @@ func (c *teiClient) embedOpenAI(ctx context.Context, inputs []string) ([][]float
 		Model          string   `json:"model"`
 		Input          []string `json:"input"`
 		EncodingFormat string   `json:"encoding_format"`
-	}{openAIEmbeddingModel, inputs, "float"})
+	}{c.model, inputs, "float"})
 	if err != nil {
 		return nil, errors.New("could not encode embedding request")
 	}
@@ -551,6 +1048,10 @@ func (c *teiClient) embedOpenAI(ctx context.Context, inputs []string) ([][]float
 	if err := json.Unmarshal(body, &response); err != nil {
 		return nil, errors.New("embedding response is invalid JSON")
 	}
+	responseModel := strings.TrimSpace(response.Model)
+	if responseModel != "" && responseModel != c.model {
+		return nil, fmt.Errorf("embedding response model %q does not match configured model %q", responseModel, c.model)
+	}
 	if len(response.Data) != len(inputs) {
 		return nil, fmt.Errorf("embedding response count %d does not match request count %d", len(response.Data), len(inputs))
 	}
@@ -568,7 +1069,7 @@ func (c *teiClient) embedOpenAI(ctx context.Context, inputs []string) ([][]float
 			return nil, errors.New("embedding response indexes are incomplete")
 		}
 	}
-	if err := validateEmbeddings(ordered, len(inputs)); err != nil {
+	if err := validateEmbeddingsForDimension(ordered, len(inputs), c.dimensions); err != nil {
 		return nil, err
 	}
 	return ordered, nil
@@ -715,7 +1216,11 @@ func (a *Application) indexSubtitleSource(ctx context.Context, request subtitleS
 	fingerprints := make(map[int]string)
 	for _, plan := range plans {
 		stream := plan.Stream
-		fingerprint := subtitleSourceFingerprint(request.RatingKey, request.MediaID, request.PartID, stream, castContext, sourceRevision)
+		contractRevision := sourceRevision
+		if a.subtitleSearch != nil {
+			contractRevision += "|embedding-contract:" + a.subtitleSearch.contract.Hash
+		}
+		fingerprint := subtitleSourceFingerprint(request.RatingKey, request.MediaID, request.PartID, stream, castContext, contractRevision)
 		fingerprints[plan.PublicIndex] = fingerprint
 		unchanged := false
 		var checkErr error
@@ -1001,7 +1506,7 @@ func nullableUUID(value string) any {
 func (a *Application) persistSubtitleChunks(ctx context.Context, owner string, source LibrarySearchResult, subtitleIndex int, chunks []subtitleChunk, embeddingContext string) error {
 	inputs := make([]string, len(chunks))
 	for i, chunk := range chunks {
-		inputs[i] = subtitleEmbeddingInput(embeddingContext, chunk.Text)
+		inputs[i] = a.subtitleSearch.contract.documentInput(embeddingContext, chunk.Text)
 	}
 	bulkEmbedding := isBulkSubtitleContext(ctx)
 	if bulkEmbedding {
@@ -1053,7 +1558,7 @@ func (a *Application) persistSubtitleChunks(ctx context.Context, owner string, s
 func (a *Application) persistSharedSubtitleChunks(ctx context.Context, request subtitleSearchIndexRequest, source LibrarySearchResult, subtitleIndex int, chunks []subtitleChunk, embeddingContext, fingerprint string) error {
 	inputs := make([]string, len(chunks))
 	for i, chunk := range chunks {
-		inputs[i] = subtitleEmbeddingInput(embeddingContext, chunk.Text)
+		inputs[i] = a.subtitleSearch.contract.documentInput(embeddingContext, chunk.Text)
 	}
 	embeddings := make([][]float32, 0, len(chunks))
 	for start := 0; start < len(inputs); start += subtitleEmbeddingBatchSize {
@@ -1111,8 +1616,15 @@ func (a *Application) recordSharedSubtitleSeen(ctx context.Context, request subt
 }
 
 func subtitleEmbeddingInput(prefix, dialogue string) string {
+	return subtitleEmbeddingInputForProfile(embeddingProfileBGE, prefix, dialogue)
+}
+
+func subtitleEmbeddingInputForProfile(profile, prefix, dialogue string) string {
 	if prefix == "" {
 		return "Dialogue: " + dialogue
+	}
+	if profile == embeddingProfileQwen {
+		return prefix + "\nDialogue: " + dialogue
 	}
 	return prefix + "\nDialogue: " + dialogue
 }
@@ -1559,7 +2071,7 @@ func (a *Application) searchSubtitleIndex(ctx context.Context, query string) ([]
 	if err := load(`SELECT rating_key, media_id, part_id, subtitle_index, title, show_title, season, episode, year, start_ms, end_ms, text, ts_rank_cd(text_search, phraseto_tsquery('simple', $2)) AS score FROM subtitle_chunks WHERE owner_uuid=$1 AND text_search @@ phraseto_tsquery('simple', $2) ORDER BY score DESC, id LIMIT $3`, []any{owner, trimmedQuery, maxSubtitleLexicalCandidates}, 1); err != nil {
 		return nil, err
 	}
-	embeddings, err := a.subtitleSearch.embeddings.embed(ctx, []string{bgeQueryInstruction + trimmedQuery})
+	embeddings, err := a.subtitleSearch.embeddings.embed(ctx, []string{a.subtitleSearch.contract.queryInput(trimmedQuery)})
 	if err != nil {
 		return nil, err
 	}
@@ -1637,7 +2149,7 @@ func (a *Application) searchSharedSubtitleIndex(ctx context.Context, query strin
 	if err := load(`SELECT c.machine_identifier, c.section_uuid, c.section_key, c.scan_id, s.section_type, c.rating_key, c.media_id, c.part_id, c.subtitle_index, c.start_ms, c.end_ms, ts_rank_cd(c.text_search, phraseto_tsquery('simple', $3)) AS score FROM subtitle_shared_chunks c JOIN subtitle_shared_sections s ON s.machine_identifier=c.machine_identifier AND s.section_uuid=c.section_uuid AND s.ready_scan_id=c.scan_id AND s.state='ready' WHERE c.machine_identifier=$1 AND c.section_uuid=ANY($2) AND c.text_search @@ phraseto_tsquery('simple', $3) AND EXISTS (SELECT 1 FROM subtitle_shared_sources v WHERE v.machine_identifier=c.machine_identifier AND v.section_uuid=c.section_uuid AND v.scan_id=c.scan_id AND v.rating_key=c.rating_key AND v.media_id=c.media_id AND v.part_id=c.part_id AND v.subtitle_index=c.subtitle_index AND v.chunk_count > 0) ORDER BY score DESC, c.id LIMIT $4`, []any{a.machineIdentifier, uuidKeys, trimmedQuery, maxSharedSubtitleCandidates}, 1); err != nil {
 		return nil, err
 	}
-	embeddings, err := a.subtitleSearch.embeddings.embed(ctx, []string{bgeQueryInstruction + trimmedQuery})
+	embeddings, err := a.subtitleSearch.embeddings.embed(ctx, []string{a.subtitleSearch.contract.queryInput(trimmedQuery)})
 	if err != nil {
 		return nil, err
 	}

--- a/subtitle_search_rebuild_test.go
+++ b/subtitle_search_rebuild_test.go
@@ -1,0 +1,273 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+type rebuildRecorderDB struct {
+	state rebuildRecorderState
+	tx    *rebuildRecorderTx
+}
+
+type rebuildRecorderState struct {
+	columns        []subtitleVectorColumn
+	contract       *persistedEmbeddingContract
+	rows           map[string]int
+	indexesPresent bool
+}
+
+type rebuildRecorderTx struct {
+	pgx.Tx
+	db         *rebuildRecorderDB
+	snapshot   rebuildRecorderState
+	statements []string
+	committed  bool
+	rolledBack bool
+	failOn     string
+}
+
+func cloneRebuildState(state rebuildRecorderState) rebuildRecorderState {
+	copyState := state
+	copyState.columns = append([]subtitleVectorColumn(nil), state.columns...)
+	copyState.rows = make(map[string]int, len(state.rows))
+	for key, value := range state.rows {
+		copyState.rows[key] = value
+	}
+	if state.contract != nil {
+		copyState.contract = &persistedEmbeddingContract{embeddingContract: state.contract.embeddingContract, Generation: state.contract.Generation, State: state.contract.State}
+	}
+	return copyState
+}
+
+func (db *rebuildRecorderDB) Begin(context.Context) (pgx.Tx, error) {
+	db.tx = &rebuildRecorderTx{db: db, snapshot: cloneRebuildState(db.state)}
+	return db.tx, nil
+}
+
+func (tx *rebuildRecorderTx) Exec(_ context.Context, statement string, args ...any) (pgconn.CommandTag, error) {
+	tx.statements = append(tx.statements, statement)
+	if tx.failOn != "" && strings.Contains(statement, tx.failOn) {
+		return pgconn.CommandTag{}, errors.New("injected rebuild failure")
+	}
+	switch {
+	case strings.Contains(statement, "TRUNCATE TABLE"):
+		for table := range tx.db.state.rows {
+			tx.db.state.rows[table] = 0
+		}
+		tx.db.state.contract = nil
+	case strings.HasPrefix(statement, "DROP INDEX"):
+		tx.db.state.indexesPresent = false
+	case strings.HasPrefix(statement, "ALTER TABLE subtitle_chunks"):
+		tx.db.state.columns[0].Typmod = int32(argsDimension(statement))
+	case strings.HasPrefix(statement, "ALTER TABLE subtitle_shared_chunks"):
+		tx.db.state.columns[1].Typmod = int32(argsDimension(statement))
+	case strings.HasPrefix(statement, "CREATE INDEX"):
+		tx.db.state.indexesPresent = true
+	case strings.HasPrefix(statement, "INSERT INTO subtitle_embedding_contract"):
+		tx.db.state.contract = &persistedEmbeddingContract{
+			embeddingContract: embeddingContract{
+				Hash: args[0].(string), Provider: args[1].(string), Model: args[2].(string), Revision: args[3].(string),
+				Dimensions: args[4].(int), Profile: args[5].(string), TemplateVersion: args[6].(string), IndexVersion: args[7].(string),
+			},
+			Generation: args[8].(int64), State: "ready",
+		}
+	}
+	return pgconn.CommandTag{}, nil
+}
+
+func argsDimension(statement string) int {
+	start := strings.Index(statement, "vector(") + len("vector(")
+	end := strings.Index(statement[start:], ")") + start
+	var dimension int
+	_, _ = fmt.Sscanf(statement[start:end], "%d", &dimension)
+	return dimension
+}
+
+func (tx *rebuildRecorderTx) Query(_ context.Context, _ string, _ ...any) (pgx.Rows, error) {
+	return &rebuildRecorderRows{columns: tx.db.state.columns}, nil
+}
+
+func (tx *rebuildRecorderTx) QueryRow(_ context.Context, _ string, _ ...any) pgx.Row {
+	return &rebuildRecorderRow{contract: tx.db.state.contract}
+}
+
+func (tx *rebuildRecorderTx) Commit(context.Context) error {
+	tx.committed = true
+	return nil
+}
+
+func (tx *rebuildRecorderTx) Rollback(context.Context) error {
+	if tx.committed {
+		return nil
+	}
+	tx.db.state = cloneRebuildState(tx.snapshot)
+	tx.rolledBack = true
+	return nil
+}
+
+type rebuildRecorderRow struct{ contract *persistedEmbeddingContract }
+
+func (row *rebuildRecorderRow) Scan(dest ...any) error {
+	if row.contract == nil {
+		return pgx.ErrNoRows
+	}
+	values := []any{row.contract.Hash, row.contract.Provider, row.contract.Model, row.contract.Revision, row.contract.Dimensions, row.contract.Profile, row.contract.TemplateVersion, row.contract.IndexVersion, row.contract.Generation, row.contract.State}
+	for i, value := range values {
+		switch target := dest[i].(type) {
+		case *string:
+			*target = value.(string)
+		case *int:
+			*target = value.(int)
+		case *int64:
+			*target = value.(int64)
+		}
+	}
+	return nil
+}
+
+type rebuildRecorderRows struct {
+	columns []subtitleVectorColumn
+	index   int
+}
+
+func (rows *rebuildRecorderRows) Close()                                       {}
+func (rows *rebuildRecorderRows) Err() error                                   { return nil }
+func (rows *rebuildRecorderRows) CommandTag() pgconn.CommandTag                { return pgconn.CommandTag{} }
+func (rows *rebuildRecorderRows) FieldDescriptions() []pgconn.FieldDescription { return nil }
+func (rows *rebuildRecorderRows) Next() bool {
+	if rows.index >= len(rows.columns) {
+		return false
+	}
+	rows.index++
+	return true
+}
+func (rows *rebuildRecorderRows) Scan(dest ...any) error {
+	column := rows.columns[rows.index-1]
+	values := []any{column.Table, column.HasEmbedding, column.Typmod, column.DataType}
+	for i, value := range values {
+		switch target := dest[i].(type) {
+		case *string:
+			*target = value.(string)
+		case *bool:
+			*target = value.(bool)
+		case *int32:
+			*target = value.(int32)
+		}
+	}
+	return nil
+}
+func (rows *rebuildRecorderRows) Values() ([]any, error) { return nil, nil }
+func (rows *rebuildRecorderRows) RawValues() [][]byte    { return nil }
+func (rows *rebuildRecorderRows) Conn() *pgx.Conn        { return nil }
+
+func testEmbeddingContract(model string, dimensions int) embeddingContract {
+	profile := embeddingProfileQwen
+	if model == openAIEmbeddingModel {
+		profile = embeddingProfileBGE
+	}
+	contract, _ := newEmbeddingContract(SemanticSearchConfig{EmbeddingsProvider: embeddingsProviderOpenAI, EmbeddingsModel: model, EmbeddingsDimensions: dimensions, EmbeddingsProfile: profile})
+	return contract
+}
+
+func TestRebuildEmbeddingCorpusResetsPersistsAndUsesAdvisoryLock(t *testing.T) {
+	old := testEmbeddingContract(openAIEmbeddingModel, 768)
+	target := testEmbeddingContract(qwenEmbeddingModel, 1024)
+	db := &rebuildRecorderDB{state: rebuildRecorderState{
+		columns:  []subtitleVectorColumn{{Table: "subtitle_chunks", TableExists: true, HasEmbedding: true, Typmod: 768, DataType: "public.vector"}, {Table: "subtitle_shared_chunks", TableExists: true, HasEmbedding: true, Typmod: 768, DataType: "public.vector"}},
+		contract: &persistedEmbeddingContract{embeddingContract: old, Generation: 4, State: "ready"},
+		rows:     map[string]int{"subtitle_chunks": 4, "subtitle_shared_chunks": 5, "subtitle_index_sources": 2, "subtitle_shared_sources": 3, "subtitle_shared_sections": 1, "subtitle_index_jobs": 1}, indexesPresent: true,
+	}}
+	if err := rebuildEmbeddingCorpus(context.Background(), db, target); err != nil {
+		t.Fatal(err)
+	}
+	if !db.tx.committed || db.tx.rolledBack || !db.state.indexesPresent || db.state.contract == nil || db.state.contract.Generation != 5 || db.state.contract.State != "ready" || !embeddingContractsMatch(target, db.state.contract) {
+		t.Fatalf("rebuild state = %+v tx=%+v", db.state, db.tx)
+	}
+	for table, count := range db.state.rows {
+		if count != 0 {
+			t.Fatalf("%s retained %d rows", table, count)
+		}
+	}
+	if db.state.columns[0].Typmod != 1024 || db.state.columns[1].Typmod != 1024 {
+		t.Fatalf("vector dimensions = %+v", db.state.columns)
+	}
+	if !containsRebuildStatement(db.tx.statements, "pg_advisory_xact_lock") {
+		t.Fatal("rebuild did not invoke advisory lock")
+	}
+}
+
+func containsRebuildStatement(statements []string, fragment string) bool {
+	for _, statement := range statements {
+		if strings.Contains(statement, fragment) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestRebuildEmbeddingCorpusMatchingContractIsIdempotent(t *testing.T) {
+	contract := testEmbeddingContract(qwenEmbeddingModel, 1024)
+	db := &rebuildRecorderDB{state: rebuildRecorderState{
+		columns:  []subtitleVectorColumn{{Table: "subtitle_chunks", TableExists: true, HasEmbedding: true, Typmod: 1024, DataType: "vector"}, {Table: "subtitle_shared_chunks", TableExists: true, HasEmbedding: true, Typmod: 1024, DataType: "vector"}},
+		contract: &persistedEmbeddingContract{embeddingContract: contract, Generation: 7, State: "ready"},
+		rows:     map[string]int{"subtitle_chunks": 4, "subtitle_shared_chunks": 5}, indexesPresent: true,
+	}}
+	if err := rebuildEmbeddingCorpus(context.Background(), db, contract); err != nil {
+		t.Fatal(err)
+	}
+	if !db.tx.committed || containsRebuildStatement(db.tx.statements, "TRUNCATE TABLE") || db.state.rows["subtitle_chunks"] != 4 || db.state.contract.Generation != 7 {
+		t.Fatalf("matching rebuild was not idempotent: %+v tx=%+v", db.state, db.tx)
+	}
+}
+
+func TestRebuildEmbeddingCorpusRollsBackInjectedFailure(t *testing.T) {
+	old := testEmbeddingContract(openAIEmbeddingModel, 768)
+	target := testEmbeddingContract(qwenEmbeddingModel, 1024)
+	db := &rebuildRecorderDB{state: rebuildRecorderState{
+		columns:  []subtitleVectorColumn{{Table: "subtitle_chunks", TableExists: true, HasEmbedding: true, Typmod: 768, DataType: "vector"}, {Table: "subtitle_shared_chunks", TableExists: true, HasEmbedding: true, Typmod: 768, DataType: "vector"}},
+		contract: &persistedEmbeddingContract{embeddingContract: old, Generation: 2, State: "ready"},
+		rows:     map[string]int{"subtitle_chunks": 4, "subtitle_shared_chunks": 5}, indexesPresent: true,
+	}}
+	// The recorder injects the failure after the reset and first index creation.
+	failingDB := &rebuildFailingDB{inner: db, failOn: "CREATE INDEX subtitle_shared_chunks"}
+	if err := rebuildEmbeddingCorpus(context.Background(), failingDB, target); err == nil {
+		t.Fatal("injected rebuild failure unexpectedly succeeded")
+	}
+	if db.state.rows["subtitle_chunks"] != 4 || db.state.rows["subtitle_shared_chunks"] != 5 || db.state.columns[0].Typmod != 768 || db.state.contract.Generation != 2 || !db.tx.rolledBack {
+		t.Fatalf("rollback did not restore prior state: %+v tx=%+v", db.state, db.tx)
+	}
+}
+
+type rebuildFailingDB struct {
+	inner  *rebuildRecorderDB
+	failOn string
+}
+
+func (db *rebuildFailingDB) Begin(ctx context.Context) (pgx.Tx, error) {
+	tx, err := db.inner.Begin(ctx)
+	if err == nil {
+		db.inner.tx.failOn = db.failOn
+	}
+	return tx, err
+}
+
+func TestBootstrapLegacyEmbeddingContractPreservesRows(t *testing.T) {
+	contract := testEmbeddingContract(openAIEmbeddingModel, 768)
+	db := &rebuildRecorderDB{state: rebuildRecorderState{
+		columns: []subtitleVectorColumn{{Table: "subtitle_chunks", TableExists: true, HasEmbedding: true, Typmod: 768, DataType: "public.vector"}, {Table: "subtitle_shared_chunks", TableExists: true, HasEmbedding: true, Typmod: 768, DataType: "public.vector"}},
+		rows:    map[string]int{"subtitle_chunks": 4, "subtitle_shared_chunks": 5}, indexesPresent: true,
+	}}
+	if err := bootstrapLegacyEmbeddingContract(context.Background(), db, contract); err != nil {
+		t.Fatal(err)
+	}
+	if db.state.contract == nil || !embeddingContractsMatch(contract, db.state.contract) || db.state.rows["subtitle_chunks"] != 4 || db.state.rows["subtitle_shared_chunks"] != 5 || !db.tx.committed {
+		t.Fatalf("legacy bootstrap changed corpus: %+v tx=%+v", db.state, db.tx)
+	}
+}

--- a/subtitle_search_test.go
+++ b/subtitle_search_test.go
@@ -307,6 +307,22 @@ func TestOpenAIEmbeddingClientRejectsWrongDimension(t *testing.T) {
 	}
 }
 
+func TestOpenAIEmbeddingClientRejectsResponseModelMismatch(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		vector := make([]float32, subtitleEmbeddingDimensions)
+		vector[0] = 1
+		_ = json.NewEncoder(w).Encode(openAIEmbeddingResponse{Model: "wrong/model", Data: []openAIEmbeddingItem{{Index: 0, Embedding: vector}}})
+	}))
+	defer server.Close()
+	client, err := newEmbeddingClient(server.URL, embeddingsProviderOpenAI, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.embed(context.Background(), []string{"model check"}); err == nil || !strings.Contains(err.Error(), "does not match configured model") {
+		t.Fatalf("model mismatch error = %v", err)
+	}
+}
+
 func TestEmbeddingsProviderDefaultsToTEIAndRejectsUnsupported(t *testing.T) {
 	provider, err := normalizeEmbeddingsProvider("")
 	if err != nil || provider != embeddingsProviderTEI {
@@ -314,6 +330,182 @@ func TestEmbeddingsProviderDefaultsToTEIAndRejectsUnsupported(t *testing.T) {
 	}
 	if _, err := normalizeEmbeddingsProvider("local"); err == nil {
 		t.Fatal("unsupported provider accepted")
+	}
+}
+
+func TestEmbeddingContractDefaultsToBGECompatibility(t *testing.T) {
+	contract, err := newEmbeddingContract(SemanticSearchConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if contract.Model != openAIEmbeddingModel || contract.Dimensions != subtitleEmbeddingDimensions || contract.Profile != embeddingProfileBGE {
+		t.Fatalf("default embedding contract = %+v", contract)
+	}
+	if got := contract.queryInput("hello"); got != bgeQueryInstruction+"hello" {
+		t.Fatalf("default query format = %q", got)
+	}
+}
+
+func TestNonLegacySameDimensionContractRequiresRebuildBeforeCorpusUse(t *testing.T) {
+	_, err := newSubtitleSearchStore(context.Background(), SemanticSearchConfig{
+		EmbeddingsModel:      "custom/bge-compatible",
+		EmbeddingsDimensions: subtitleEmbeddingDimensions,
+		EmbeddingsProfile:    embeddingProfileBGE,
+	})
+	if err == nil || !strings.Contains(err.Error(), "corpus rebuild required") {
+		t.Fatalf("same-dimension nonlegacy error = %v", err)
+	}
+	_, err = newSubtitleSearchStore(context.Background(), SemanticSearchConfig{
+		EmbeddingsModelRevision: "checkpoint-2",
+	})
+	if err == nil || !strings.Contains(err.Error(), "corpus rebuild required") {
+		t.Fatalf("revision-only nonlegacy error = %v", err)
+	}
+}
+
+func TestOpenAIBGEContractRemainsLegacyCompatible(t *testing.T) {
+	contract, err := newEmbeddingContract(SemanticSearchConfig{
+		EmbeddingsProvider:   embeddingsProviderOpenAI,
+		EmbeddingsModel:      openAIEmbeddingModel,
+		EmbeddingsDimensions: subtitleEmbeddingDimensions,
+		EmbeddingsProfile:    embeddingProfileBGE,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !isLegacyEmbeddingContract(contract) {
+		t.Fatalf("exact OpenAI BGE contract was rejected as legacy: %+v", contract)
+	}
+	for _, nonlegacy := range []embeddingContract{
+		{Provider: embeddingsProviderOpenAI, Model: "custom/model", Dimensions: subtitleEmbeddingDimensions, Profile: embeddingProfileBGE},
+		{Provider: embeddingsProviderOpenAI, Model: openAIEmbeddingModel, Dimensions: subtitleEmbeddingDimensions, Profile: embeddingProfileQwen},
+		{Provider: embeddingsProviderOpenAI, Model: openAIEmbeddingModel, Dimensions: subtitleEmbeddingDimensions, Profile: embeddingProfileBGE, Revision: "rev-1"},
+	} {
+		if isLegacyEmbeddingContract(nonlegacy) {
+			t.Fatalf("nonlegacy contract was accepted: %+v", nonlegacy)
+		}
+	}
+}
+
+func TestSubtitleVectorTypmodsRejectAlteredExistingColumnsAndAllowAbsentTables(t *testing.T) {
+	if err := validateSubtitleVectorColumns(nil); err != nil {
+		t.Fatalf("absent tables rejected: %v", err)
+	}
+	if err := validateSubtitleVectorColumns([]subtitleVectorColumn{{Table: "subtitle_chunks", TableExists: true, HasEmbedding: true, Typmod: currentSubtitleSchemaDimensions, DataType: "vector"}, {Table: "subtitle_shared_chunks", TableExists: true, HasEmbedding: true, Typmod: currentSubtitleSchemaDimensions, DataType: "vector"}}); err != nil {
+		t.Fatalf("legacy typmods rejected: %v", err)
+	}
+	for _, altered := range []subtitleVectorColumn{
+		{Table: "subtitle_chunks", TableExists: true, HasEmbedding: true, Typmod: 1024, DataType: "vector"},
+		{Table: "subtitle_shared_chunks", TableExists: true, HasEmbedding: true, Typmod: -1, DataType: "vector"},
+		{Table: "subtitle_chunks", TableExists: true, HasEmbedding: false, Typmod: -1},
+	} {
+		if err := validateSubtitleVectorColumns([]subtitleVectorColumn{altered}); err == nil || !strings.Contains(err.Error(), "corpus rebuild required") {
+			t.Fatalf("altered column %+v was accepted: %v", altered, err)
+		}
+	}
+}
+
+func TestQwenRebuildDDLIsBoundedAndTargetsBothVectorColumns(t *testing.T) {
+	statements, err := embeddingVectorAlterStatements(1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(statements) != 2 || !strings.Contains(statements[0], "subtitle_chunks") || !strings.Contains(statements[0], "vector(1024)") || !strings.Contains(statements[1], "subtitle_shared_chunks") || !strings.Contains(statements[1], "vector(1024)") {
+		t.Fatalf("unexpected Qwen rebuild DDL: %v", statements)
+	}
+	if _, err := embeddingVectorAlterStatements(maxEmbeddingDimensions + 1); err == nil {
+		t.Fatal("unbounded embedding DDL dimension accepted")
+	}
+}
+
+func TestQwenOpenAIEmbeddingContractUsesConfiguredModelAndRetrievalProfile(t *testing.T) {
+	contract, err := newEmbeddingContract(SemanticSearchConfig{
+		EmbeddingsProvider:   embeddingsProviderOpenAI,
+		EmbeddingsModel:      "Qwen/Qwen3-Embedding-0.6B",
+		EmbeddingsDimensions: 1024,
+		EmbeddingsProfile:    embeddingProfileQwen,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	query := contract.queryInput("find the scene")
+	if query != "Instruct: Given a query, retrieve relevant passages\nQuery: find the scene" || strings.Contains(query, bgeQueryInstruction) {
+		t.Fatalf("unexpected Qwen query format: %q", query)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var request struct {
+			Model string `json:"model"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Fatal(err)
+		}
+		if request.Model != contract.Model {
+			t.Errorf("model = %q, want %q", request.Model, contract.Model)
+		}
+		vector := make([]float32, contract.Dimensions)
+		vector[0] = 1
+		_ = json.NewEncoder(w).Encode(openAIEmbeddingResponse{Data: []openAIEmbeddingItem{{Index: 0, Embedding: vector}}})
+	}))
+	defer server.Close()
+	client, err := newEmbeddingClientWithContract(server.URL, contract, "secret-key")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.embed(context.Background(), []string{query}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestEmbeddingContractProbeRejectsObservedDimensionMismatch(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		vector := make([]float32, subtitleEmbeddingDimensions)
+		vector[0] = 1
+		_ = json.NewEncoder(w).Encode(openAIEmbeddingResponse{Data: []openAIEmbeddingItem{{Index: 0, Embedding: vector}}})
+	}))
+	defer server.Close()
+	contract := embeddingContract{Provider: embeddingsProviderOpenAI, Model: qwenEmbeddingModel, Dimensions: 1024, Profile: embeddingProfileQwen, TemplateVersion: embeddingTemplateVersion, IndexVersion: subtitleSearchIndexVersion}
+	client, err := newEmbeddingClientWithContract(server.URL, contract, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := client.probe(context.Background()); err == nil || !strings.Contains(err.Error(), "want 1024") {
+		t.Fatalf("dimension mismatch probe error = %v", err)
+	}
+	if _, err := newSubtitleSearchStore(context.Background(), SemanticSearchConfig{EmbeddingsURL: server.URL, EmbeddingsProvider: embeddingsProviderOpenAI, EmbeddingsModel: qwenEmbeddingModel, EmbeddingsDimensions: 1024, EmbeddingsProfile: embeddingProfileQwen}); err == nil || !strings.Contains(err.Error(), "corpus rebuild required") {
+		t.Fatalf("dimension rebuild error = %v", err)
+	}
+}
+
+func TestEmbeddingContractProbeRejectsAllZeroVector(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(openAIEmbeddingResponse{Data: []openAIEmbeddingItem{{Index: 0, Embedding: make([]float32, subtitleEmbeddingDimensions)}}})
+	}))
+	defer server.Close()
+	client, err := newEmbeddingClient(server.URL, embeddingsProviderOpenAI, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := client.probe(context.Background()); err == nil || !strings.Contains(err.Error(), "all-zero") {
+		t.Fatalf("zero-vector probe error = %v", err)
+	}
+}
+
+func TestEmbeddingContractHashExcludesEndpointAndSecret(t *testing.T) {
+	first, err := newEmbeddingContract(SemanticSearchConfig{EmbeddingsProvider: embeddingsProviderOpenAI, EmbeddingsURL: "http://one", EmbeddingsAPIKey: "secret-a", EmbeddingsModel: "model", EmbeddingsDimensions: 768, EmbeddingsProfile: embeddingProfileBGE})
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := newEmbeddingContract(SemanticSearchConfig{EmbeddingsProvider: embeddingsProviderOpenAI, EmbeddingsURL: "http://two", EmbeddingsAPIKey: "secret-b", EmbeddingsModel: "model", EmbeddingsDimensions: 768, EmbeddingsProfile: embeddingProfileBGE})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.Hash != second.Hash || first.Hash == "" {
+		t.Fatalf("contract hash changed with endpoint/key: %q vs %q", first.Hash, second.Hash)
+	}
+	second.Revision = "different"
+	second.Hash = embeddingContractHash(second)
+	if first.Hash == second.Hash {
+		t.Fatal("contract hash ignored model revision")
 	}
 }
 


### PR DESCRIPTION
## Summary
- configure embedding model, dimensions, profile, and revision
- add Qwen3 1024-dimensional OpenAI-compatible overlay
- protect corpora with startup contract validation and explicit transactional rebuilds
- document safe BGE-to-Qwen migration and required reindexing

## Validation
- `go test ./...`
- `go test -race ./...`
- `git diff --check`

Stacked on #17.