### PR TITLE
Fix audit findings, harden subtitle indexing, and support configurable embedding dimensions

### DIFF
--- a/api.go
+++ b/api.go
@@ -415,7 +415,7 @@ func (a *API) Shutdown() error {
 func (a *API) getSessions(ctx fiber.Ctx) error {
 	sessions, err := a.app.GetSessions(ctx.UserContext())
 	if err != nil {
-		return err
+		return renderAPIErrorCode(ctx, http.StatusServiceUnavailable, "sessions_unavailable", "could not retrieve active sessions")
 	}
 
 	return ctx.JSON(sessions)
@@ -609,7 +609,7 @@ func renderSourceAPIError(ctx fiber.Ctx, err error) error {
 func (a *API) getSubtitleEntries(ctx fiber.Ctx) error {
 	ratingKeyStr := ctx.Params("ratingKey")
 	if ratingKeyStr == "" || len(ratingKeyStr) > 512 {
-		return fmt.Errorf("ratingKey not specified")
+		return renderAPIErrorCode(ctx, http.StatusUnprocessableEntity, "validation_error", "ratingKey is required")
 	}
 
 	mediaIdStr := ctx.Query("mediaId")
@@ -621,7 +621,7 @@ func (a *API) getSubtitleEntries(ctx fiber.Ctx) error {
 	subtitleIndexStr := ctx.Query("subtitle", "-1")
 	subtitleIndex, err := strconv.Atoi(subtitleIndexStr)
 	if err != nil {
-		return fmt.Errorf("subtitle not an integer")
+		return renderAPIErrorCode(ctx, http.StatusUnprocessableEntity, "validation_error", "subtitle not an integer")
 	}
 
 	if subtitleIndex < 0 {
@@ -688,13 +688,16 @@ func (a *API) clip(ctx fiber.Ctx) error {
 
 func (a *API) thumb(ctx fiber.Ctx) error {
 	path := ctx.Query("path")
-	if path == "" {
-		return fmt.Errorf("path not specified")
+	if strings.TrimSpace(path) == "" {
+		return renderAPIErrorCode(ctx, http.StatusBadRequest, "validation_error", "path is required")
 	}
 
 	respBody, contentType, err := a.app.Thumb(ctx.UserContext(), path)
 	if err != nil {
-		return err
+		if errors.Is(err, errThumbValidation) {
+			return renderAPIErrorCode(ctx, http.StatusBadRequest, "validation_error", err.Error())
+		}
+		return renderAPIErrorCode(ctx, http.StatusServiceUnavailable, "thumbnail_unavailable", "thumbnail is unavailable")
 	}
 
 	defer respBody.Close()
@@ -1371,7 +1374,7 @@ func plexGetPin(ctx context.Context, product string, strong bool, clientID strin
 	req.Header.Set("X-Plex-Product", product)
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := plexTVHTTPClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -1408,7 +1411,7 @@ func plexGetToken(ctx context.Context, pinID int64, clientID string) (*plexToken
 	}
 	req.Header.Set("X-Plex-Client-Identifier", clientID)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := plexTVHTTPClient.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/application.go
+++ b/application.go
@@ -783,7 +783,7 @@ func (a *Application) plexSourceToken(ctx context.Context, userScoped bool) stri
 }
 
 func (a *Application) GetValidatedUser(ctx context.Context) (*User, error) {
-	user, err := NewPlexTV(*AuthTokenFromContext(ctx)).getUser()
+	user, err := NewPlexTV(*AuthTokenFromContext(ctx)).getUserContext(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -793,7 +793,7 @@ func (a *Application) GetValidatedUser(ctx context.Context) (*User, error) {
 	}
 
 	// Check if user is an invited user on this server
-	users, err := a.plexTv.getUsers()
+	users, err := a.plexTv.getUsersContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("could not get server users: %w", err)
 	}
@@ -806,7 +806,11 @@ func (a *Application) GetValidatedUser(ctx context.Context) (*User, error) {
 }
 
 func (a *Application) GetSessions(ctx context.Context) ([]sessionMetadata, error) {
-	sessionsURL := fmt.Sprintf("%s/status/sessions", a.config.Plex.Host)
+	baseOrigin, err := validatePlexOrigin(a.config.Plex.Host)
+	if err != nil {
+		return nil, fmt.Errorf("configured Plex origin is invalid: %w", err)
+	}
+	sessionsURL := fmt.Sprintf("%s/status/sessions", baseOrigin.String())
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, sessionsURL, nil)
 	if err != nil {
@@ -815,15 +819,31 @@ func (a *Application) GetSessions(ctx context.Context) ([]sessionMetadata, error
 	req.Header.Set("X-Plex-Token", a.config.Plex.Token)
 	req.Header.Set("Accept", "application/json")
 
-	resp, err := http.DefaultClient.Do(req)
+	client := &http.Client{
+		Timeout: librarySearchTimeout,
+		CheckRedirect: func(next *http.Request, via []*http.Request) error {
+			if len(via) == 0 {
+				return nil
+			}
+			if !samePlexOrigin(baseOrigin, next.URL) {
+				return errors.New("sessions redirect leaves configured Plex origin")
+			}
+			return nil
+		},
+	}
+
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("could not get sessions: %w", err)
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("could not read sessions response: %w", err)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxLibraryResponseBytes+1))
+	if err != nil || len(body) > maxLibraryResponseBytes {
+		if err != nil {
+			return nil, fmt.Errorf("could not read sessions response: %w", err)
+		}
+		return nil, errors.New("sessions response exceeds size limit")
 	}
 
 	if resp.StatusCode != http.StatusOK {
@@ -1273,9 +1293,14 @@ func (a *Application) GetSubtitleEntriesForSource(ctx context.Context, ratingKey
 	if err != nil {
 		return nil, fmt.Errorf("could not acquire encoder: %w", err)
 	}
-	tmpFile, err := ExtractSubtitleFullContext(operationCtx, fileURL, source.EmbeddedIndex)
+	tmpFile, err := extractSubtitleFullContextFn(operationCtx, fileURL, source.EmbeddedIndex)
 	release()
 	if err != nil {
+		if errors.Is(err, ErrNoUsableSubtitleCues) {
+			entries = []SubtitleEntry{}
+			a.subtitleCache.setForCaller(cacheKey, entries, callerID)
+			return entries, nil
+		}
 		return nil, fmt.Errorf("could not extract subtitle: %w", err)
 	}
 	defer os.Remove(tmpFile)
@@ -1322,18 +1347,44 @@ func (a *Application) downloadSubtitleWithAccess(ctx context.Context, streamKey,
 }
 
 func (a *Application) downloadSubtitleWithToken(ctx context.Context, streamKey, codec, token string) ([]SubtitleEntry, error) {
-	streamURL := fmt.Sprintf("%s%s?X-Plex-Token=%s",
-		a.config.Plex.Host,
-		streamKey,
-		token,
-	)
+	if strings.TrimSpace(streamKey) == "" {
+		return nil, errors.New("subtitle stream key is required")
+	}
+	if strings.HasPrefix(streamKey, "//") {
+		return nil, errors.New("scheme-relative subtitle stream path is not allowed")
+	}
+	parsed, err := url.Parse(streamKey)
+	if err != nil || parsed.User != nil || parsed.IsAbs() || !strings.HasPrefix(parsed.Path, "/") {
+		return nil, errors.New("subtitle stream path is invalid")
+	}
+	baseOrigin, err := validatePlexOrigin(a.config.Plex.Host)
+	if err != nil {
+		return nil, fmt.Errorf("configured Plex origin is invalid: %w", err)
+	}
+	streamURL := fmt.Sprintf("%s%s", baseOrigin.String(), parsed.RequestURI())
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, streamURL, nil)
 	if err != nil {
 		return nil, err
 	}
+	if token != "" {
+		req.Header.Set("X-Plex-Token", token)
+	}
 
-	resp, err := http.DefaultClient.Do(req)
+	client := &http.Client{
+		Timeout: 15 * time.Second,
+		CheckRedirect: func(next *http.Request, via []*http.Request) error {
+			if len(via) == 0 {
+				return nil
+			}
+			if !samePlexOrigin(baseOrigin, next.URL) {
+				return errors.New("subtitle redirect leaves configured Plex origin")
+			}
+			return nil
+		},
+	}
+
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -1343,34 +1394,15 @@ func (a *Application) downloadSubtitleWithToken(ctx context.Context, streamKey, 
 		return nil, fmt.Errorf("subtitle download returned status %d", resp.StatusCode)
 	}
 
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	switch strings.ToLower(strings.TrimSpace(codec)) {
-	case "webvtt":
-		return ParseWebVTT(body)
-	case "ass", "ssa":
-		return ParseASS(body)
-	case "srt", "subrip", "text":
-		tmpFile, err := os.CreateTemp("", "cutscene_sub_*.srt")
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxLibraryResponseBytes+1))
+	if err != nil || len(body) > maxLibraryResponseBytes {
 		if err != nil {
 			return nil, err
 		}
-		tmpFilePath := tmpFile.Name()
-		defer os.Remove(tmpFilePath)
-		if _, err := tmpFile.Write(body); err != nil {
-			_ = tmpFile.Close()
-			return nil, err
-		}
-		if err := tmpFile.Close(); err != nil {
-			return nil, err
-		}
-		return ParseSRT(tmpFilePath)
-	default:
-		return nil, fmt.Errorf("unsupported native subtitle codec %q", codec)
+		return nil, errors.New("subtitle response exceeds size limit")
 	}
+
+	return parseSubtitleBody(body, codec)
 }
 
 func parseSubtitleBody(body []byte, codec string) ([]SubtitleEntry, error) {
@@ -1504,9 +1536,15 @@ func (a *Application) Clip(ctx context.Context, ratingKeyStr, mediaIdStr, from, 
 			}
 			subtitleFile, err = a.prepareExternalSubtitle(ctx, source, fromMs, toMs)
 			if err != nil {
-				return "", err
+				if errors.Is(err, ErrNoUsableSubtitleCues) {
+					subtitleFile = ""
+				} else {
+					return "", err
+				}
 			}
-			defer os.Remove(subtitleFile)
+			if subtitleFile != "" {
+				defer os.Remove(subtitleFile)
+			}
 		} else if source.PGS {
 			subtitleIdxForFFmpeg = source.EmbeddedIndex
 		} else {
@@ -1514,29 +1552,53 @@ func (a *Application) Clip(ctx context.Context, ratingKeyStr, mediaIdStr, from, 
 			if acquireErr != nil {
 				return "", fmt.Errorf("could not acquire encoder: %w", acquireErr)
 			}
-			subtitleFile, err = ExtractSubtitleContext(ctx, fileURL, from, to, source.EmbeddedIndex)
+			subtitleFile, err = extractSubtitleContextFn(ctx, fileURL, from, to, source.EmbeddedIndex)
 			release()
 			if err != nil {
-				return "", fmt.Errorf("could not extract subtitle: %w", err)
+				if errors.Is(err, ErrNoUsableSubtitleCues) {
+					subtitleFile = ""
+				} else {
+					return "", fmt.Errorf("could not extract subtitle: %w", err)
+				}
 			}
-			defer os.Remove(subtitleFile)
+			if subtitleFile != "" {
+				defer os.Remove(subtitleFile)
+			}
 		}
 	}
 
 	var fileName string
 	if metadata.Type == "episode" {
-		fileName = fmt.Sprintf("%s S%02dE%02d %s (%s - %s).mp4",
-			*metadata.GrandparentTitle,
-			*metadata.ParentIndex,
-			*metadata.Index,
+		season := 0
+		if metadata.ParentIndex != nil {
+			season = *metadata.ParentIndex
+		}
+		episode := 0
+		if metadata.Index != nil {
+			episode = *metadata.Index
+		}
+		showTitle := ""
+		if metadata.GrandparentTitle != nil && *metadata.GrandparentTitle != "" {
+			showTitle = *metadata.GrandparentTitle + " "
+		}
+		fileName = fmt.Sprintf("%sS%02dE%02d %s (%s - %s).mp4",
+			showTitle,
+			season,
+			episode,
 			metadata.Title,
 			from,
 			to,
 		)
-	} else {
+	} else if metadata.Year != nil {
 		fileName = fmt.Sprintf("%s (%d) (%s - %s).mp4",
 			metadata.Title,
 			*metadata.Year,
+			from,
+			to,
+		)
+	} else {
+		fileName = fmt.Sprintf("%s (%s - %s).mp4",
+			metadata.Title,
 			from,
 			to,
 		)
@@ -1575,24 +1637,78 @@ func (a *Application) Clip(ctx context.Context, ratingKeyStr, mediaIdStr, from, 
 		return "", fmt.Errorf("could not acquire encoder: %w", err)
 	}
 	defer release()
-	return DoFfmpeg(params)
+	return doFfmpegFn(params)
 }
 
+var errThumbValidation = errors.New("invalid thumbnail path")
+
+const thumbnailProxyTimeout = 15 * time.Second
+
 func (a *Application) Thumb(ctx context.Context, thumb string) (io.ReadCloser, string, error) {
+	if strings.TrimSpace(thumb) == "" {
+		return nil, "", fmt.Errorf("%w: path is required", errThumbValidation)
+	}
+	if strings.HasPrefix(thumb, "//") {
+		return nil, "", fmt.Errorf("%w: scheme-relative thumbnail URL is not allowed", errThumbValidation)
+	}
+	parsed, err := url.Parse(thumb)
+	if err != nil {
+		return nil, "", fmt.Errorf("%w: %v", errThumbValidation, err)
+	}
+	if parsed.User != nil {
+		return nil, "", fmt.Errorf("%w: userinfo is not allowed", errThumbValidation)
+	}
+
+	baseOrigin, err := validatePlexOrigin(a.config.Plex.Host)
+	if err != nil {
+		return nil, "", fmt.Errorf("configured Plex origin is invalid: %w", err)
+	}
+
+	var targetPath string
+	if parsed.IsAbs() {
+		if !samePlexOrigin(baseOrigin, parsed) {
+			return nil, "", fmt.Errorf("%w: thumbnail is not hosted by configured Plex", errThumbValidation)
+		}
+		targetPath = parsed.RequestURI()
+	} else {
+		if !strings.HasPrefix(parsed.Path, "/") {
+			return nil, "", fmt.Errorf("%w: path must begin with /", errThumbValidation)
+		}
+		targetPath = parsed.RequestURI()
+	}
+	if !strings.HasPrefix(targetPath, "/") || strings.HasPrefix(targetPath, "//") {
+		return nil, "", fmt.Errorf("%w: invalid path structure", errThumbValidation)
+	}
+
 	token := a.plexSourceToken(ctx, AuthTokenFromContext(ctx) != nil)
-	transcodeURL := fmt.Sprintf("%s/photo/:/transcode?width=320&height=320&url=%s&X-Plex-Token=%s",
-		a.config.Plex.Host,
-		url.QueryEscape(thumb),
-		token,
+	transcodeURL := fmt.Sprintf("%s/photo/:/transcode?width=320&height=320&url=%s",
+		baseOrigin.String(),
+		url.QueryEscape(targetPath),
 	)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, transcodeURL, nil)
 	if err != nil {
 		return nil, "", err
 	}
+	if token != "" {
+		req.Header.Set("X-Plex-Token", token)
+	}
 	req.Header.Set("Accept", "image/*")
 
-	resp, err := http.DefaultClient.Do(req)
+	client := &http.Client{
+		Timeout: thumbnailProxyTimeout,
+		CheckRedirect: func(next *http.Request, via []*http.Request) error {
+			if len(via) == 0 {
+				return nil
+			}
+			if !samePlexOrigin(baseOrigin, next.URL) {
+				return errors.New("thumbnail redirect leaves configured Plex origin")
+			}
+			return nil
+		},
+	}
+
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, "", err
 	}

--- a/application.go
+++ b/application.go
@@ -263,10 +263,6 @@ func NewApplication(config Config) (*Application, error) {
 			return nil, searchErr
 		}
 		app.subtitleSearch = searchStore
-		if err := app.subtitleJobs.recoverPersistedJobs(); err != nil {
-			app.subtitleSearch.close()
-			return nil, err
-		}
 	}
 
 	identity, err := app.plexAdmin.General.GetIdentity(context.Background())
@@ -280,6 +276,13 @@ func NewApplication(config Config) (*Application, error) {
 	// remains usable, while untrusted advertised alternatives remain rejected.
 	if err := app.plexResources.DiscoverTrustedOrigins(context.Background(), config.Plex.Token, app.machineIdentifier); err != nil {
 		log.Printf("Plex trusted-origin discovery unavailable: %s", redactedDiagnostic(err))
+	}
+
+	if config.SemanticSearch.Enabled {
+		if err := app.subtitleJobs.recoverPersistedJobs(); err != nil {
+			app.subtitleSearch.close()
+			return nil, err
+		}
 	}
 
 	tokenDetails, err := app.plexAdmin.Authentication.GetTokenDetails(context.Background(), operations.GetTokenDetailsRequest{})

--- a/application_fixes_test.go
+++ b/application_fixes_test.go
@@ -1,0 +1,318 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/LukeHagar/plexgo"
+	"github.com/gofiber/fiber/v3"
+)
+
+type testAPIErrorResponse struct {
+	Error struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+func TestDownloadSubtitleWithTokenValidation(t *testing.T) {
+	app := &Application{}
+	app.config.Plex.Host = "http://127.0.0.1:32400"
+	app.config.Plex.Token = "token"
+
+	tests := []struct {
+		name      string
+		streamKey string
+		errMsg    string
+	}{
+		{"empty", "", "subtitle stream key is required"},
+		{"whitespace", "   ", "subtitle stream key is required"},
+		{"scheme-relative", "//evil.com/sub.srt", "scheme-relative subtitle stream path is not allowed"},
+		{"absolute url", "http://evil.com/sub.srt", "subtitle stream path is invalid"},
+		{"missing leading slash", "sub.srt", "subtitle stream path is invalid"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := app.downloadSubtitleWithToken(context.Background(), tc.streamKey, "srt", "test-token")
+			if err == nil {
+				t.Fatalf("expected error for streamKey %q, got nil", tc.streamKey)
+			}
+			if !strings.Contains(err.Error(), tc.errMsg) {
+				t.Fatalf("expected error %q, got %q", tc.errMsg, err.Error())
+			}
+		})
+	}
+}
+
+func TestDownloadSubtitleWithTokenExecution(t *testing.T) {
+	var capturedToken atomic.Pointer[string]
+	var capturedURL atomic.Pointer[string]
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tok := r.Header.Get("X-Plex-Token")
+		capturedToken.Store(&tok)
+		u := r.URL.String()
+		capturedURL.Store(&u)
+
+		switch r.URL.Path {
+		case "/subtitles/valid.srt":
+			w.Header().Set("Content-Type", "text/plain")
+			_, _ = io.WriteString(w, "1\n00:00:01,000 --> 00:00:02,000\nHello World\n\n")
+		case "/subtitles/huge.srt":
+			w.Header().Set("Content-Type", "text/plain")
+			// Write more than maxLibraryResponseBytes (8MB)
+			largeBuf := make([]byte, 1024*1024)
+			for i := range largeBuf {
+				largeBuf[i] = 'A'
+			}
+			for i := 0; i < 9; i++ {
+				_, _ = w.Write(largeBuf)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	app := &Application{}
+	app.config.Plex.Host = server.URL
+	app.config.Plex.Token = "default-token"
+
+	t.Run("successful download sends token in header", func(t *testing.T) {
+		entries, err := app.downloadSubtitleWithToken(context.Background(), "/subtitles/valid.srt", "srt", "custom-token")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(entries) != 1 || entries[0].Text != "Hello World" {
+			t.Fatalf("unexpected entries: %+v", entries)
+		}
+		tok := capturedToken.Load()
+		if tok == nil || *tok != "custom-token" {
+			t.Fatalf("captured token = %v, want 'custom-token'", tok)
+		}
+		rawURL := capturedURL.Load()
+		if rawURL != nil && strings.Contains(*rawURL, "X-Plex-Token") {
+			t.Fatalf("X-Plex-Token should not be in query: %s", *rawURL)
+		}
+	})
+
+	t.Run("response exceeding size limit returns error", func(t *testing.T) {
+		_, err := app.downloadSubtitleWithToken(context.Background(), "/subtitles/huge.srt", "srt", "token")
+		if err == nil {
+			t.Fatal("expected size limit error")
+		}
+		if !strings.Contains(err.Error(), "exceeds size limit") {
+			t.Fatalf("expected size limit error, got: %v", err)
+		}
+	})
+}
+
+func TestGetSessionsValidationAndLimit(t *testing.T) {
+	t.Run("invalid configured origin fails", func(t *testing.T) {
+		app := &Application{}
+		app.config.Plex.Host = "http://evil.com:invalid-port"
+		_, err := app.GetSessions(context.Background())
+		if err == nil {
+			t.Fatal("expected origin error")
+		}
+	})
+
+	t.Run("response exceeding size limit fails", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			largeBuf := make([]byte, 1024*1024)
+			for i := 0; i < 9; i++ {
+				_, _ = w.Write(largeBuf)
+			}
+		}))
+		defer server.Close()
+
+		app := &Application{}
+		app.config.Plex.Host = server.URL
+		app.config.Plex.Token = "token"
+
+		_, err := app.GetSessions(context.Background())
+		if err == nil {
+			t.Fatal("expected size limit error")
+		}
+		if !strings.Contains(err.Error(), "exceeds size limit") {
+			t.Fatalf("expected size limit error, got: %v", err)
+		}
+	})
+
+	t.Run("successful sessions parse", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"MediaContainer":{"size":1,"Metadata":[{"ratingKey":"1","title":"Session 1"}]}}`)
+		}))
+		defer server.Close()
+
+		app := &Application{}
+		app.config.Plex.Host = server.URL
+		app.config.Plex.Token = "token"
+
+		sessions, err := app.GetSessions(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(sessions) != 1 || sessions[0].RatingKey == nil || *sessions[0].RatingKey != "1" {
+			t.Fatalf("expected 1 session with ratingKey 1, got %+v", sessions)
+		}
+	})
+}
+
+func TestClipNoUsableSubtitleCuesFallback(t *testing.T) {
+	origExtract := extractSubtitleContextFn
+	origDoFfmpeg := doFfmpegFn
+	defer func() {
+		extractSubtitleContextFn = origExtract
+		doFfmpegFn = origDoFfmpeg
+	}()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/library/metadata/10":
+			_, _ = io.WriteString(w, `{
+				"MediaContainer": {
+					"Metadata": [{
+						"ratingKey": "10",
+						"type": "movie",
+						"title": "Test Movie",
+						"Media": [{
+							"id": 100,
+							"Part": [{
+								"id": 200,
+								"key": "/library/parts/200/file.mp4",
+								"Stream": [
+									{"id": 300, "streamType": 1, "codec": "h264"},
+									{"id": 301, "streamType": 2, "codec": "aac"},
+									{"id": 302, "streamType": 3, "codec": "srt", "index": 2}
+								]
+							}]
+						}]
+					}]
+				}
+			}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	app := &Application{}
+	app.config.Plex.Host = server.URL
+	app.config.Plex.Token = "admin-tok"
+	app.plexAdmin = plexgo.New(plexgo.WithServerURL(server.URL), plexgo.WithSecurity("admin-tok"))
+
+	// Subtitle extraction returns ErrNoUsableSubtitleCues
+	extractSubtitleContextFn = func(ctx context.Context, fileURL, from, to string, subtitleIndex int, subtitleOffsetMs ...int64) (string, error) {
+		return "", ErrNoUsableSubtitleCues
+	}
+
+	var capturedParams FfmpegParams
+	doFfmpegFn = func(params FfmpegParams) (string, error) {
+		capturedParams = params
+		return "/tmp/out.mp4", nil
+	}
+
+	res, err := app.Clip(context.Background(), "10", "100", "00:01:00.000", "00:02:00.000", 720, 20, 0)
+	if err != nil {
+		t.Fatalf("Clip failed unexpectedly: %v", err)
+	}
+	if res != "/tmp/out.mp4" {
+		t.Fatalf("result = %q, want /tmp/out.mp4", res)
+	}
+	if capturedParams.SubtitleFile != "" {
+		t.Fatalf("expected empty SubtitleFile on fallback, got %q", capturedParams.SubtitleFile)
+	}
+	if capturedParams.SubtitleIndex != -1 {
+		t.Fatalf("expected SubtitleIndex -1 on fallback, got %d", capturedParams.SubtitleIndex)
+	}
+}
+
+func TestAPISessionsAndSubtitleStructuredErrors(t *testing.T) {
+	app := &Application{}
+	app.config.Plex.Host = "http://127.0.0.1:1" // unconnectable host
+	app.config.Plex.Token = "token"
+
+	api := &API{
+		config: Config{},
+		app:    app,
+	}
+
+	httpApp := fiber.New()
+	httpApp.Use(func(ctx fiber.Ctx) error {
+		ctx.SetUserContext(ContextWithUser(ContextWithAuthToken(context.Background(), "tok"), User{Uuid: "user-1"}))
+		return ctx.Next()
+	})
+	httpApp.Get("/sessions", api.getSessions)
+	httpApp.Get("/subtitles/:ratingKey", api.getSubtitleEntries)
+	httpApp.Get("/subtitles", api.getSubtitleEntries)
+
+	t.Run("getSessions failure returns 503 structured error", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/sessions", nil)
+		resp, err := httpApp.Test(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusServiceUnavailable {
+			t.Fatalf("status = %d, want 503", resp.StatusCode)
+		}
+		var errResp testAPIErrorResponse
+		if err := json.NewDecoder(resp.Body).Decode(&errResp); err != nil {
+			t.Fatalf("failed to decode JSON error: %v", err)
+		}
+		if errResp.Error.Code != "sessions_unavailable" {
+			t.Fatalf("error code = %q, want 'sessions_unavailable'", errResp.Error.Code)
+		}
+	})
+
+	t.Run("getSubtitleEntries missing ratingKey returns 422 structured error", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/subtitles", nil)
+		resp, err := httpApp.Test(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusUnprocessableEntity {
+			t.Fatalf("status = %d, want 422", resp.StatusCode)
+		}
+		var errResp testAPIErrorResponse
+		if err := json.NewDecoder(resp.Body).Decode(&errResp); err != nil {
+			t.Fatalf("failed to decode JSON error: %v", err)
+		}
+		if errResp.Error.Code != "validation_error" {
+			t.Fatalf("error code = %q, want 'validation_error'", errResp.Error.Code)
+		}
+	})
+
+	t.Run("getSubtitleEntries non-integer subtitle returns 422 structured error", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/subtitles/100?subtitle=notanint", nil)
+		resp, err := httpApp.Test(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusUnprocessableEntity {
+			t.Fatalf("status = %d, want 422", resp.StatusCode)
+		}
+		var errResp testAPIErrorResponse
+		if err := json.NewDecoder(resp.Body).Decode(&errResp); err != nil {
+			t.Fatalf("failed to decode JSON error: %v", err)
+		}
+		if errResp.Error.Code != "validation_error" || !strings.Contains(errResp.Error.Message, "not an integer") {
+			t.Fatalf("unexpected error response: %+v", errResp)
+		}
+	})
+}

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -28,6 +28,14 @@ semantic_search:
   postgres_dsn: postgresql://cutscene:cutscene-poc@postgres:5432/cutscene?sslmode=disable
   embeddings_provider: tei
   embeddings_url: http://tei:80
+  # Batch size sent to embedding service per request (default: 32).
+  # batch_size: 32
+  # Concurrency for parallel embedding requests across workers (default: 2).
+  # Higher values take advantage of GPU continuous dynamic batching in TEI.
+  # concurrency: 2
+  # Optional query instruction prefix for retrieval models (e.g. BGE).
+  # Defaults to BGE prefix for BGE models, or empty for Qwen/OpenAI.
+  # query_instruction: ""
   # AMD alternative: use the AMD overlay instead, then change the two lines
   # above to:
   # embeddings_provider: openai

--- a/config_test.go
+++ b/config_test.go
@@ -118,3 +118,37 @@ func TestNewFFmpegLimiterNormalizesNonPositiveConcurrency(t *testing.T) {
 		}
 	}
 }
+
+func TestSemanticSearchConfigDefaultsAndOverrides(t *testing.T) {
+	t.Run("defaults", func(t *testing.T) {
+		cfg := loadConfigForTest(t, "plex:\n  host: http://plex\n")
+		if cfg.SemanticSearch.BatchSize != defaultSubtitleEmbeddingBatchSize {
+			t.Fatalf("expected default batch size %d, got %d", defaultSubtitleEmbeddingBatchSize, cfg.SemanticSearch.BatchSize)
+		}
+		if cfg.SemanticSearch.Concurrency != defaultSubtitleEmbeddingConcurrency {
+			t.Fatalf("expected default concurrency %d, got %d", defaultSubtitleEmbeddingConcurrency, cfg.SemanticSearch.Concurrency)
+		}
+		if cfg.SemanticSearch.QueryInstruction != nil {
+			t.Fatalf("expected nil QueryInstruction by default, got %v", *cfg.SemanticSearch.QueryInstruction)
+		}
+	})
+
+	t.Run("overrides", func(t *testing.T) {
+		cfg := loadConfigForTest(t, `plex:
+  host: http://plex
+semantic_search:
+  batch_size: 64
+  concurrency: 4
+  query_instruction: "Instruct: search\nQuery: "
+`)
+		if cfg.SemanticSearch.BatchSize != 64 {
+			t.Fatalf("expected batch size 64, got %d", cfg.SemanticSearch.BatchSize)
+		}
+		if cfg.SemanticSearch.Concurrency != 4 {
+			t.Fatalf("expected concurrency 4, got %d", cfg.SemanticSearch.Concurrency)
+		}
+		if cfg.SemanticSearch.QueryInstruction == nil || *cfg.SemanticSearch.QueryInstruction != "Instruct: search\nQuery: " {
+			t.Fatalf("unexpected query instruction: %v", cfg.SemanticSearch.QueryInstruction)
+		}
+	})
+}

--- a/ffmpeg.go
+++ b/ffmpeg.go
@@ -901,8 +901,12 @@ func ExtractSubtitleTracksBatchContext(ctx context.Context, mediaURL string, emb
 	const maxBatchSubtitleCues = 100000
 	for embeddedIndex, path := range paths {
 		info, statErr := os.Stat(path)
-		if statErr != nil || !info.Mode().IsRegular() || info.Size() == 0 || info.Size() > maxBatchSubtitleBytes {
+		if statErr != nil || !info.Mode().IsRegular() || info.Size() > maxBatchSubtitleBytes {
 			return nil, errors.New("batch subtitle output is invalid")
+		}
+		if info.Size() == 0 {
+			result[embeddedIndex] = nil
+			continue
 		}
 		entries, parseErr := ParseSRT(path)
 		if parseErr != nil || len(entries) > maxBatchSubtitleCues {
@@ -916,6 +920,10 @@ func ExtractSubtitleTracksBatchContext(ctx context.Context, mediaURL string, emb
 var subtitleBatchFFmpegCommand = func(ctx context.Context, args ...string) *exec.Cmd {
 	return exec.CommandContext(ctx, "ffmpeg", args...)
 }
+
+var extractSubtitleFullContextFn = ExtractSubtitleFullContext
+var extractSubtitleContextFn = ExtractSubtitleContext
+var doFfmpegFn = DoFfmpeg
 
 func subtitleOffsetArgument(offsets []int64) (int64, error) {
 	if len(offsets) > 1 {

--- a/ffmpeg_batch_test.go
+++ b/ffmpeg_batch_test.go
@@ -18,7 +18,11 @@ func TestSubtitleBatchHelperProcess(t *testing.T) {
 	args := os.Args
 	for i := 0; i+2 < len(args); i++ {
 		if args[i] == "-c:s" && args[i+1] == "srt" {
-			if err := os.WriteFile(args[i+2], []byte("1\n00:00:01,000 --> 00:00:02,000\nhello\n"), 0600); err != nil {
+			data := []byte("1\n00:00:01,000 --> 00:00:02,000\nhello\n")
+			if os.Getenv("CUTSCENE_BATCH_HELPER_EMPTY_FIRST") == "1" && strings.Contains(args[i+2], "track_000") {
+				data = []byte("")
+			}
+			if err := os.WriteFile(args[i+2], data, 0600); err != nil {
 				os.Exit(2)
 			}
 		}
@@ -84,3 +88,29 @@ func TestExtractSubtitleTracksBatchCleansOutputsOnCommandFailure(t *testing.T) {
 		t.Fatalf("failed batch output was not cleaned up: %v", err)
 	}
 }
+
+func TestExtractSubtitleTracksBatchAllowsZeroByteTrack(t *testing.T) {
+	original := subtitleBatchFFmpegCommand
+	t.Cleanup(func() { subtitleBatchFFmpegCommand = original })
+	subtitleBatchFFmpegCommand = func(ctx context.Context, args ...string) *exec.Cmd {
+		cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=TestSubtitleBatchHelperProcess", "--")
+		cmd.Env = append(os.Environ(), "CUTSCENE_BATCH_HELPER=1", "CUTSCENE_BATCH_HELPER_EMPTY_FIRST=1")
+		cmd.Args = append(cmd.Args, args...)
+		return cmd
+	}
+
+	entries, err := ExtractSubtitleTracksBatchContext(context.Background(), "http://127.0.0.1/media", []int{10, 20})
+	if err != nil {
+		t.Fatalf("batch extraction with 0-byte track failed: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("entries count = %d, want 2", len(entries))
+	}
+	if entries[10] != nil {
+		t.Fatalf("expected nil entries for 0-byte track 10, got: %+v", entries[10])
+	}
+	if len(entries[20]) != 1 {
+		t.Fatalf("expected 1 cue for track 20, got: %+v", entries[20])
+	}
+}
+

--- a/main.go
+++ b/main.go
@@ -38,6 +38,8 @@ type SemanticSearchConfig struct {
 	EmbeddingsURL      string `mapstructure:"embeddings_url"`
 	EmbeddingsProvider string `mapstructure:"embeddings_provider"`
 	EmbeddingsAPIKey   string `mapstructure:"embeddings_api_key"`
+	EmbeddingsModel    string `mapstructure:"embeddings_model"`
+	Dimensions         int    `mapstructure:"dimensions"`
 	Enabled            bool   `mapstructure:"enabled"`
 	SharedCorpus       bool   `mapstructure:"shared_corpus"`
 }
@@ -47,6 +49,7 @@ func loadConfig() (*Config, error) {
 	viper.SetConfigName("config")
 	viper.AddConfigPath(".")
 	viper.SetDefault("ffmpeg.concurrency", defaultFFmpegConcurrency)
+	viper.SetDefault("semantic_search.dimensions", 0)
 	if err := viper.ReadInConfig(); err != nil {
 		return nil, fmt.Errorf("reading config file: %w", err)
 	}

--- a/main.go
+++ b/main.go
@@ -34,14 +34,17 @@ type Config struct {
 }
 
 type SemanticSearchConfig struct {
-	PostgresDSN        string `mapstructure:"postgres_dsn"`
-	EmbeddingsURL      string `mapstructure:"embeddings_url"`
-	EmbeddingsProvider string `mapstructure:"embeddings_provider"`
-	EmbeddingsAPIKey   string `mapstructure:"embeddings_api_key"`
-	EmbeddingsModel    string `mapstructure:"embeddings_model"`
-	Dimensions         int    `mapstructure:"dimensions"`
-	Enabled            bool   `mapstructure:"enabled"`
-	SharedCorpus       bool   `mapstructure:"shared_corpus"`
+	PostgresDSN        string  `mapstructure:"postgres_dsn"`
+	EmbeddingsURL      string  `mapstructure:"embeddings_url"`
+	EmbeddingsProvider string  `mapstructure:"embeddings_provider"`
+	EmbeddingsAPIKey   string  `mapstructure:"embeddings_api_key"`
+	EmbeddingsModel    string  `mapstructure:"embeddings_model"`
+	Dimensions         int     `mapstructure:"dimensions"`
+	BatchSize          int     `mapstructure:"batch_size"`
+	Concurrency        int     `mapstructure:"concurrency"`
+	QueryInstruction   *string `mapstructure:"query_instruction"`
+	Enabled            bool    `mapstructure:"enabled"`
+	SharedCorpus       bool    `mapstructure:"shared_corpus"`
 }
 
 func loadConfig() (*Config, error) {
@@ -50,6 +53,8 @@ func loadConfig() (*Config, error) {
 	viper.AddConfigPath(".")
 	viper.SetDefault("ffmpeg.concurrency", defaultFFmpegConcurrency)
 	viper.SetDefault("semantic_search.dimensions", 0)
+	viper.SetDefault("semantic_search.batch_size", defaultSubtitleEmbeddingBatchSize)
+	viper.SetDefault("semantic_search.concurrency", defaultSubtitleEmbeddingConcurrency)
 	if err := viper.ReadInConfig(); err != nil {
 		return nil, fmt.Errorf("reading config file: %w", err)
 	}
@@ -58,6 +63,8 @@ func loadConfig() (*Config, error) {
 		return nil, fmt.Errorf("unmarshal config file: %w", err)
 	}
 	cfg.Ffmpeg.Concurrency = normalizeFFmpegConcurrency(cfg.Ffmpeg.Concurrency)
+	cfg.SemanticSearch.BatchSize = normalizeSubtitleEmbeddingBatchSize(cfg.SemanticSearch.BatchSize)
+	cfg.SemanticSearch.Concurrency = normalizeSubtitleEmbeddingConcurrency(cfg.SemanticSearch.Concurrency)
 	cfg.SemanticSearch.EmbeddingsProvider, err = normalizeEmbeddingsProvider(cfg.SemanticSearch.EmbeddingsProvider)
 	if err != nil {
 		return nil, fmt.Errorf("semantic_search.embeddings_provider: %w", err)

--- a/plex_resource.go
+++ b/plex_resource.go
@@ -686,7 +686,14 @@ func (r *PlexResourceResolver) doPlexRequestOnceWithClient(ctx context.Context, 
 	if requestErr != nil {
 		return nil, requestErr
 	}
-	return client.Do(refreshedRequest)
+	response, err = client.Do(refreshedRequest)
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
+		return nil, fmt.Errorf("%w: PMS request failed", errPlexAvailability)
+	}
+	return response, nil
 }
 
 func requestWithAccess(original *http.Request, access *PlexAccess) (*http.Request, error) {

--- a/plex_resource_test.go
+++ b/plex_resource_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -433,3 +434,86 @@ func TestPlexResolverCacheCapacityIsBounded(t *testing.T) {
 		t.Fatalf("cache size = %d, want %d", size, maxPlexAccessEntries)
 	}
 }
+
+func TestDoPlexRequestOnceWithClientRetryErrorHandling(t *testing.T) {
+	var server *httptest.Server
+	server = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/resources":
+			_ = json.NewEncoder(w).Encode([]PlexResource{{
+				ClientIdentifier: "machine",
+				Provides:         "server",
+				AccessToken:      "refreshed-token",
+				Connections: []PlexConnection{
+					{URI: server.URL, Protocol: "https"},
+				},
+			}})
+		case "/identity":
+			_, _ = w.Write([]byte(`{"MediaContainer":{"machineIdentifier":"machine"}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	resolver, err := NewPlexResourceResolver(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolver.client = server.Client()
+	resolver.resourcesURL = server.URL + "/resources"
+	if err := resolver.SetTrustedOrigins("machine", []string{server.URL}); err != nil {
+		t.Fatal(err)
+	}
+
+	access := &PlexAccess{
+		baseOrigin:        server.URL,
+		secretToken:       "old-token",
+		accountToken:      "account-secret",
+		callerUUID:        "caller",
+		machineIdentifier: "machine",
+	}
+
+	t.Run("retry network failure wraps errPlexAvailability", func(t *testing.T) {
+		var attempts atomic.Int32
+		client := &http.Client{
+			Transport: plexRoundTripFunc(func(r *http.Request) (*http.Response, error) {
+				if attempts.Add(1) == 1 {
+					return &http.Response{StatusCode: http.StatusUnauthorized, Body: http.NoBody, Header: make(http.Header), Request: r}, nil
+				}
+				return nil, errors.New("connection reset by peer")
+			}),
+		}
+		req, _ := newPlexRequest(context.Background(), access, http.MethodGet, "/library/metadata/1")
+		_, err := resolver.doPlexRequestOnceWithClient(context.Background(), access, req, client)
+		if err == nil {
+			t.Fatal("expected retry failure")
+		}
+		if !errors.Is(err, errPlexAvailability) {
+			t.Fatalf("expected errPlexAvailability wrapper, got: %v", err)
+		}
+	})
+
+	t.Run("retry context canceled returns context error", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		var attempts atomic.Int32
+		client := &http.Client{
+			Transport: plexRoundTripFunc(func(r *http.Request) (*http.Response, error) {
+				if attempts.Add(1) == 1 {
+					return &http.Response{StatusCode: http.StatusUnauthorized, Body: http.NoBody, Header: make(http.Header), Request: r}, nil
+				}
+				cancel()
+				return nil, ctx.Err()
+			}),
+		}
+		req, _ := newPlexRequest(ctx, access, http.MethodGet, "/library/metadata/1")
+		_, err := resolver.doPlexRequestOnceWithClient(ctx, access, req, client)
+		if err == nil {
+			t.Fatal("expected retry failure")
+		}
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context.Canceled, got: %v", err)
+		}
+	})
+}
+

--- a/plex_tv.go
+++ b/plex_tv.go
@@ -2,14 +2,21 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
+	"io"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/google/uuid"
 )
+
+var plexTVHTTPClient = &http.Client{
+	Timeout: 10 * time.Second,
+}
 
 type PlexTV struct {
 	token      string
@@ -57,17 +64,33 @@ func (u Users) HasUser(userId string, machineId string) bool {
 }
 
 func (p *PlexTV) getUsers() (*Users, error) {
-	url := fmt.Sprintf("https://plex.tv/api/users?X-Plex-Token=%s&X-Plex-Client-Identifier=%s", p.token, p.identifier)
+	return p.getUsersContext(context.Background())
+}
 
-	resp, err := http.Get(url)
+func (p *PlexTV) getUsersContext(ctx context.Context) (*Users, error) {
+	reqUrl := "https://plex.tv/api/users"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqUrl, nil)
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("X-Plex-Token", p.token)
+	if p.identifier != "" {
+		req.Header.Set("X-Plex-Client-Identifier", p.identifier)
+	}
 
+	resp, err := plexTVHTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, fmt.Errorf("plex.tv users returned status %d: %s", resp.StatusCode, string(body))
+	}
+
 	var users Users
-	if err := xml.NewDecoder(resp.Body).Decode(&users); err != nil {
+	if err := xml.NewDecoder(io.LimitReader(resp.Body, 8<<20)).Decode(&users); err != nil {
 		return nil, err
 	}
 
@@ -142,7 +165,11 @@ type GetUserResp struct {
 }
 
 func (p *PlexTV) getUser() (*User, error) {
-	req, err := http.NewRequest(http.MethodGet, "https://plex.tv/users/account.json", nil)
+	return p.getUserContext(context.Background())
+}
+
+func (p *PlexTV) getUserContext(ctx context.Context) (*User, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://plex.tv/users/account.json", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -151,15 +178,19 @@ func (p *PlexTV) getUser() (*User, error) {
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := plexTVHTTPClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
-
 	defer resp.Body.Close()
 
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, fmt.Errorf("plex.tv account returned status %d: %s", resp.StatusCode, string(body))
+	}
+
 	var userResp GetUserResp
-	if err := json.NewDecoder(resp.Body).Decode(&userResp); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&userResp); err != nil {
 		return nil, err
 	}
 

--- a/plex_tv_test.go
+++ b/plex_tv_test.go
@@ -1,0 +1,187 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestPlexTVGetUser(t *testing.T) {
+	origClient := plexTVHTTPClient
+	defer func() {
+		plexTVHTTPClient = origClient
+	}()
+
+	t.Run("successful numeric id", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/users/account.json" {
+				http.NotFound(w, r)
+				return
+			}
+			if r.Header.Get("X-Plex-Token") != "test-token" {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"user":{"id":12345,"uuid":"u-123","username":"plexuser","title":"Plex User","email":"user@example.com"}}`))
+		}))
+		defer server.Close()
+
+		plexTVHTTPClient = server.Client()
+		p := &PlexTV{token: "test-token", identifier: "client-id"}
+
+		// Test with mock URL by redirecting via roundtripper
+		plexTVHTTPClient.Transport = plexRoundTripFunc(func(r *http.Request) (*http.Response, error) {
+			r.URL.Scheme = "http"
+			r.URL.Host = server.Listener.Addr().String()
+			return http.DefaultTransport.RoundTrip(r)
+		})
+
+		user, err := p.getUserContext(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if user.Id != 12345 || user.Uuid != "u-123" || user.Username != "plexuser" {
+			t.Fatalf("unexpected user: %+v", user)
+		}
+	})
+
+	t.Run("successful quoted string id", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"user":{"id":"67890","uuid":"u-678","username":"plexuser2","title":"User 2","email":"user2@example.com"}}`))
+		}))
+		defer server.Close()
+
+		plexTVHTTPClient = server.Client()
+		plexTVHTTPClient.Transport = plexRoundTripFunc(func(r *http.Request) (*http.Response, error) {
+			r.URL.Scheme = "http"
+			r.URL.Host = server.Listener.Addr().String()
+			return http.DefaultTransport.RoundTrip(r)
+		})
+
+		p := &PlexTV{token: "test-token", identifier: "client-id"}
+		user, err := p.getUserContext(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if user.Id != 67890 {
+			t.Fatalf("id = %d, want 67890", user.Id)
+		}
+	})
+
+	t.Run("non-200 status returns descriptive error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "invalid token supplied", http.StatusUnauthorized)
+		}))
+		defer server.Close()
+
+		plexTVHTTPClient = server.Client()
+		plexTVHTTPClient.Transport = plexRoundTripFunc(func(r *http.Request) (*http.Response, error) {
+			r.URL.Scheme = "http"
+			r.URL.Host = server.Listener.Addr().String()
+			return http.DefaultTransport.RoundTrip(r)
+		})
+
+		p := &PlexTV{token: "bad-token", identifier: "client-id"}
+		_, err := p.getUserContext(context.Background())
+		if err == nil {
+			t.Fatal("expected error on 401")
+		}
+		if !strings.Contains(err.Error(), "status 401") || !strings.Contains(err.Error(), "invalid token") {
+			t.Fatalf("unexpected error message: %v", err)
+		}
+	})
+
+	t.Run("context cancellation aborts request", func(t *testing.T) {
+		p := &PlexTV{token: "token", identifier: "client-id"}
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		_, err := p.getUserContext(ctx)
+		if err == nil {
+			t.Fatal("expected error with canceled context")
+		}
+	})
+}
+
+func TestPlexTVGetUsers(t *testing.T) {
+	origClient := plexTVHTTPClient
+	defer func() {
+		plexTVHTTPClient = origClient
+	}()
+
+	t.Run("successful xml parse and hasUser check", func(t *testing.T) {
+		xmlBody := `<?xml version="1.0" encoding="UTF-8"?>
+<MediaContainer machineIdentifier="server-machine-id">
+  <User id="101" username="friend1" email="friend1@example.com">
+    <Server serverId="1" machineIdentifier="server-machine-id" name="MyServer" owned="1" pending="0"/>
+  </User>
+  <User id="102" username="friend2" email="friend2@example.com">
+    <Server serverId="2" machineIdentifier="other-machine-id" name="OtherServer" owned="0" pending="0"/>
+  </User>
+</MediaContainer>`
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/api/users" {
+				http.NotFound(w, r)
+				return
+			}
+			if r.Header.Get("X-Plex-Token") != "admin-tok" {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+			w.Header().Set("Content-Type", "application/xml")
+			_, _ = w.Write([]byte(xmlBody))
+		}))
+		defer server.Close()
+
+		plexTVHTTPClient = server.Client()
+		plexTVHTTPClient.Transport = plexRoundTripFunc(func(r *http.Request) (*http.Response, error) {
+			r.URL.Scheme = "http"
+			r.URL.Host = server.Listener.Addr().String()
+			return http.DefaultTransport.RoundTrip(r)
+		})
+
+		p := &PlexTV{token: "admin-tok", identifier: "my-app"}
+		users, err := p.getUsersContext(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(users.User) != 2 {
+			t.Fatalf("user count = %d, want 2", len(users.User))
+		}
+		if !users.HasUser("101", "server-machine-id") {
+			t.Fatal("expected user 101 to have access to server-machine-id")
+		}
+		if users.HasUser("102", "server-machine-id") {
+			t.Fatal("user 102 should NOT have access to server-machine-id")
+		}
+	})
+
+	t.Run("non-200 status returns descriptive error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "access denied", http.StatusForbidden)
+		}))
+		defer server.Close()
+
+		plexTVHTTPClient = server.Client()
+		plexTVHTTPClient.Transport = plexRoundTripFunc(func(r *http.Request) (*http.Response, error) {
+			r.URL.Scheme = "http"
+			r.URL.Host = server.Listener.Addr().String()
+			return http.DefaultTransport.RoundTrip(r)
+		})
+
+		p := &PlexTV{token: "token", identifier: "app"}
+		_, err := p.getUsersContext(context.Background())
+		if err == nil {
+			t.Fatal("expected error on 403")
+		}
+		if !strings.Contains(err.Error(), "status 403") {
+			t.Fatalf("unexpected error message: %v", err)
+		}
+	})
+}

--- a/render_jobs.go
+++ b/render_jobs.go
@@ -1703,7 +1703,7 @@ func (a *Application) executeRenderSpec(ctx context.Context, spec renderJobSpec,
 				var subtitleErr error
 				subtitleFile, subtitleErr = func() (string, error) {
 					defer releaseFFmpeg()
-					return ExtractSubtitleContext(ctx, subtitleURL, from, to, embeddedIndex, spec.SubtitleOffsetMs)
+					return extractSubtitleContextFn(ctx, subtitleURL, from, to, embeddedIndex, spec.SubtitleOffsetMs)
 				}()
 				if subtitleErr != nil {
 					if errors.Is(subtitleErr, ErrNoUsableSubtitleCues) {
@@ -1720,10 +1720,14 @@ func (a *Application) executeRenderSpec(ctx context.Context, spec renderJobSpec,
 			}
 			subtitleFile, err = func() (string, error) {
 				defer release()
-				return ExtractSubtitleContext(ctx, sourceURL, from, to, embeddedIndex, spec.SubtitleOffsetMs)
+				return extractSubtitleContextFn(ctx, sourceURL, from, to, embeddedIndex, spec.SubtitleOffsetMs)
 			}()
 			if err != nil {
-				return classifyRenderStageError("subtitle", err)
+				if errors.Is(err, ErrNoUsableSubtitleCues) {
+					subtitleFile = ""
+				} else {
+					return classifyRenderStageError("subtitle", err)
+				}
 			}
 		}
 	subtitleReady:
@@ -1746,7 +1750,7 @@ func (a *Application) executeRenderSpec(ctx context.Context, spec renderJobSpec,
 	if err != nil {
 		return classifyRenderStageError("encoder", err)
 	}
-	_, err = DoFfmpeg(params)
+	_, err = doFfmpegFn(params)
 	release()
 	if err != nil {
 		return classifyRenderError(err)

--- a/subtitle_empty_test.go
+++ b/subtitle_empty_test.go
@@ -1,0 +1,195 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/LukeHagar/plexgo"
+)
+
+func TestValidateSubtitleFileForBurn(t *testing.T) {
+	tempDir := t.TempDir()
+
+	t.Run("zero-byte file returns ErrNoUsableSubtitleCues", func(t *testing.T) {
+		emptyFile := filepath.Join(tempDir, "empty.srt")
+		if err := os.WriteFile(emptyFile, []byte(""), 0600); err != nil {
+			t.Fatal(err)
+		}
+		err := validateSubtitleFileForBurn(emptyFile)
+		if !errors.Is(err, ErrNoUsableSubtitleCues) {
+			t.Fatalf("expected ErrNoUsableSubtitleCues, got: %v", err)
+		}
+	})
+
+	t.Run("cue with empty or whitespace text returns ErrNoUsableSubtitleCues", func(t *testing.T) {
+		blankFile := filepath.Join(tempDir, "blank.srt")
+		content := "1\n00:00:01,000 --> 00:00:02,000\n   \n\n"
+		if err := os.WriteFile(blankFile, []byte(content), 0600); err != nil {
+			t.Fatal(err)
+		}
+		err := validateSubtitleFileForBurn(blankFile)
+		if !errors.Is(err, ErrNoUsableSubtitleCues) {
+			t.Fatalf("expected ErrNoUsableSubtitleCues, got: %v", err)
+		}
+	})
+
+	t.Run("valid cues pass validation", func(t *testing.T) {
+		validFile := filepath.Join(tempDir, "valid.srt")
+		content := "1\n00:00:01,000 --> 00:00:02,000\nHello World\n\n"
+		if err := os.WriteFile(validFile, []byte(content), 0600); err != nil {
+			t.Fatal(err)
+		}
+		if err := validateSubtitleFileForBurn(validFile); err != nil {
+			t.Fatalf("expected nil error, got: %v", err)
+		}
+	})
+}
+
+func TestExecuteRenderSpecNonScopedEmbeddedEmptySubtitle(t *testing.T) {
+	origExtract := extractSubtitleContextFn
+	origDoFfmpeg := doFfmpegFn
+	t.Cleanup(func() {
+		extractSubtitleContextFn = origExtract
+		doFfmpegFn = origDoFfmpeg
+	})
+
+	app := &Application{}
+	app.config.Plex.Host = "http://127.0.0.1:32400"
+	app.config.Plex.Token = "token"
+
+	spec := renderJobSpec{
+		RatingKey:             "movie-1",
+		PartKey:               "/library/parts/1/file.mp4",
+		FromMs:                0,
+		ToMs:                  5000,
+		SubtitleIndex:         1,
+		SubtitleEmbeddedIndex: 0,
+		SubtitleExternal:      false,
+		SubtitlePGS:           false,
+	}
+
+	t.Run("empty subtitle succeeds with cleared subtitleFile", func(t *testing.T) {
+		extractSubtitleContextFn = func(ctx context.Context, url, from, to string, subtitleIndex int, subtitleOffsets ...int64) (string, error) {
+			return "", ErrNoUsableSubtitleCues
+		}
+
+		var capturedParams FfmpegParams
+		doFfmpegFn = func(params FfmpegParams) (string, error) {
+			capturedParams = params
+			return "/out/job.mp4", nil
+		}
+
+		err := app.executeRenderSpec(context.Background(), spec, "/out/job.mp4")
+		if err != nil {
+			t.Fatalf("executeRenderSpec failed: %v", err)
+		}
+		if capturedParams.SubtitleFile != "" {
+			t.Fatalf("expected empty SubtitleFile, got: %q", capturedParams.SubtitleFile)
+		}
+	})
+
+	t.Run("other subtitle error fails with subtitle stage failure", func(t *testing.T) {
+		extractSubtitleContextFn = func(ctx context.Context, url, from, to string, subtitleIndex int, subtitleOffsets ...int64) (string, error) {
+			return "", errors.New("ffmpeg extraction failed")
+		}
+
+		err := app.executeRenderSpec(context.Background(), spec, "/out/job.mp4")
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		var failure *renderFailure
+		if !errors.As(err, &failure) || failure.stage != "subtitle" || failure.code != "subtitle_unavailable" {
+			t.Fatalf("expected subtitle_unavailable stage failure, got: %v", err)
+		}
+	})
+}
+
+func TestGetSubtitleEntriesForSourceEmptySubtitle(t *testing.T) {
+	origExtract := extractSubtitleFullContextFn
+	t.Cleanup(func() {
+		extractSubtitleFullContextFn = origExtract
+	})
+
+	metadataJSON := `{
+		"MediaContainer": {
+			"Metadata": [{
+				"ratingKey": "movie-1",
+				"type": "movie",
+				"title": "Test Movie",
+				"Media": [{
+					"id": 10,
+					"Part": [{
+						"id": 20,
+						"key": "/library/parts/20/file.mp4",
+						"Stream": [{
+							"id": 30,
+							"streamType": 3,
+							"codec": "srt",
+							"index": 2
+						}]
+					}]
+				}]
+			}]
+		}
+	}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/library/metadata/movie-1":
+			_, _ = io.WriteString(w, metadataJSON)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	cfg := Config{}
+	cfg.Plex.Host = server.URL
+	cfg.Plex.Token = "admin-token"
+
+	app := &Application{
+		config:        cfg,
+		plexAdmin:     plexgo.New(plexgo.WithServerURL(server.URL), plexgo.WithSecurity("admin-token")),
+		subtitleCache: newSubtitleCache(100),
+	}
+
+	var extractionCount atomic.Int32
+	extractSubtitleFullContextFn = func(ctx context.Context, url string, subtitleIndex int) (string, error) {
+		extractionCount.Add(1)
+		return "", ErrNoUsableSubtitleCues
+	}
+
+	ctx := context.Background()
+
+	// First call should return empty slice and nil error
+	entries, err := app.GetSubtitleEntriesForSource(ctx, "movie-1", "10", "20", 0)
+	if err != nil {
+		t.Fatalf("unexpected error for empty subtitle: %v", err)
+	}
+	if entries == nil || len(entries) != 0 {
+		t.Fatalf("expected empty slice, got: %+v", entries)
+	}
+	if extractionCount.Load() != 1 {
+		t.Fatalf("expected 1 extraction attempt, got: %d", extractionCount.Load())
+	}
+
+	// Second call should return from cache without re-extracting
+	cachedEntries, err := app.GetSubtitleEntriesForSource(ctx, "movie-1", "10", "20", 0)
+	if err != nil {
+		t.Fatalf("unexpected error from cached empty subtitle: %v", err)
+	}
+	if cachedEntries == nil || len(cachedEntries) != 0 {
+		t.Fatalf("expected empty slice from cache, got: %+v", cachedEntries)
+	}
+	if extractionCount.Load() != 1 {
+		t.Fatalf("expected cache hit (count remaining 1), got: %d", extractionCount.Load())
+	}
+}

--- a/subtitle_indexing_test.go
+++ b/subtitle_indexing_test.go
@@ -237,12 +237,12 @@ func TestStreamIndexLibrarySectionSourcesPaginationCycleTermination(t *testing.T
 	}
 	ctx := ContextWithPlexAccess(context.Background(), access)
 
-	// Stream should detect cycle on second page and terminate cleanly (not loop indefinitely)
+	// Stream should detect cycle on second page and return errPaginationIncomplete
 	err = app.streamIndexLibrarySectionSources(ctx, "user-token", "1", "movie", func(items []components.Metadata) error {
 		return nil
 	})
-	if err != nil {
-		t.Fatalf("expected nil error on cycle termination, got: %v", err)
+	if !errors.Is(err, errPaginationIncomplete) {
+		t.Fatalf("expected errPaginationIncomplete on cycle termination, got: %v", err)
 	}
 	if requestCount.Load() > 5 {
 		t.Fatalf("expected pagination to terminate quickly on cycle, but made %d requests", requestCount.Load())
@@ -340,12 +340,12 @@ func TestStreamIndexLibrarySectionSourcesStopPagination(t *testing.T) {
 	}
 	ctx := ContextWithPlexAccess(context.Background(), access)
 
-	// Returning errStopPagination should stop pagination and return nil
+	// Returning errStopPagination before totalSize is reached should return errPaginationIncomplete
 	err = app.streamIndexLibrarySectionSources(ctx, "user-token", "1", "movie", func(items []components.Metadata) error {
 		return errStopPagination
 	})
-	if err != nil {
-		t.Fatalf("expected nil error on errStopPagination, got: %v", err)
+	if !errors.Is(err, errPaginationIncomplete) {
+		t.Fatalf("expected errPaginationIncomplete on errStopPagination, got: %v", err)
 	}
 	if requestCount.Load() != 1 {
 		t.Fatalf("expected exactly 1 request before stop, got %d", requestCount.Load())
@@ -402,6 +402,71 @@ func TestCallerSectionSourceSetPaginationCycle(t *testing.T) {
 		t.Fatalf("expected %d sources, got %d", indexLibraryPageSize, len(sources))
 	}
 	_ = itemsSeen
+}
+
+func TestDiscoverAndIndexSourcesSkipsPruningOnPaginationCycle(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/identity" {
+			_, _ = w.Write([]byte(`{"MediaContainer":{"machineIdentifier":"pms-discover-cycle"}}`))
+			return
+		}
+		if r.URL.Path == "/library/sections" {
+			_, _ = w.Write([]byte(`{"MediaContainer":{"Directory":[{"key":"1","type":"movie","title":"Movies","uuid":"sec-1"}]}}`))
+			return
+		}
+		// Returns same page of items to trigger a pagination cycle
+		var items []string
+		for i := 0; i < indexLibraryPageSize; i++ {
+			items = append(items, fmt.Sprintf(`{"ratingKey":"%d","type":"movie","title":"Movie %d","duration":60000,"Media":[{"id":%d,"duration":60000,"Part":[{"id":%d,"duration":60000,"key":"/video.mp4"}]}]}`, i, i, i+10, i+20))
+		}
+		_, _ = w.Write([]byte(fmt.Sprintf(`{"MediaContainer":{"size":%d,"offset":0,"Metadata":[%s]}}`, indexLibraryPageSize, strings.Join(items, ","))))
+	}))
+	defer server.Close()
+
+	resolver, err := NewPlexResourceResolver(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resolver.SetTrustedOrigins("pms-discover-cycle", []string{server.URL})
+
+	app := &Application{
+		plexResources:     resolver,
+		machineIdentifier: "pms-discover-cycle",
+	}
+	app.config.Plex.Host = server.URL
+	app.config.Plex.Token = "server-token"
+
+	token := "user-token"
+	ctx := ContextWithAuthToken(context.Background(), token)
+	job := &subtitleIndexJob{
+		owner: "owner-1",
+	}
+
+	var indexedCount atomic.Int32
+	err = app.discoverAndIndexSources(ctx, job, func(work subtitleIndexWork) error {
+		indexedCount.Add(1)
+		return nil
+	})
+
+	// Must return errPaginationIncomplete and not nil
+	if !errors.Is(err, errPaginationIncomplete) {
+		t.Fatalf("expected errPaginationIncomplete, got: %v", err)
+	}
+	if indexedCount.Load() == 0 {
+		t.Fatal("expected items before cycle to be indexed")
+	}
+}
+
+func TestRecoverPersistedJobsRequiresMachineIdentifierForShared(t *testing.T) {
+	app := &Application{
+		sharedCorpus:      true,
+		machineIdentifier: "", // uninitialized machineIdentifier
+	}
+	mgr := newSubtitleIndexJobManager(app)
+	if err := mgr.recoverPersistedJobs(); err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
 }
 
 

--- a/subtitle_indexing_test.go
+++ b/subtitle_indexing_test.go
@@ -1,0 +1,408 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/LukeHagar/plexgo/models/components"
+	"github.com/jackc/pgx/v5"
+)
+
+func TestBuildPlexSourceURLValidation(t *testing.T) {
+	app := &Application{}
+	app.config.Plex.Host = "http://127.0.0.1:32400"
+	app.config.Plex.Token = "test-token"
+
+	t.Run("valid relative path", func(t *testing.T) {
+		got, err := app.buildPlexSourceURL("/library/parts/123/file.mp4", "tok-123")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.HasPrefix(got, "http://127.0.0.1:32400/library/parts/123/file.mp4?") || !strings.Contains(got, "X-Plex-Token=tok-123") {
+			t.Fatalf("unexpected url: %s", got)
+		}
+	})
+
+	invalidPaths := []struct {
+		name string
+		path string
+	}{
+		{"empty", ""},
+		{"whitespace", "   "},
+		{"scheme-relative", "//evil.com/file.mp4"},
+		{"userinfo", "http://user:pass@127.0.0.1:32400/file.mp4"},
+		{"external origin", "http://evil.com/file.mp4"},
+		{"relative without slash", "library/parts/123/file.mp4"},
+	}
+
+	for _, tc := range invalidPaths {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := app.buildPlexSourceURL(tc.path, "tok")
+			if err == nil {
+				t.Fatalf("path %q was unexpectedly accepted", tc.path)
+			}
+		})
+	}
+}
+
+func TestSubtitleIndexJobManagerErrNoRowsCompatibility(t *testing.T) {
+	// Verify that checking pgx.ErrNoRows and sql.ErrNoRows matches pgx.ErrNoRows
+	pgxErr := pgx.ErrNoRows
+	if !(errors.Is(pgxErr, pgx.ErrNoRows) || errors.Is(pgxErr, sql.ErrNoRows)) {
+		t.Fatal("expected pgx.ErrNoRows to match")
+	}
+	sqlErr := sql.ErrNoRows
+	if !(errors.Is(sqlErr, pgx.ErrNoRows) || errors.Is(sqlErr, sql.ErrNoRows)) {
+		t.Fatal("expected sql.ErrNoRows to match")
+	}
+}
+
+func TestDiscoverAndIndexSourcesCancelsOnWorkerFatalError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/identity":
+			_, _ = w.Write([]byte(`{"MediaContainer":{"machineIdentifier":"pms-1"}}`))
+		case "/library/sections":
+			_, _ = w.Write([]byte(`{"MediaContainer":{"Directory":[{"key":"1","type":"movie","uuid":"sec-1"}]}}`))
+		case "/library/sections/1/all":
+			// Return a large batch of items
+			_, _ = w.Write([]byte(`{"MediaContainer":{"size":5,"Metadata":[
+				{"ratingKey":"1","type":"movie","title":"Movie 1","duration":60000,"Media":[{"id":10,"duration":60000,"Part":[{"id":20,"duration":60000,"key":"/library/parts/20/file.mp4"}]}]},
+				{"ratingKey":"2","type":"movie","title":"Movie 2","duration":60000,"Media":[{"id":11,"duration":60000,"Part":[{"id":21,"duration":60000,"key":"/library/parts/21/file.mp4"}]}]},
+				{"ratingKey":"3","type":"movie","title":"Movie 3","duration":60000,"Media":[{"id":12,"duration":60000,"Part":[{"id":22,"duration":60000,"key":"/library/parts/22/file.mp4"}]}]},
+				{"ratingKey":"4","type":"movie","title":"Movie 4","duration":60000,"Media":[{"id":13,"duration":60000,"Part":[{"id":23,"duration":60000,"key":"/library/parts/23/file.mp4"}]}]},
+				{"ratingKey":"5","type":"movie","title":"Movie 5","duration":60000,"Media":[{"id":14,"duration":60000,"Part":[{"id":24,"duration":60000,"key":"/library/parts/24/file.mp4"}]}]}
+			]}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	resolver, err := NewPlexResourceResolver(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resolver.SetTrustedOrigins("pms-1", []string{server.URL})
+
+	app := &Application{
+		plexResources:     resolver,
+		machineIdentifier: "pms-1",
+	}
+	app.config.Plex.Host = server.URL
+	app.config.Plex.Token = "server-token"
+
+	now := time.Now().UTC()
+	job := &subtitleIndexJob{
+		id:        "job-test",
+		owner:     "owner-test",
+		state:     "running",
+		startedAt: now,
+		updatedAt: now,
+	}
+
+	ctx := ContextWithUser(ContextWithAuthToken(context.Background(), "user-token"), User{Uuid: "owner-test"})
+	access := &PlexAccess{
+		baseOrigin:        server.URL,
+		secretToken:       "user-token",
+		accountToken:      "user-token",
+		callerUUID:        "owner-test",
+		machineIdentifier: "pms-1",
+	}
+	ctx = ContextWithPlexAccess(ctx, access)
+	fatalErr := errors.New("database connection terminated")
+
+	var processedCount atomic.Int32
+	err = app.discoverAndIndexSources(ctx, job, func(work subtitleIndexWork) error {
+		count := processedCount.Add(1)
+		if count == 1 {
+			// First item encounters fatal worker error
+			return fatalErr
+		}
+		// Subsequent items should not run indefinitely
+		time.Sleep(10 * time.Millisecond)
+		return nil
+	})
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, fatalErr) && !strings.Contains(err.Error(), "database connection terminated") {
+		t.Fatalf("expected fatalErr, got: %v", err)
+	}
+}
+
+func TestBulkEmbeddingsSemaphoreReleaseBeforeWrites(t *testing.T) {
+	store := &subtitleSearchStore{
+		bulkEmbeddings: make(chan struct{}, 1),
+		bulkWrites:     make(chan struct{}, 1),
+	}
+
+	app := &Application{
+		subtitleSearch: store,
+	}
+
+	// Verify that with withBulkSubtitleContext, acquire and release helper functions work properly
+	ctx := withBulkSubtitleContext(context.Background())
+	if !isBulkSubtitleContext(ctx) {
+		t.Fatal("expected bulk subtitle context to be true")
+	}
+
+	if err := acquireSubtitleSemaphore(ctx, app.subtitleSearch.bulkEmbeddings); err != nil {
+		t.Fatal(err)
+	}
+	// Verify semaphore is acquired (channel has 1 element)
+	if len(app.subtitleSearch.bulkEmbeddings) != 1 {
+		t.Fatalf("expected bulkEmbeddings len 1, got %d", len(app.subtitleSearch.bulkEmbeddings))
+	}
+
+	releaseSubtitleSemaphore(app.subtitleSearch.bulkEmbeddings)
+	if len(app.subtitleSearch.bulkEmbeddings) != 0 {
+		t.Fatalf("expected bulkEmbeddings len 0, got %d", len(app.subtitleSearch.bulkEmbeddings))
+	}
+}
+
+func TestRecoverPersistedJobsSafeWhenNilOrDisabled(t *testing.T) {
+	app := &Application{}
+	manager := newSubtitleIndexJobManager(app)
+	if err := manager.recoverPersistedJobs(); err != nil {
+		t.Fatalf("expected nil error when subtitleSearch is nil, got: %v", err)
+	}
+}
+
+func TestBatchChunkQueuing(t *testing.T) {
+	chunks := []subtitleChunk{
+		{Start: 1000, End: 2000, Text: "Line 1"},
+		{Start: 2500, End: 4000, Text: "Line 2"},
+		{Start: 5000, End: 7000, Text: "Line 3"},
+	}
+
+	batch := &pgx.Batch{}
+	for _, chunk := range chunks {
+		batch.Queue("INSERT INTO subtitle_chunks ...", chunk.Start, chunk.End, chunk.Text)
+	}
+
+	if batch.Len() != 3 {
+		t.Fatalf("batch len = %d, want 3", batch.Len())
+	}
+}
+
+func TestStreamIndexLibrarySectionSourcesPaginationCycleTermination(t *testing.T) {
+	var requestCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/identity" {
+			_, _ = w.Write([]byte(`{"MediaContainer":{"machineIdentifier":"pms-cycle"}}`))
+			return
+		}
+		// Every request returns the exact same full page of 100 items (a cycle)
+		count := requestCount.Add(1)
+		var items []string
+		for i := 0; i < indexLibraryPageSize; i++ {
+			items = append(items, fmt.Sprintf(`{"ratingKey":"%d","type":"movie","title":"Movie %d"}`, i, i))
+		}
+		_, _ = w.Write([]byte(fmt.Sprintf(`{"MediaContainer":{"size":%d,"offset":0,"Metadata":[%s]}}`, indexLibraryPageSize, strings.Join(items, ","))))
+		_ = count
+	}))
+	defer server.Close()
+
+	resolver, err := NewPlexResourceResolver(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resolver.SetTrustedOrigins("pms-cycle", []string{server.URL})
+
+	app := &Application{
+		plexResources:     resolver,
+		machineIdentifier: "pms-cycle",
+	}
+	app.config.Plex.Host = server.URL
+	app.config.Plex.Token = "server-token"
+
+	access := &PlexAccess{
+		baseOrigin:        server.URL,
+		secretToken:       "user-token",
+		accountToken:      "user-token",
+		callerUUID:        "owner-test",
+		machineIdentifier: "pms-cycle",
+	}
+	ctx := ContextWithPlexAccess(context.Background(), access)
+
+	// Stream should detect cycle on second page and terminate cleanly (not loop indefinitely)
+	err = app.streamIndexLibrarySectionSources(ctx, "user-token", "1", "movie", func(items []components.Metadata) error {
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("expected nil error on cycle termination, got: %v", err)
+	}
+	if requestCount.Load() > 5 {
+		t.Fatalf("expected pagination to terminate quickly on cycle, but made %d requests", requestCount.Load())
+	}
+}
+
+func TestStreamIndexLibrarySectionSourcesTotalSizeTermination(t *testing.T) {
+	var requestCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/identity" {
+			_, _ = w.Write([]byte(`{"MediaContainer":{"machineIdentifier":"pms-totalsize"}}`))
+			return
+		}
+		requestCount.Add(1)
+		// Returns exactly indexLibraryPageSize items with totalSize = indexLibraryPageSize
+		var items []string
+		for i := 0; i < indexLibraryPageSize; i++ {
+			items = append(items, fmt.Sprintf(`{"ratingKey":"%d","type":"movie","title":"Movie %d"}`, i, i))
+		}
+		_, _ = w.Write([]byte(fmt.Sprintf(`{"MediaContainer":{"size":%d,"totalSize":%d,"offset":0,"Metadata":[%s]}}`, indexLibraryPageSize, indexLibraryPageSize, strings.Join(items, ","))))
+	}))
+	defer server.Close()
+
+	resolver, err := NewPlexResourceResolver(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resolver.SetTrustedOrigins("pms-totalsize", []string{server.URL})
+
+	app := &Application{
+		plexResources:     resolver,
+		machineIdentifier: "pms-totalsize",
+	}
+	app.config.Plex.Host = server.URL
+	app.config.Plex.Token = "server-token"
+
+	access := &PlexAccess{
+		baseOrigin:        server.URL,
+		secretToken:       "user-token",
+		accountToken:      "user-token",
+		callerUUID:        "owner-test",
+		machineIdentifier: "pms-totalsize",
+	}
+	ctx := ContextWithPlexAccess(context.Background(), access)
+
+	err = app.streamIndexLibrarySectionSources(ctx, "user-token", "1", "movie", func(items []components.Metadata) error {
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+	// Should terminate after page 1 because start + len(items) >= totalSize
+	if requestCount.Load() != 1 {
+		t.Fatalf("expected 1 request, got %d", requestCount.Load())
+	}
+}
+
+func TestStreamIndexLibrarySectionSourcesStopPagination(t *testing.T) {
+	var requestCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/identity" {
+			_, _ = w.Write([]byte(`{"MediaContainer":{"machineIdentifier":"pms-stop"}}`))
+			return
+		}
+		requestCount.Add(1)
+		var items []string
+		for i := 0; i < indexLibraryPageSize; i++ {
+			items = append(items, fmt.Sprintf(`{"ratingKey":"%d","type":"movie","title":"Movie %d"}`, i, i))
+		}
+		_, _ = w.Write([]byte(fmt.Sprintf(`{"MediaContainer":{"size":%d,"offset":0,"Metadata":[%s]}}`, indexLibraryPageSize, strings.Join(items, ","))))
+	}))
+	defer server.Close()
+
+	resolver, err := NewPlexResourceResolver(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resolver.SetTrustedOrigins("pms-stop", []string{server.URL})
+
+	app := &Application{
+		plexResources:     resolver,
+		machineIdentifier: "pms-stop",
+	}
+	app.config.Plex.Host = server.URL
+	app.config.Plex.Token = "server-token"
+
+	access := &PlexAccess{
+		baseOrigin:        server.URL,
+		secretToken:       "user-token",
+		accountToken:      "user-token",
+		callerUUID:        "owner-test",
+		machineIdentifier: "pms-stop",
+	}
+	ctx := ContextWithPlexAccess(context.Background(), access)
+
+	// Returning errStopPagination should stop pagination and return nil
+	err = app.streamIndexLibrarySectionSources(ctx, "user-token", "1", "movie", func(items []components.Metadata) error {
+		return errStopPagination
+	})
+	if err != nil {
+		t.Fatalf("expected nil error on errStopPagination, got: %v", err)
+	}
+	if requestCount.Load() != 1 {
+		t.Fatalf("expected exactly 1 request before stop, got %d", requestCount.Load())
+	}
+}
+
+func TestCallerSectionSourceSetPaginationCycle(t *testing.T) {
+	var requestCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/identity" {
+			_, _ = w.Write([]byte(`{"MediaContainer":{"machineIdentifier":"pms-auth-cycle"}}`))
+			return
+		}
+		requestCount.Add(1)
+		var items []string
+		for i := 0; i < indexLibraryPageSize; i++ {
+			items = append(items, fmt.Sprintf(`{"ratingKey":"%d","type":"movie","title":"Movie %d","Media":[{"id":%d,"duration":1000,"Part":[{"id":%d,"key":"/library/parts/%d"}]}]}`, i, i, i+100, i+200, i+200))
+		}
+		_, _ = w.Write([]byte(fmt.Sprintf(`{"MediaContainer":{"size":%d,"offset":0,"Metadata":[%s]}}`, indexLibraryPageSize, strings.Join(items, ","))))
+	}))
+	defer server.Close()
+
+	resolver, err := NewPlexResourceResolver(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resolver.SetTrustedOrigins("pms-auth-cycle", []string{server.URL})
+
+	app := &Application{
+		plexResources:     resolver,
+		machineIdentifier: "pms-auth-cycle",
+	}
+	app.config.Plex.Host = server.URL
+	app.config.Plex.Token = "server-token"
+
+	access := &PlexAccess{
+		baseOrigin:        server.URL,
+		secretToken:       "user-token",
+		accountToken:      "user-token",
+		callerUUID:        "owner-test",
+		machineIdentifier: "pms-auth-cycle",
+	}
+	ctx := ContextWithPlexAccess(context.Background(), access)
+
+	sources, pages, itemsSeen, err := app.callerSectionSourceSet(ctx, resolver, "1", "movie")
+	if err != nil {
+		t.Fatalf("expected nil error on cycle termination, got: %v", err)
+	}
+	if pages > 5 {
+		t.Fatalf("expected pagination to terminate quickly on cycle, but did %d pages", pages)
+	}
+	if len(sources) != indexLibraryPageSize {
+		t.Fatalf("expected %d sources, got %d", indexLibraryPageSize, len(sources))
+	}
+	_ = itemsSeen
+}
+
+
+

--- a/subtitle_search.go
+++ b/subtitle_search.go
@@ -35,7 +35,13 @@ const (
 	subtitleEmbeddingDimensions            = defaultSubtitleEmbeddingDimensions
 	minSubtitleEmbeddingDimensions         = 1
 	maxSubtitleEmbeddingDimensions         = 2000
-	subtitleEmbeddingBatchSize             = 32
+	defaultSubtitleEmbeddingBatchSize      = 32
+	minSubtitleEmbeddingBatchSize          = 1
+	maxSubtitleEmbeddingBatchSize          = 512
+	defaultSubtitleEmbeddingConcurrency    = 2
+	minSubtitleEmbeddingConcurrency        = 1
+	maxSubtitleEmbeddingConcurrency        = 32
+	subtitleEmbeddingBatchSize             = defaultSubtitleEmbeddingBatchSize
 	maxSharedSubtitleCandidates            = 200
 	maxSharedSubtitleSourceChecks          = 100
 	maxSharedSubtitleAuthorizedHits        = 50
@@ -47,8 +53,10 @@ const (
 	maxSubtitleSemanticCandidates          = 200
 	// Keep result windows focused enough to open directly as short clips.
 	// Subtitle timing still determines the exact duration.
-	subtitleChunkMaxRunes = 400
-	bgeQueryInstruction   = "Represent this sentence for searching relevant passages: "
+	subtitleChunkMaxRunes      = 400
+	subtitleChunkMaxGapMs      int64 = 15 * 1000
+	subtitleChunkMaxDurationMs int64 = 60 * 1000
+	bgeQueryInstruction        = "Represent this sentence for searching relevant passages: "
 )
 
 var errSubtitleSearchDisabled = errors.New("semantic subtitle search is disabled")
@@ -98,13 +106,16 @@ func releaseSubtitleSemaphore(semaphore chan struct{}) {
 // constructed when semantic_search.enabled is false, so existing deployments
 // do not need PostgreSQL or TEI.
 type subtitleSearchStore struct {
-	pool           *pgxpool.Pool
-	embeddings     *teiClient
-	dimensions     int
-	bulkEmbeddings chan struct{}
-	bulkWrites     chan struct{}
-	trackLocks     keyedSubtitleLocks
-	jobMu          sync.Mutex
+	pool             *pgxpool.Pool
+	embeddings       *teiClient
+	dimensions       int
+	batchSize        int
+	concurrency      int
+	queryInstruction string
+	bulkEmbeddings   chan struct{}
+	bulkWrites       chan struct{}
+	trackLocks       keyedSubtitleLocks
+	jobMu            sync.Mutex
 }
 
 type keyedSubtitleLocks struct {
@@ -324,7 +335,7 @@ func migrateSubtitleEmbeddingDimensions(ctx context.Context, pool *pgxpool.Pool,
 	return nil
 }
 
-const subtitleSearchIndexVersion = "subtitle-index-v4-chunk-400-cast-clean-text"
+const subtitleSearchIndexVersion = "subtitle-index-v5-chunk-400-gap-15s-cast-clean-text"
 
 func newSubtitleSearchStore(ctx context.Context, cfg SemanticSearchConfig) (*subtitleSearchStore, error) {
 	provider, err := normalizeEmbeddingsProvider(cfg.EmbeddingsProvider)
@@ -416,12 +427,19 @@ func newSubtitleSearchStore(ctx context.Context, cfg SemanticSearchConfig) (*sub
 		pool.Close()
 		return nil, errors.New("could not connect to semantic search database")
 	}
+	batchSize := normalizeSubtitleEmbeddingBatchSize(cfg.BatchSize)
+	concurrency := normalizeSubtitleEmbeddingConcurrency(cfg.Concurrency)
+	queryInstruction := resolveQueryInstruction(cfg, dimensions)
+
 	return &subtitleSearchStore{
-		pool:           pool,
-		embeddings:     embeddings,
-		dimensions:     dimensions,
-		bulkEmbeddings: make(chan struct{}, 1),
-		bulkWrites:     make(chan struct{}, 1),
+		pool:             pool,
+		embeddings:       embeddings,
+		dimensions:       dimensions,
+		batchSize:        batchSize,
+		concurrency:      concurrency,
+		queryInstruction: queryInstruction,
+		bulkEmbeddings:   make(chan struct{}, concurrency),
+		bulkWrites:       make(chan struct{}, 1),
 	}, nil
 }
 
@@ -485,17 +503,29 @@ func chunkSubtitleEntries(entries []SubtitleEntry) []subtitleChunk {
 			continue
 		}
 		entryRunes := utf8.RuneCountInString(text)
-		if currentRunes > 0 && currentRunes+1+entryRunes > subtitleChunkMaxRunes {
-			flush()
+		if currentRunes > 0 {
+			isRuneLimit := currentRunes+1+entryRunes > subtitleChunkMaxRunes
+			isGapLimit := entry.Start > current.End && (entry.Start-current.End) > subtitleChunkMaxGapMs
+			candidateEnd := current.End
+			if entry.End > candidateEnd {
+				candidateEnd = entry.End
+			}
+			isDurationLimit := (candidateEnd - current.Start) > subtitleChunkMaxDurationMs
+			isOutOfOrder := entry.Start < current.Start
+			if isRuneLimit || isGapLimit || isDurationLimit || isOutOfOrder {
+				flush()
+			}
 		}
 		if currentRunes == 0 {
 			current.Start = entry.Start
+			current.End = entry.End
+		} else if entry.End > current.End {
+			current.End = entry.End
 		}
 		if current.Text != "" {
 			current.Text += "\n"
 		}
 		current.Text += text
-		current.End = entry.End
 		currentRunes += entryRunes + 1
 		// A single pathological cue is split without inventing timestamps.
 		for utf8.RuneCountInString(current.Text) > subtitleChunkMaxRunes {
@@ -538,6 +568,53 @@ func normalizeEmbeddingsProvider(value string) (string, error) {
 	default:
 		return "", fmt.Errorf("unsupported embeddings provider %q (want tei or openai)", provider)
 	}
+}
+
+func normalizeSubtitleEmbeddingBatchSize(value int) int {
+	if value <= 0 {
+		return defaultSubtitleEmbeddingBatchSize
+	}
+	if value < minSubtitleEmbeddingBatchSize {
+		return minSubtitleEmbeddingBatchSize
+	}
+	if value > maxSubtitleEmbeddingBatchSize {
+		return maxSubtitleEmbeddingBatchSize
+	}
+	return value
+}
+
+func normalizeSubtitleEmbeddingConcurrency(value int) int {
+	if value <= 0 {
+		return defaultSubtitleEmbeddingConcurrency
+	}
+	if value < minSubtitleEmbeddingConcurrency {
+		return minSubtitleEmbeddingConcurrency
+	}
+	if value > maxSubtitleEmbeddingConcurrency {
+		return maxSubtitleEmbeddingConcurrency
+	}
+	return value
+}
+
+func resolveQueryInstruction(cfg SemanticSearchConfig, dimensions int) string {
+	if cfg.QueryInstruction != nil {
+		return *cfg.QueryInstruction
+	}
+	modelLower := strings.ToLower(strings.TrimSpace(cfg.EmbeddingsModel))
+	if strings.Contains(modelLower, "bge") {
+		return bgeQueryInstruction
+	}
+	if modelLower == "" && cfg.EmbeddingsProvider != embeddingsProviderOpenAI && dimensions == defaultSubtitleEmbeddingDimensions {
+		return bgeQueryInstruction
+	}
+	return ""
+}
+
+func (s *subtitleSearchStore) queryInput(query string) string {
+	if s != nil && s.queryInstruction != "" {
+		return s.queryInstruction + query
+	}
+	return query
 }
 
 func newEmbeddingClient(rawURL, provider, apiKey, model string, dimensions int) (*teiClient, error) {
@@ -1204,9 +1281,13 @@ func (a *Application) persistSubtitleChunks(ctx context.Context, owner string, s
 			return err
 		}
 	}
+	batchSize := defaultSubtitleEmbeddingBatchSize
+	if a.subtitleSearch != nil && a.subtitleSearch.batchSize > 0 {
+		batchSize = a.subtitleSearch.batchSize
+	}
 	embeddings := make([][]float32, 0, len(chunks))
-	for start := 0; start < len(inputs); start += subtitleEmbeddingBatchSize {
-		end := start + subtitleEmbeddingBatchSize
+	for start := 0; start < len(inputs); start += batchSize {
+		end := start + batchSize
 		if end > len(inputs) {
 			end = len(inputs)
 		}
@@ -1268,9 +1349,13 @@ func (a *Application) persistSharedSubtitleChunks(ctx context.Context, request s
 			return err
 		}
 	}
+	batchSize := defaultSubtitleEmbeddingBatchSize
+	if a.subtitleSearch != nil && a.subtitleSearch.batchSize > 0 {
+		batchSize = a.subtitleSearch.batchSize
+	}
 	embeddings := make([][]float32, 0, len(chunks))
-	for start := 0; start < len(inputs); start += subtitleEmbeddingBatchSize {
-		end := start + subtitleEmbeddingBatchSize
+	for start := 0; start < len(inputs); start += batchSize {
+		end := start + batchSize
 		if end > len(inputs) {
 			end = len(inputs)
 		}
@@ -1792,7 +1877,7 @@ func (a *Application) searchSubtitleIndex(ctx context.Context, query string) ([]
 	if err := load(`SELECT rating_key, media_id, part_id, subtitle_index, title, show_title, season, episode, year, start_ms, end_ms, text, ts_rank_cd(text_search, phraseto_tsquery('simple', $2)) AS score FROM subtitle_chunks WHERE owner_uuid=$1 AND text_search @@ phraseto_tsquery('simple', $2) ORDER BY score DESC, id LIMIT $3`, []any{owner, trimmedQuery, maxSubtitleLexicalCandidates}, 1); err != nil {
 		return nil, err
 	}
-	embeddings, err := a.subtitleSearch.embeddings.embed(ctx, []string{bgeQueryInstruction + trimmedQuery})
+	embeddings, err := a.subtitleSearch.embeddings.embed(ctx, []string{a.subtitleSearch.queryInput(trimmedQuery)})
 	if err != nil {
 		return nil, err
 	}
@@ -1809,6 +1894,9 @@ func (a *Application) searchSubtitleIndex(ctx context.Context, query string) ([]
 }
 
 func (a *Application) searchSharedSubtitleIndex(ctx context.Context, query string) ([]subtitleSearchHit, error) {
+	if a.subtitleSearch == nil {
+		return nil, errSubtitleSearchDisabled
+	}
 	if a.plexResources == nil || strings.TrimSpace(a.machineIdentifier) == "" {
 		return nil, errors.New("shared subtitle search is unavailable")
 	}
@@ -1870,7 +1958,7 @@ func (a *Application) searchSharedSubtitleIndex(ctx context.Context, query strin
 	if err := load(`SELECT c.machine_identifier, c.section_uuid, c.section_key, c.scan_id, s.section_type, c.rating_key, c.media_id, c.part_id, c.subtitle_index, c.start_ms, c.end_ms, ts_rank_cd(c.text_search, phraseto_tsquery('simple', $3)) AS score FROM subtitle_shared_chunks c JOIN subtitle_shared_sections s ON s.machine_identifier=c.machine_identifier AND s.section_uuid=c.section_uuid AND s.ready_scan_id=c.scan_id AND s.state='ready' WHERE c.machine_identifier=$1 AND c.section_uuid=ANY($2) AND c.text_search @@ phraseto_tsquery('simple', $3) AND EXISTS (SELECT 1 FROM subtitle_shared_sources v WHERE v.machine_identifier=c.machine_identifier AND v.section_uuid=c.section_uuid AND v.scan_id=c.scan_id AND v.rating_key=c.rating_key AND v.media_id=c.media_id AND v.part_id=c.part_id AND v.subtitle_index=c.subtitle_index AND v.chunk_count > 0) ORDER BY score DESC, c.id LIMIT $4`, []any{a.machineIdentifier, uuidKeys, trimmedQuery, maxSharedSubtitleCandidates}, 1); err != nil {
 		return nil, err
 	}
-	embeddings, err := a.subtitleSearch.embeddings.embed(ctx, []string{bgeQueryInstruction + trimmedQuery})
+	embeddings, err := a.subtitleSearch.embeddings.embed(ctx, []string{a.subtitleSearch.queryInput(trimmedQuery)})
 	if err != nil {
 		return nil, err
 	}

--- a/subtitle_search.go
+++ b/subtitle_search.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"html"
 	"io"
+	"log"
 	"net/http"
 	"net/url"
 	"os"
@@ -30,7 +31,10 @@ import (
 )
 
 const (
-	subtitleEmbeddingDimensions            = 768
+	defaultSubtitleEmbeddingDimensions     = 768
+	subtitleEmbeddingDimensions            = defaultSubtitleEmbeddingDimensions
+	minSubtitleEmbeddingDimensions         = 1
+	maxSubtitleEmbeddingDimensions         = 2000
 	subtitleEmbeddingBatchSize             = 32
 	maxSharedSubtitleCandidates            = 200
 	maxSharedSubtitleSourceChecks          = 100
@@ -96,6 +100,7 @@ func releaseSubtitleSemaphore(semaphore chan struct{}) {
 type subtitleSearchStore struct {
 	pool           *pgxpool.Pool
 	embeddings     *teiClient
+	dimensions     int
 	bulkEmbeddings chan struct{}
 	bulkWrites     chan struct{}
 	trackLocks     keyedSubtitleLocks
@@ -142,7 +147,11 @@ const (
 	openAIEmbeddingModel     = "BAAI/bge-base-en-v1.5"
 )
 
-const subtitleSearchSchema = `
+func subtitleSearchSchema(dimensions int) string {
+	if dimensions <= 0 {
+		dimensions = defaultSubtitleEmbeddingDimensions
+	}
+	return fmt.Sprintf(`
 CREATE EXTENSION IF NOT EXISTS vector;
 CREATE TABLE IF NOT EXISTS subtitle_chunks (
     id BIGSERIAL PRIMARY KEY,
@@ -160,7 +169,7 @@ CREATE TABLE IF NOT EXISTS subtitle_chunks (
     end_ms BIGINT NOT NULL,
     text TEXT NOT NULL,
     content_hash TEXT NOT NULL,
-    embedding vector(768) NOT NULL,
+    embedding vector(%d) NOT NULL,
     text_search TSVECTOR GENERATED ALWAYS AS (to_tsvector('simple', text)) STORED,
     UNIQUE (owner_uuid, rating_key, media_id, part_id, subtitle_index, start_ms, end_ms, content_hash)
 );
@@ -249,7 +258,7 @@ CREATE TABLE IF NOT EXISTS subtitle_shared_chunks (
     end_ms BIGINT NOT NULL,
     text TEXT NOT NULL,
     content_hash TEXT NOT NULL,
-    embedding vector(768) NOT NULL,
+    embedding vector(%d) NOT NULL,
     scan_id UUID NOT NULL,
     text_search TSVECTOR GENERATED ALWAYS AS (to_tsvector('simple', text)) STORED,
     UNIQUE (machine_identifier, section_uuid, scan_id, rating_key, media_id, part_id, subtitle_index, start_ms, end_ms, content_hash)
@@ -257,7 +266,63 @@ CREATE TABLE IF NOT EXISTS subtitle_shared_chunks (
 CREATE INDEX IF NOT EXISTS subtitle_shared_chunks_text_idx ON subtitle_shared_chunks USING GIN (text_search);
 CREATE INDEX IF NOT EXISTS subtitle_shared_chunks_embedding_idx ON subtitle_shared_chunks USING hnsw (embedding vector_cosine_ops);
 ALTER TABLE subtitle_shared_sections ADD COLUMN IF NOT EXISTS ready BOOLEAN NOT NULL DEFAULT FALSE;
-`
+`, dimensions, dimensions)
+}
+
+func migrateSubtitleEmbeddingDimensions(ctx context.Context, pool *pgxpool.Pool, targetDimensions int) error {
+	var currentDim int32 = -1
+	_ = pool.QueryRow(ctx, `
+		SELECT COALESCE((
+			SELECT atttypmod
+			FROM pg_attribute
+			WHERE attrelid = to_regclass('subtitle_chunks')
+			  AND attname = 'embedding'
+			  AND NOT attisdropped
+		), -1)
+	`).Scan(&currentDim)
+
+	if currentDim > 0 && int(currentDim) != targetDimensions {
+		log.Printf("semantic search embedding dimension changed from %d to %d; migrating subtitle_chunks schema", currentDim, targetDimensions)
+		migrationSQL := fmt.Sprintf(`
+			DROP INDEX IF EXISTS subtitle_chunks_embedding_hnsw_idx;
+			TRUNCATE TABLE subtitle_chunks;
+			TRUNCATE TABLE subtitle_index_sources;
+			ALTER TABLE subtitle_chunks ALTER COLUMN embedding TYPE vector(%d);
+			CREATE INDEX IF NOT EXISTS subtitle_chunks_embedding_hnsw_idx ON subtitle_chunks USING hnsw (embedding vector_cosine_ops);
+		`, targetDimensions)
+		if _, err := pool.Exec(ctx, migrationSQL); err != nil {
+			return fmt.Errorf("could not migrate subtitle_chunks embedding dimensions: %w", err)
+		}
+	}
+
+	var sharedDim int32 = -1
+	_ = pool.QueryRow(ctx, `
+		SELECT COALESCE((
+			SELECT atttypmod
+			FROM pg_attribute
+			WHERE attrelid = to_regclass('subtitle_shared_chunks')
+			  AND attname = 'embedding'
+			  AND NOT attisdropped
+		), -1)
+	`).Scan(&sharedDim)
+
+	if sharedDim > 0 && int(sharedDim) != targetDimensions {
+		log.Printf("semantic search embedding dimension changed from %d to %d; migrating subtitle_shared_chunks schema", sharedDim, targetDimensions)
+		sharedMigrationSQL := fmt.Sprintf(`
+			DROP INDEX IF EXISTS subtitle_shared_chunks_embedding_idx;
+			TRUNCATE TABLE subtitle_shared_chunks;
+			TRUNCATE TABLE subtitle_shared_sources;
+			UPDATE subtitle_shared_sections SET state='building', ready=FALSE, ready_scan_id=NULL;
+			ALTER TABLE subtitle_shared_chunks ALTER COLUMN embedding TYPE vector(%d);
+			CREATE INDEX IF NOT EXISTS subtitle_shared_chunks_embedding_idx ON subtitle_shared_chunks USING hnsw (embedding vector_cosine_ops);
+		`, targetDimensions)
+		if _, err := pool.Exec(ctx, sharedMigrationSQL); err != nil {
+			return fmt.Errorf("could not migrate subtitle_shared_chunks embedding dimensions: %w", err)
+		}
+	}
+
+	return nil
+}
 
 const subtitleSearchIndexVersion = "subtitle-index-v4-chunk-400-cast-clean-text"
 
@@ -269,7 +334,7 @@ func newSubtitleSearchStore(ctx context.Context, cfg SemanticSearchConfig) (*sub
 	if strings.TrimSpace(cfg.PostgresDSN) == "" {
 		return nil, errors.New("semantic_search.postgres_dsn is required when semantic search is enabled")
 	}
-	embeddings, err := newEmbeddingClient(cfg.EmbeddingsURL, provider, cfg.EmbeddingsAPIKey)
+	embeddings, err := newEmbeddingClient(cfg.EmbeddingsURL, provider, cfg.EmbeddingsAPIKey, cfg.EmbeddingsModel, cfg.Dimensions)
 	if err != nil {
 		return nil, err
 	}
@@ -286,7 +351,56 @@ func newSubtitleSearchStore(ctx context.Context, cfg SemanticSearchConfig) (*sub
 		pool.Close()
 		return nil, errors.New("could not connect to semantic search database")
 	}
-	if _, err := pool.Exec(ctx, subtitleSearchSchema); err != nil {
+
+	dimensions := cfg.Dimensions
+	if dimensions > 0 {
+		if dimensions < minSubtitleEmbeddingDimensions || dimensions > maxSubtitleEmbeddingDimensions {
+			pool.Close()
+			return nil, fmt.Errorf("semantic_search.dimensions must be between %d and %d", minSubtitleEmbeddingDimensions, maxSubtitleEmbeddingDimensions)
+		}
+	} else {
+		probedDim, probeErr := embeddings.probeDimensions(ctx)
+		if probeErr == nil && probedDim > 0 {
+			if probedDim < minSubtitleEmbeddingDimensions || probedDim > maxSubtitleEmbeddingDimensions {
+				pool.Close()
+				return nil, fmt.Errorf("probed embedding dimension %d exceeds supported range (%d-%d)", probedDim, minSubtitleEmbeddingDimensions, maxSubtitleEmbeddingDimensions)
+			}
+			dimensions = probedDim
+			log.Printf("semantic search auto-detected embedding dimension %d from %s", dimensions, cfg.EmbeddingsURL)
+		} else {
+			var existingDim int32 = -1
+			_ = pool.QueryRow(ctx, `
+				SELECT COALESCE((
+					SELECT atttypmod
+					FROM pg_attribute
+					WHERE attrelid = to_regclass('subtitle_chunks')
+					  AND attname = 'embedding'
+					  AND NOT attisdropped
+				), -1)
+			`).Scan(&existingDim)
+			if existingDim > 0 {
+				dimensions = int(existingDim)
+				log.Printf("semantic search embedding probe unavailable (%v); using existing database dimension %d", probeErr, dimensions)
+			} else {
+				dimensions = defaultSubtitleEmbeddingDimensions
+				log.Printf("semantic search embedding probe unavailable (%v); falling back to default dimension %d", probeErr, dimensions)
+			}
+		}
+	}
+	embeddings.dimensions = dimensions
+
+	// Ensure vector extension is enabled before checking attributes
+	if _, err := pool.Exec(ctx, "CREATE EXTENSION IF NOT EXISTS vector;"); err != nil {
+		pool.Close()
+		return nil, errors.New("could not initialize vector extension")
+	}
+
+	if err := migrateSubtitleEmbeddingDimensions(ctx, pool, dimensions); err != nil {
+		pool.Close()
+		return nil, err
+	}
+
+	if _, err := pool.Exec(ctx, subtitleSearchSchema(dimensions)); err != nil {
 		pool.Close()
 		return nil, errors.New("could not initialize semantic search schema")
 	}
@@ -302,7 +416,13 @@ func newSubtitleSearchStore(ctx context.Context, cfg SemanticSearchConfig) (*sub
 		pool.Close()
 		return nil, errors.New("could not connect to semantic search database")
 	}
-	return &subtitleSearchStore{pool: pool, embeddings: embeddings, bulkEmbeddings: make(chan struct{}, 1), bulkWrites: make(chan struct{}, 1)}, nil
+	return &subtitleSearchStore{
+		pool:           pool,
+		embeddings:     embeddings,
+		dimensions:     dimensions,
+		bulkEmbeddings: make(chan struct{}, 1),
+		bulkWrites:     make(chan struct{}, 1),
+	}, nil
 }
 
 func (s *subtitleSearchStore) close() {
@@ -395,14 +515,16 @@ func chunkSubtitleEntries(entries []SubtitleEntry) []subtitleChunk {
 }
 
 type teiClient struct {
-	url      string
-	provider string
-	apiKey   string
-	client   *http.Client
+	url        string
+	provider   string
+	apiKey     string
+	model      string
+	dimensions int
+	client     *http.Client
 }
 
 func newTEIClient(rawURL string) (*teiClient, error) {
-	return newEmbeddingClient(rawURL, embeddingsProviderTEI, "")
+	return newEmbeddingClient(rawURL, embeddingsProviderTEI, "", "", defaultSubtitleEmbeddingDimensions)
 }
 
 func normalizeEmbeddingsProvider(value string) (string, error) {
@@ -418,7 +540,7 @@ func normalizeEmbeddingsProvider(value string) (string, error) {
 	}
 }
 
-func newEmbeddingClient(rawURL, provider, apiKey string) (*teiClient, error) {
+func newEmbeddingClient(rawURL, provider, apiKey, model string, dimensions int) (*teiClient, error) {
 	parsed, err := url.Parse(strings.TrimSpace(rawURL))
 	if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Host == "" || parsed.User != nil {
 		return nil, errors.New("semantic_search.embeddings_url must be an HTTP(S) URL")
@@ -439,16 +561,33 @@ func newEmbeddingClient(rawURL, provider, apiKey string) (*teiClient, error) {
 			parsed.Path += "/v1/embeddings"
 		}
 	}
-	return &teiClient{url: parsed.String(), provider: provider, apiKey: strings.TrimSpace(apiKey), client: &http.Client{Timeout: 30 * time.Second}}, nil
+	if dimensions <= 0 {
+		dimensions = defaultSubtitleEmbeddingDimensions
+	}
+	trimmedModel := strings.TrimSpace(model)
+	if trimmedModel == "" && provider == embeddingsProviderOpenAI {
+		trimmedModel = openAIEmbeddingModel
+	}
+	return &teiClient{
+		url:        parsed.String(),
+		provider:   provider,
+		apiKey:     strings.TrimSpace(apiKey),
+		model:      trimmedModel,
+		dimensions: dimensions,
+		client:     &http.Client{Timeout: 30 * time.Second},
+	}, nil
 }
 
-func validateEmbeddings(embeddings [][]float32, expected int) error {
+func validateEmbeddings(embeddings [][]float32, expected int, dimensions int) error {
 	if len(embeddings) != expected {
 		return fmt.Errorf("embedding response count %d does not match request count %d", len(embeddings), expected)
 	}
+	if dimensions <= 0 {
+		dimensions = defaultSubtitleEmbeddingDimensions
+	}
 	for i, embedding := range embeddings {
-		if len(embedding) != subtitleEmbeddingDimensions {
-			return fmt.Errorf("embedding %d has dimension %d, want %d", i, len(embedding), subtitleEmbeddingDimensions)
+		if len(embedding) != dimensions {
+			return fmt.Errorf("embedding %d has dimension %d, want %d", i, len(embedding), dimensions)
 		}
 	}
 	return nil
@@ -458,9 +597,44 @@ func (c *teiClient) embed(ctx context.Context, inputs []string) ([][]float32, er
 	if len(inputs) == 0 {
 		return [][]float32{}, nil
 	}
-	if c.provider == embeddingsProviderOpenAI {
-		return c.embedOpenAI(ctx, inputs)
+	vecs, err := c.embedRaw(ctx, inputs)
+	if err != nil {
+		return nil, err
 	}
+	expectedDim := c.dimensions
+	if expectedDim <= 0 {
+		expectedDim = defaultSubtitleEmbeddingDimensions
+	}
+	if err := validateEmbeddings(vecs, len(inputs), expectedDim); err != nil {
+		return nil, err
+	}
+	return vecs, nil
+}
+
+func (c *teiClient) probeDimensions(ctx context.Context) (int, error) {
+	probeCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	vecs, err := c.embedRaw(probeCtx, []string{"probe"})
+	if err != nil {
+		return 0, err
+	}
+	if len(vecs) == 0 || len(vecs[0]) == 0 {
+		return 0, errors.New("embedding probe returned empty vector")
+	}
+	return len(vecs[0]), nil
+}
+
+func (c *teiClient) embedRaw(ctx context.Context, inputs []string) ([][]float32, error) {
+	if len(inputs) == 0 {
+		return [][]float32{}, nil
+	}
+	if c.provider == embeddingsProviderOpenAI {
+		return c.embedRawOpenAI(ctx, inputs)
+	}
+	return c.embedRawTEI(ctx, inputs)
+}
+
+func (c *teiClient) embedRawTEI(ctx context.Context, inputs []string) ([][]float32, error) {
 	payload, err := json.Marshal(struct {
 		Inputs    []string `json:"inputs"`
 		Normalize bool     `json:"normalize"`
@@ -503,9 +677,6 @@ func (c *teiClient) embed(ctx context.Context, inputs []string) ([][]float32, er
 		}
 		embeddings = wrapped.Embeddings
 	}
-	if err := validateEmbeddings(embeddings, len(inputs)); err != nil {
-		return nil, err
-	}
 	return embeddings, nil
 }
 
@@ -518,12 +689,16 @@ type openAIEmbeddingResponse struct {
 	Data []openAIEmbeddingItem `json:"data"`
 }
 
-func (c *teiClient) embedOpenAI(ctx context.Context, inputs []string) ([][]float32, error) {
+func (c *teiClient) embedRawOpenAI(ctx context.Context, inputs []string) ([][]float32, error) {
+	model := c.model
+	if strings.TrimSpace(model) == "" {
+		model = openAIEmbeddingModel
+	}
 	payload, err := json.Marshal(struct {
 		Model          string   `json:"model"`
 		Input          []string `json:"input"`
 		EncodingFormat string   `json:"encoding_format"`
-	}{openAIEmbeddingModel, inputs, "float"})
+	}{model, inputs, "float"})
 	if err != nil {
 		return nil, errors.New("could not encode embedding request")
 	}
@@ -568,9 +743,6 @@ func (c *teiClient) embedOpenAI(ctx context.Context, inputs []string) ([][]float
 			return nil, errors.New("embedding response indexes are incomplete")
 		}
 	}
-	if err := validateEmbeddings(ordered, len(inputs)); err != nil {
-		return nil, err
-	}
 	return ordered, nil
 }
 
@@ -579,8 +751,14 @@ func (a *Application) buildPlexSourceURL(path, token string) (string, error) {
 	if err != nil || (base.Scheme != "http" && base.Scheme != "https") || base.Host == "" || base.User != nil {
 		return "", errors.New("configured Plex origin is invalid")
 	}
+	if strings.TrimSpace(path) == "" {
+		return "", errors.New("Plex source path is required")
+	}
+	if strings.HasPrefix(path, "//") {
+		return "", errors.New("scheme-relative Plex source path is not allowed")
+	}
 	parsed, err := url.Parse(path)
-	if err != nil || parsed.User != nil || parsed.IsAbs() || !strings.HasPrefix(parsed.Path, "/") {
+	if err != nil || parsed.User != nil || parsed.IsAbs() || parsed.Host != "" || !strings.HasPrefix(parsed.Path, "/") {
 		return "", errors.New("Plex source path is invalid")
 	}
 	base.Path = strings.TrimRight(base.Path, "/") + parsed.Path
@@ -713,9 +891,13 @@ func (a *Application) indexSubtitleSource(ctx context.Context, request subtitleS
 	result := subtitleSearchIndexResponse{RatingKey: request.RatingKey, MediaID: request.MediaID, PartID: request.PartID, Skipped: []subtitleSearchSkipped{}}
 	changed := make([]subtitleTrackPlan, 0)
 	fingerprints := make(map[int]string)
+	dim := 0
+	if a.subtitleSearch != nil {
+		dim = a.subtitleSearch.dimensions
+	}
 	for _, plan := range plans {
 		stream := plan.Stream
-		fingerprint := subtitleSourceFingerprint(request.RatingKey, request.MediaID, request.PartID, stream, castContext, sourceRevision)
+		fingerprint := subtitleSourceFingerprintWithDimensions(request.RatingKey, request.MediaID, request.PartID, stream, castContext, dim, sourceRevision)
 		fingerprints[plan.PublicIndex] = fingerprint
 		unchanged := false
 		var checkErr error
@@ -781,9 +963,13 @@ func (a *Application) indexSubtitleSource(ctx context.Context, request subtitleS
 	if urlErr != nil {
 		return result, subtitleItemFailure(urlErr)
 	}
-	if releaseCapability != nil {
-		defer releaseCapability()
+	cleanCapability := func() {
+		if releaseCapability != nil {
+			releaseCapability()
+			releaseCapability = nil
+		}
 	}
+	defer cleanCapability()
 	embeddedIndices := make([]int, 0, len(changed))
 	for _, plan := range changed {
 		embeddedIndices = append(embeddedIndices, plan.EmbeddedIndex)
@@ -840,6 +1026,7 @@ func (a *Application) indexSubtitleSource(ctx context.Context, request subtitleS
 			entriesByEmbedded[plan.EmbeddedIndex] = entries
 		}
 	}
+	cleanCapability()
 	for _, plan := range changed {
 		entries, extracted := entriesByEmbedded[plan.EmbeddedIndex]
 		if !extracted {
@@ -933,12 +1120,20 @@ func boundedFingerprintValue(value string) string {
 }
 
 func subtitleSourceFingerprint(ratingKey string, mediaID, partID int64, stream SubtitleStream, castContext string, sourceRevisions ...string) string {
+	return subtitleSourceFingerprintWithDimensions(ratingKey, mediaID, partID, stream, castContext, 0, sourceRevisions...)
+}
+
+func subtitleSourceFingerprintWithDimensions(ratingKey string, mediaID, partID int64, stream SubtitleStream, castContext string, dimensions int, sourceRevisions ...string) string {
 	hash := sha256.New()
 	revision := ""
 	if len(sourceRevisions) > 0 {
 		revision = sourceRevisions[0]
 	}
-	_, _ = fmt.Fprintf(hash, "%s|%s|%d|%d|%d|%s|%s|%s|%t|%s|%s|%s", subtitleSearchIndexVersion, boundedFingerprintValue(ratingKey), mediaID, partID, stream.Index, stream.Codec, stream.Language, stream.LanguageCode, stream.External, stream.Type, castContext, revision)
+	version := subtitleSearchIndexVersion
+	if dimensions > 0 {
+		version = fmt.Sprintf("%s-dim-%d", subtitleSearchIndexVersion, dimensions)
+	}
+	_, _ = fmt.Fprintf(hash, "%s|%s|%d|%d|%d|%s|%s|%s|%t|%s|%s|%s", version, boundedFingerprintValue(ratingKey), mediaID, partID, stream.Index, stream.Codec, stream.Language, stream.LanguageCode, stream.External, stream.Type, castContext, revision)
 	return hex.EncodeToString(hash.Sum(nil))
 }
 
@@ -1004,11 +1199,10 @@ func (a *Application) persistSubtitleChunks(ctx context.Context, owner string, s
 		inputs[i] = subtitleEmbeddingInput(embeddingContext, chunk.Text)
 	}
 	bulkEmbedding := isBulkSubtitleContext(ctx)
-	if bulkEmbedding {
+	if bulkEmbedding && a.subtitleSearch != nil {
 		if err := acquireSubtitleSemaphore(ctx, a.subtitleSearch.bulkEmbeddings); err != nil {
 			return err
 		}
-		defer releaseSubtitleSemaphore(a.subtitleSearch.bulkEmbeddings)
 	}
 	embeddings := make([][]float32, 0, len(chunks))
 	for start := 0; start < len(inputs); start += subtitleEmbeddingBatchSize {
@@ -1018,11 +1212,15 @@ func (a *Application) persistSubtitleChunks(ctx context.Context, owner string, s
 		}
 		batch, err := a.subtitleSearch.embeddings.embed(ctx, inputs[start:end])
 		if err != nil {
+			if bulkEmbedding && a.subtitleSearch != nil {
+				releaseSubtitleSemaphore(a.subtitleSearch.bulkEmbeddings)
+			}
 			return err
 		}
 		embeddings = append(embeddings, batch...)
 	}
-	if bulkEmbedding {
+	if bulkEmbedding && a.subtitleSearch != nil {
+		releaseSubtitleSemaphore(a.subtitleSearch.bulkEmbeddings)
 		if err := acquireSubtitleSemaphore(ctx, a.subtitleSearch.bulkWrites); err != nil {
 			return err
 		}
@@ -1036,13 +1234,22 @@ func (a *Application) persistSubtitleChunks(ctx context.Context, owner string, s
 	if _, err := tx.Exec(ctx, `DELETE FROM subtitle_chunks WHERE owner_uuid=$1 AND rating_key=$2 AND media_id=$3 AND part_id=$4 AND subtitle_index=$5`, owner, source.RatingKey, source.MediaID, source.PartID, subtitleIndex); err != nil {
 		return errors.New("could not update subtitle index")
 	}
+
+	batch := &pgx.Batch{}
 	for i, chunk := range chunks {
 		hash := sha256.Sum256([]byte(chunk.Text))
-		_, err := tx.Exec(ctx, `INSERT INTO subtitle_chunks (owner_uuid, rating_key, media_id, part_id, subtitle_index, title, show_title, season, episode, year, start_ms, end_ms, text, content_hash, embedding) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)`,
+		batch.Queue(`INSERT INTO subtitle_chunks (owner_uuid, rating_key, media_id, part_id, subtitle_index, title, show_title, season, episode, year, start_ms, end_ms, text, content_hash, embedding) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)`,
 			owner, source.RatingKey, source.MediaID, source.PartID, subtitleIndex, source.Title, nullableString(source.GrandparentTitle), nullableInt(source.SeasonNumber), nullableInt(source.EpisodeNumber), nullableInt(source.Year), chunk.Start, chunk.End, chunk.Text, hex.EncodeToString(hash[:]), pgvector.NewVector(embeddings[i]))
-		if err != nil {
+	}
+	br := tx.SendBatch(ctx, batch)
+	defer br.Close()
+	for range chunks {
+		if _, err := br.Exec(); err != nil {
 			return errors.New("could not update subtitle index")
 		}
+	}
+	if err := br.Close(); err != nil {
+		return errors.New("could not update subtitle index")
 	}
 	if err := tx.Commit(ctx); err != nil {
 		return errors.New("could not update subtitle index")
@@ -1055,6 +1262,12 @@ func (a *Application) persistSharedSubtitleChunks(ctx context.Context, request s
 	for i, chunk := range chunks {
 		inputs[i] = subtitleEmbeddingInput(embeddingContext, chunk.Text)
 	}
+	bulkEmbedding := isBulkSubtitleContext(ctx)
+	if bulkEmbedding && a.subtitleSearch != nil {
+		if err := acquireSubtitleSemaphore(ctx, a.subtitleSearch.bulkEmbeddings); err != nil {
+			return err
+		}
+	}
 	embeddings := make([][]float32, 0, len(chunks))
 	for start := 0; start < len(inputs); start += subtitleEmbeddingBatchSize {
 		end := start + subtitleEmbeddingBatchSize
@@ -1063,9 +1276,19 @@ func (a *Application) persistSharedSubtitleChunks(ctx context.Context, request s
 		}
 		batch, err := a.subtitleSearch.embeddings.embed(ctx, inputs[start:end])
 		if err != nil {
+			if bulkEmbedding && a.subtitleSearch != nil {
+				releaseSubtitleSemaphore(a.subtitleSearch.bulkEmbeddings)
+			}
 			return err
 		}
 		embeddings = append(embeddings, batch...)
+	}
+	if bulkEmbedding && a.subtitleSearch != nil {
+		releaseSubtitleSemaphore(a.subtitleSearch.bulkEmbeddings)
+		if err := acquireSubtitleSemaphore(ctx, a.subtitleSearch.bulkWrites); err != nil {
+			return err
+		}
+		defer releaseSubtitleSemaphore(a.subtitleSearch.bulkWrites)
 	}
 	tx, err := a.subtitleSearch.pool.Begin(ctx)
 	if err != nil {
@@ -1075,11 +1298,21 @@ func (a *Application) persistSharedSubtitleChunks(ctx context.Context, request s
 	if _, err := tx.Exec(ctx, `DELETE FROM subtitle_shared_chunks WHERE machine_identifier=$1 AND section_uuid=$2 AND scan_id=$3 AND rating_key=$4 AND media_id=$5 AND part_id=$6 AND subtitle_index=$7`, a.machineIdentifier, request.SectionUUID, request.ScanID, source.RatingKey, source.MediaID, source.PartID, subtitleIndex); err != nil {
 		return errors.New("could not update shared subtitle index")
 	}
+
+	batch := &pgx.Batch{}
 	for i, chunk := range chunks {
 		hash := sha256.Sum256([]byte(chunk.Text))
-		if _, err := tx.Exec(ctx, `INSERT INTO subtitle_shared_chunks (machine_identifier, section_uuid, section_key, rating_key, media_id, part_id, subtitle_index, title, show_title, season, episode, year, start_ms, end_ms, text, content_hash, embedding, scan_id) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18)`, a.machineIdentifier, request.SectionUUID, request.SectionKey, source.RatingKey, source.MediaID, source.PartID, subtitleIndex, source.Title, nullableString(source.GrandparentTitle), nullableInt(source.SeasonNumber), nullableInt(source.EpisodeNumber), nullableInt(source.Year), chunk.Start, chunk.End, chunk.Text, hex.EncodeToString(hash[:]), pgvector.NewVector(embeddings[i]), request.ScanID); err != nil {
+		batch.Queue(`INSERT INTO subtitle_shared_chunks (machine_identifier, section_uuid, section_key, rating_key, media_id, part_id, subtitle_index, title, show_title, season, episode, year, start_ms, end_ms, text, content_hash, embedding, scan_id) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18)`, a.machineIdentifier, request.SectionUUID, request.SectionKey, source.RatingKey, source.MediaID, source.PartID, subtitleIndex, source.Title, nullableString(source.GrandparentTitle), nullableInt(source.SeasonNumber), nullableInt(source.EpisodeNumber), nullableInt(source.Year), chunk.Start, chunk.End, chunk.Text, hex.EncodeToString(hash[:]), pgvector.NewVector(embeddings[i]), request.ScanID)
+	}
+	br := tx.SendBatch(ctx, batch)
+	defer br.Close()
+	for range chunks {
+		if _, err := br.Exec(); err != nil {
 			return errors.New("could not update shared subtitle index")
 		}
+	}
+	if err := br.Close(); err != nil {
+		return errors.New("could not update shared subtitle index")
 	}
 	_, err = tx.Exec(ctx, `INSERT INTO subtitle_shared_sources (machine_identifier, section_uuid, section_key, rating_key, media_id, part_id, subtitle_index, fingerprint, chunk_count, scan_id, indexed_at) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,NOW()) ON CONFLICT (machine_identifier, section_uuid, scan_id, rating_key, media_id, part_id, subtitle_index) DO UPDATE SET fingerprint=EXCLUDED.fingerprint, chunk_count=EXCLUDED.chunk_count, section_key=EXCLUDED.section_key, indexed_at=EXCLUDED.indexed_at`, a.machineIdentifier, request.SectionUUID, request.SectionKey, source.RatingKey, source.MediaID, source.PartID, subtitleIndex, fingerprint, len(chunks), request.ScanID)
 	if err != nil {
@@ -1708,7 +1941,7 @@ func (a *Application) callerSectionSourceSet(ctx context.Context, resolver *Plex
 		return nil, 0, 0, errors.New("shared subtitle visibility is unavailable")
 	}
 	sources := make(map[string]struct{})
-	previousPage := ""
+	seenPages := make(map[string]bool)
 	previousStart := -1
 	itemsSeen := 0
 	for pageCount, start := 1, 0; pageCount <= maxSharedSubtitleAuthorizationPages; pageCount++ {
@@ -1756,14 +1989,13 @@ func (a *Application) callerSectionSourceSet(ctx context.Context, resolver *Plex
 		if itemsSeen > maxSharedSubtitleAuthorizationItems {
 			return nil, pageCount, itemsSeen, errors.New("shared subtitle authorization budget exceeded")
 		}
-		pageKey := ""
 		if len(items) > 0 {
-			pageKey = stringValue(items[0].RatingKey) + ":" + stringValue(items[len(items)-1].RatingKey)
-			if pageKey == previousPage {
-				return nil, pageCount, itemsSeen, errors.New("shared subtitle visibility is unavailable")
+			pageKey := stringValue(items[0].RatingKey) + ":" + stringValue(items[len(items)-1].RatingKey)
+			if seenPages[pageKey] {
+				return sources, pageCount, itemsSeen, nil
 			}
+			seenPages[pageKey] = true
 		}
-		previousPage = pageKey
 		for i := range items {
 			item := &items[i]
 			if item.Type != "movie" && item.Type != "episode" {
@@ -1776,6 +2008,9 @@ func (a *Application) callerSectionSourceSet(ctx context.Context, resolver *Plex
 			sources[fmt.Sprintf("%s:%d:%d", stringValue(item.RatingKey), media.ID, part.ID)] = struct{}{}
 		}
 		if len(items) == 0 || len(items) < indexLibraryPageSize {
+			return sources, pageCount, itemsSeen, nil
+		}
+		if page.MediaContainer.TotalSize > 0 && start+len(items) >= page.MediaContainer.TotalSize {
 			return sources, pageCount, itemsSeen, nil
 		}
 		start += len(items)

--- a/subtitle_search_library.go
+++ b/subtitle_search_library.go
@@ -27,7 +27,10 @@ const (
 	subtitleBulkQueueSize = 6
 )
 
-var errStopPagination = errors.New("stop pagination")
+var (
+	errStopPagination       = errors.New("stop pagination")
+	errPaginationIncomplete = errors.New("section pagination ended prematurely")
+)
 
 type subtitleIndexJobManager struct {
 	app      *Application
@@ -193,17 +196,19 @@ func (m *subtitleIndexJobManager) loadOrCreatePersistedJob(owner string) (*subti
 }
 
 func (m *subtitleIndexJobManager) recoverPersistedJobs() error {
-	if m.app.subtitleSearch == nil {
+	if m == nil || m.app == nil || m.app.subtitleSearch == nil {
 		return nil
 	}
-	_, err := m.app.subtitleSearch.pool.Exec(context.Background(), `UPDATE subtitle_index_jobs SET state='interrupted', updated_at=NOW(), error='indexing interrupted; rescan resumes completed sources' WHERE state IN ('queued','running')`)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	_, err := m.app.subtitleSearch.pool.Exec(ctx, `UPDATE subtitle_index_jobs SET state='interrupted', updated_at=NOW(), error='indexing interrupted; rescan resumes completed sources' WHERE state IN ('queued','running')`)
 	if err != nil {
 		return errors.New("could not recover subtitle index jobs")
 	}
-	if m.app.sharedCorpus {
-		_, _ = m.app.subtitleSearch.pool.Exec(context.Background(), `UPDATE subtitle_shared_sections SET state=CASE WHEN ready THEN 'ready' ELSE 'failed' END, scan_id=COALESCE(ready_scan_id, scan_id) WHERE state='building'`)
-		_, _ = m.app.subtitleSearch.pool.Exec(context.Background(), `DELETE FROM subtitle_shared_chunks WHERE scan_id NOT IN (SELECT ready_scan_id FROM subtitle_shared_sections WHERE ready=TRUE AND ready_scan_id IS NOT NULL)`)
-		_, _ = m.app.subtitleSearch.pool.Exec(context.Background(), `DELETE FROM subtitle_shared_sources WHERE scan_id NOT IN (SELECT ready_scan_id FROM subtitle_shared_sections WHERE ready=TRUE AND ready_scan_id IS NOT NULL)`)
+	if m.app.sharedCorpus && strings.TrimSpace(m.app.machineIdentifier) != "" {
+		_, _ = m.app.subtitleSearch.pool.Exec(ctx, `UPDATE subtitle_shared_sections SET state=CASE WHEN ready THEN 'ready' ELSE 'failed' END, scan_id=COALESCE(ready_scan_id, scan_id) WHERE machine_identifier=$1 AND state='building'`, m.app.machineIdentifier)
+		_, _ = m.app.subtitleSearch.pool.Exec(ctx, `DELETE FROM subtitle_shared_chunks WHERE machine_identifier=$1 AND scan_id NOT IN (SELECT ready_scan_id FROM subtitle_shared_sections WHERE machine_identifier=$1 AND ready=TRUE AND ready_scan_id IS NOT NULL)`, m.app.machineIdentifier)
+		_, _ = m.app.subtitleSearch.pool.Exec(ctx, `DELETE FROM subtitle_shared_sources WHERE machine_identifier=$1 AND scan_id NOT IN (SELECT ready_scan_id FROM subtitle_shared_sections WHERE machine_identifier=$1 AND ready=TRUE AND ready_scan_id IS NOT NULL)`, m.app.machineIdentifier)
 	}
 	return nil
 }
@@ -562,13 +567,19 @@ func (a *Application) streamIndexLibrarySectionSources(ctx context.Context, toke
 		pageKey := stringValue(items[0].RatingKey) + ":" + stringValue(items[len(items)-1].RatingKey)
 		if seenPages[pageKey] {
 			log.Printf("subtitle index-all section detected pagination cycle key=%s type=%s page_key=%s", key, sectionType, pageKey)
-			return nil
+			if page.MediaContainer.TotalSize > 0 && start >= page.MediaContainer.TotalSize {
+				return nil
+			}
+			return errPaginationIncomplete
 		}
 		seenPages[pageKey] = true
 		if err := consume(items); err != nil {
 			if errors.Is(err, errStopPagination) {
 				log.Printf("subtitle index-all section stopped key=%s type=%s pages=%d (stop requested)", key, sectionType, pageCount)
-				return nil
+				if page.MediaContainer.TotalSize > 0 && start+len(items) >= page.MediaContainer.TotalSize {
+					return nil
+				}
+				return errPaginationIncomplete
 			}
 			return err
 		}
@@ -602,6 +613,7 @@ func (a *Application) discoverAndIndexSources(ctx context.Context, job *subtitle
 	if err != nil {
 		return fmt.Errorf("could not discover Plex libraries: %w", err)
 	}
+	hasIncompleteSection := false
 	for _, section := range sections {
 		if section.Type != "movie" && section.Type != "show" {
 			continue
@@ -704,6 +716,14 @@ func (a *Application) discoverAndIndexSources(ctx context.Context, job *subtitle
 			return currentWorkerErr
 		}
 		if pageErr != nil {
+			if errors.Is(pageErr, errPaginationIncomplete) {
+				log.Printf("subtitle index-all section ended prematurely key=%s; skipping publication/pruning to protect index", section.Key)
+				hasIncompleteSection = true
+				if a.sharedCorpus {
+					_ = a.abortSharedSubtitleScan(ctx, section.UUID, scanID)
+				}
+				continue
+			}
 			if a.sharedCorpus {
 				a.abortSharedSubtitleScan(ctx, section.UUID, scanID)
 			}
@@ -739,11 +759,16 @@ func (a *Application) discoverAndIndexSources(ctx context.Context, job *subtitle
 		job.mu.RLock()
 		failed, owner, scanID := job.failed, job.owner, job.scanID
 		job.mu.RUnlock()
-		if failed == 0 {
+		if failed == 0 && !hasIncompleteSection {
 			if err := a.prunePrivateSubtitleSources(ctx, owner, scanID); err != nil {
 				return err
 			}
+		} else if hasIncompleteSection {
+			log.Printf("subtitle index-all private pruning skipped due to incomplete section traversal owner=%s scan_id=%s", owner, scanID)
 		}
+	}
+	if hasIncompleteSection {
+		return errPaginationIncomplete
 	}
 	return nil
 }

--- a/subtitle_search_library.go
+++ b/subtitle_search_library.go
@@ -17,14 +17,17 @@ import (
 
 	"github.com/LukeHagar/plexgo/models/components"
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 )
 
 const (
 	indexLibraryPageSize  = 100
-	maxIndexLibraryPages  = 200000
+	maxIndexLibraryPages  = 10000
 	subtitleBulkWorkers   = 3
 	subtitleBulkQueueSize = 6
 )
+
+var errStopPagination = errors.New("stop pagination")
 
 type subtitleIndexJobManager struct {
 	app      *Application
@@ -77,7 +80,11 @@ type subtitleIndexJobStatus struct {
 }
 
 func newSubtitleIndexJobManager(app *Application) *subtitleIndexJobManager {
-	lifetime, cancel := context.WithCancel(app.lifetime)
+	parent := context.Background()
+	if app != nil && app.lifetime != nil {
+		parent = app.lifetime
+	}
+	lifetime, cancel := context.WithCancel(parent)
 	return &subtitleIndexJobManager{app: app, jobs: make(map[string]*subtitleIndexJob), cancel: cancel, lifetime: lifetime}
 }
 
@@ -148,7 +155,7 @@ func (m *subtitleIndexJobManager) loadOrCreatePersistedJob(owner string) (*subti
 	var current, safeError sql.NullString
 	var finished sql.NullTime
 	err := m.app.subtitleSearch.pool.QueryRow(context.Background(), `SELECT id::text, state, discovered, processed, indexed_chunks, skipped, failed, unchanged_tracks, unsupported_tracks, empty_tracks, failed_tracks, current_title, started_at, updated_at, finished_at, error FROM subtitle_index_jobs WHERE owner_uuid=$1 ORDER BY updated_at DESC LIMIT 1`, owner).Scan(&job.id, &job.state, &job.discovered, &job.processed, &job.indexed, &job.skipped, &job.failed, &job.unchangedTracks, &job.unsupportedTracks, &job.emptyTracks, &job.failedTracks, &current, &job.startedAt, &job.updatedAt, &finished, &safeError)
-	if errors.Is(err, sql.ErrNoRows) {
+	if errors.Is(err, pgx.ErrNoRows) || errors.Is(err, sql.ErrNoRows) {
 		job.id, job.owner, job.state, job.startedAt, job.updatedAt = uuid.NewString(), owner, "queued", now, now
 		if _, err := m.app.subtitleSearch.pool.Exec(context.Background(), `INSERT INTO subtitle_index_jobs (id, owner_uuid, state, started_at, updated_at) VALUES ($1,$2,$3,$4,$5)`, job.id, owner, job.state, job.startedAt, job.updatedAt); err != nil {
 			return nil, errors.New("could not create subtitle index job")
@@ -192,6 +199,11 @@ func (m *subtitleIndexJobManager) recoverPersistedJobs() error {
 	_, err := m.app.subtitleSearch.pool.Exec(context.Background(), `UPDATE subtitle_index_jobs SET state='interrupted', updated_at=NOW(), error='indexing interrupted; rescan resumes completed sources' WHERE state IN ('queued','running')`)
 	if err != nil {
 		return errors.New("could not recover subtitle index jobs")
+	}
+	if m.app.sharedCorpus {
+		_, _ = m.app.subtitleSearch.pool.Exec(context.Background(), `UPDATE subtitle_shared_sections SET state=CASE WHEN ready THEN 'ready' ELSE 'failed' END, scan_id=COALESCE(ready_scan_id, scan_id) WHERE state='building'`)
+		_, _ = m.app.subtitleSearch.pool.Exec(context.Background(), `DELETE FROM subtitle_shared_chunks WHERE scan_id NOT IN (SELECT ready_scan_id FROM subtitle_shared_sections WHERE ready=TRUE AND ready_scan_id IS NOT NULL)`)
+		_, _ = m.app.subtitleSearch.pool.Exec(context.Background(), `DELETE FROM subtitle_shared_sources WHERE scan_id NOT IN (SELECT ready_scan_id FROM subtitle_shared_sections WHERE ready=TRUE AND ready_scan_id IS NOT NULL)`)
 	}
 	return nil
 }
@@ -237,7 +249,7 @@ func (m *subtitleIndexJobManager) current(owner string) (*subtitleIndexJob, bool
 	var current, safeError sql.NullString
 	var finished sql.NullTime
 	err := m.app.subtitleSearch.pool.QueryRow(context.Background(), `SELECT id::text, state, discovered, processed, indexed_chunks, skipped, failed, unchanged_tracks, unsupported_tracks, empty_tracks, failed_tracks, current_title, started_at, updated_at, finished_at, error FROM subtitle_index_jobs WHERE owner_uuid=$1 ORDER BY CASE WHEN state IN ('queued','running') THEN 0 ELSE 1 END, updated_at DESC LIMIT 1`, owner).Scan(&job.id, &job.state, &job.discovered, &job.processed, &job.indexed, &job.skipped, &job.failed, &job.unchangedTracks, &job.unsupportedTracks, &job.emptyTracks, &job.failedTracks, &current, &job.startedAt, &job.updatedAt, &finished, &safeError)
-	if errors.Is(err, sql.ErrNoRows) {
+	if errors.Is(err, pgx.ErrNoRows) || errors.Is(err, sql.ErrNoRows) {
 		return nil, false, nil
 	}
 	if err != nil {
@@ -488,13 +500,16 @@ func (a *Application) streamIndexLibrarySectionSources(ctx context.Context, toke
 		return errors.New("caller Plex access is unavailable")
 	}
 	start, previous, pageCount := 0, -1, 0
-	previousPage := ""
+	seenPages := make(map[string]bool)
 	typeValue := map[string]string{"movie": "1", "show": "4"}[sectionType]
 	if typeValue == "" {
 		return errors.New("unsupported Plex section type")
 	}
 	log.Printf("subtitle index-all section started key=%s type=%s", key, sectionType)
 	for {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
 		pageCount++
 		if pageCount > maxIndexLibraryPages {
 			return errors.New("Plex section exceeded pagination safety limit")
@@ -540,22 +555,32 @@ func (a *Application) streamIndexLibrarySectionSources(ctx context.Context, toke
 		if page.MediaContainer.Offset != 0 && page.MediaContainer.Offset != start {
 			return errors.New("Plex section pagination returned an unexpected offset")
 		}
-		pageKey := ""
-		if len(items) > 0 {
-			pageKey = stringValue(items[0].RatingKey) + ":" + stringValue(items[len(items)-1].RatingKey)
-			if pageKey == previousPage {
-				return errors.New("Plex section pagination made no progress")
-			}
+		if len(items) == 0 {
+			log.Printf("subtitle index-all section finished key=%s type=%s pages=%d (empty page)", key, sectionType, pageCount)
+			return nil
 		}
-		previousPage = pageKey
+		pageKey := stringValue(items[0].RatingKey) + ":" + stringValue(items[len(items)-1].RatingKey)
+		if seenPages[pageKey] {
+			log.Printf("subtitle index-all section detected pagination cycle key=%s type=%s page_key=%s", key, sectionType, pageKey)
+			return nil
+		}
+		seenPages[pageKey] = true
 		if err := consume(items); err != nil {
+			if errors.Is(err, errStopPagination) {
+				log.Printf("subtitle index-all section stopped key=%s type=%s pages=%d (stop requested)", key, sectionType, pageCount)
+				return nil
+			}
 			return err
 		}
 		if pageCount == 1 || pageCount%10 == 0 {
 			log.Printf("subtitle index-all section progress key=%s type=%s pages=%d page_items=%d", key, sectionType, pageCount, len(items))
 		}
-		if len(items) == 0 || len(items) < indexLibraryPageSize {
-			log.Printf("subtitle index-all section finished key=%s type=%s pages=%d", key, sectionType, pageCount)
+		if len(items) < indexLibraryPageSize {
+			log.Printf("subtitle index-all section finished key=%s type=%s pages=%d (last page len=%d)", key, sectionType, pageCount, len(items))
+			return nil
+		}
+		if page.MediaContainer.TotalSize > 0 && start+len(items) >= page.MediaContainer.TotalSize {
+			log.Printf("subtitle index-all section reached total size key=%s type=%s total=%d pages=%d", key, sectionType, page.MediaContainer.TotalSize, pageCount)
 			return nil
 		}
 		start += len(items)
@@ -591,6 +616,7 @@ func (a *Application) discoverAndIndexSources(ctx context.Context, job *subtitle
 				return errors.New("could not start shared subtitle section scan")
 			}
 		}
+		sectionCtx, cancelSection := context.WithCancel(ctx)
 		seen := make(map[string]bool)
 		queue := make(chan subtitleIndexWork, subtitleBulkQueueSize)
 		var workers sync.WaitGroup
@@ -602,7 +628,7 @@ func (a *Application) discoverAndIndexSources(ctx context.Context, job *subtitle
 			go func() {
 				defer workers.Done()
 				for source := range queue {
-					if ctx.Err() != nil {
+					if sectionCtx.Err() != nil {
 						continue
 					}
 					if err := index(source); err != nil {
@@ -611,13 +637,16 @@ func (a *Application) discoverAndIndexSources(ctx context.Context, job *subtitle
 							itemFailed = true
 						} else if workerErr == nil {
 							workerErr = err
+							cancelSection()
 						}
 						workerMu.Unlock()
 					}
 				}
 			}()
 		}
-		pageErr := a.streamIndexLibrarySectionSources(ctx, *token, section.Key, section.Type, func(items []components.Metadata) error {
+		consecutiveDuplicatePages := 0
+		pageErr := a.streamIndexLibrarySectionSources(sectionCtx, *token, section.Key, section.Type, func(items []components.Metadata) error {
+			newItemsOnPage := 0
 			for _, item := range items {
 				if item.Type != "movie" && item.Type != "episode" {
 					continue
@@ -639,35 +668,46 @@ func (a *Application) discoverAndIndexSources(ctx context.Context, job *subtitle
 					continue
 				}
 				seen[identity] = true
+				newItemsOnPage++
 				select {
 				case queue <- subtitleIndexWork{source: value, sectionUUID: section.UUID, sectionKey: section.Key, scanID: scanID}:
 					job.mu.Lock()
 					job.discovered++
 					job.updatedAt = time.Now().UTC()
 					job.mu.Unlock()
-				case <-ctx.Done():
-					return ctx.Err()
+				case <-sectionCtx.Done():
+					return sectionCtx.Err()
 				}
+			}
+			if len(items) > 0 && newItemsOnPage == 0 {
+				consecutiveDuplicatePages++
+				if consecutiveDuplicatePages >= 3 {
+					log.Printf("subtitle index-all section detected 3 consecutive duplicate pages key=%s, terminating section pagination", section.Key)
+					return errStopPagination
+				}
+			} else {
+				consecutiveDuplicatePages = 0
 			}
 			return nil
 		})
 		close(queue)
 		workers.Wait()
+		cancelSection()
 		workerMu.Lock()
 		currentWorkerErr := workerErr
 		currentItemFailed := itemFailed
 		workerMu.Unlock()
-		if pageErr != nil {
-			if a.sharedCorpus {
-				a.abortSharedSubtitleScan(ctx, section.UUID, scanID)
-			}
-			return pageErr
-		}
 		if currentWorkerErr != nil {
 			if a.sharedCorpus {
 				a.abortSharedSubtitleScan(ctx, section.UUID, scanID)
 			}
 			return currentWorkerErr
+		}
+		if pageErr != nil {
+			if a.sharedCorpus {
+				a.abortSharedSubtitleScan(ctx, section.UUID, scanID)
+			}
+			return pageErr
 		}
 		if currentItemFailed {
 			if a.sharedCorpus {

--- a/subtitle_search_test.go
+++ b/subtitle_search_test.go
@@ -812,3 +812,225 @@ func TestSubtitleSourceFingerprintDimensionSensitivity(t *testing.T) {
 	}
 }
 
+func TestChunkSubtitleEntriesTimingBoundaries(t *testing.T) {
+	t.Run("cues with gap within 15s are merged", func(t *testing.T) {
+		entries := []SubtitleEntry{
+			{Start: 1000, End: 5000, Text: "first sentence"},
+			{Start: 15000, End: 19000, Text: "second sentence"}, // gap: 15000 - 5000 = 10000ms (10s <= 15s)
+		}
+		chunks := chunkSubtitleEntries(entries)
+		if len(chunks) != 1 {
+			t.Fatalf("expected 1 chunk, got %d: %+v", len(chunks), chunks)
+		}
+		if chunks[0].Start != 1000 || chunks[0].End != 19000 || chunks[0].Text != "first sentence\nsecond sentence" {
+			t.Fatalf("unexpected chunk content: %+v", chunks[0])
+		}
+	})
+
+	t.Run("cues with gap exceeding 15s are split", func(t *testing.T) {
+		entries := []SubtitleEntry{
+			{Start: 1000, End: 5000, Text: "first sentence"},
+			{Start: 21000, End: 25000, Text: "second sentence"}, // gap: 21000 - 5000 = 16000ms (16s > 15s)
+		}
+		chunks := chunkSubtitleEntries(entries)
+		if len(chunks) != 2 {
+			t.Fatalf("expected 2 chunks, got %d: %+v", len(chunks), chunks)
+		}
+		if chunks[0].Start != 1000 || chunks[0].End != 5000 || chunks[0].Text != "first sentence" {
+			t.Fatalf("unexpected first chunk: %+v", chunks[0])
+		}
+		if chunks[1].Start != 21000 || chunks[1].End != 25000 || chunks[1].Text != "second sentence" {
+			t.Fatalf("unexpected second chunk: %+v", chunks[1])
+		}
+	})
+
+	t.Run("cues within 60s total duration are merged", func(t *testing.T) {
+		entries := []SubtitleEntry{
+			{Start: 0, End: 10000, Text: "cue 1"},
+			{Start: 12000, End: 22000, Text: "cue 2"},
+			{Start: 24000, End: 34000, Text: "cue 3"},
+			{Start: 36000, End: 46000, Text: "cue 4"},
+			{Start: 48000, End: 58000, Text: "cue 5"}, // span 0 to 58000ms (58s <= 60s)
+		}
+		chunks := chunkSubtitleEntries(entries)
+		if len(chunks) != 1 {
+			t.Fatalf("expected 1 chunk, got %d: %+v", len(chunks), chunks)
+		}
+		if chunks[0].Start != 0 || chunks[0].End != 58000 {
+			t.Fatalf("unexpected chunk timing: start=%d end=%d", chunks[0].Start, chunks[0].End)
+		}
+	})
+
+	t.Run("cues exceeding 60s total duration are split", func(t *testing.T) {
+		entries := []SubtitleEntry{
+			{Start: 0, End: 20000, Text: "cue 1"},
+			{Start: 25000, End: 45000, Text: "cue 2"}, // total span: 45s <= 60s
+			{Start: 50000, End: 65000, Text: "cue 3"}, // gap is 5s, but total span from start 0 would be 65s > 60s
+		}
+		chunks := chunkSubtitleEntries(entries)
+		if len(chunks) != 2 {
+			t.Fatalf("expected 2 chunks due to 60s duration limit, got %d: %+v", len(chunks), chunks)
+		}
+		if chunks[0].Start != 0 || chunks[0].End != 45000 || chunks[0].Text != "cue 1\ncue 2" {
+			t.Fatalf("unexpected first chunk: %+v", chunks[0])
+		}
+		if chunks[1].Start != 50000 || chunks[1].End != 65000 || chunks[1].Text != "cue 3" {
+			t.Fatalf("unexpected second chunk: %+v", chunks[1])
+		}
+	})
+
+	t.Run("single long cue exceeding 60s is preserved without synthetic timestamps", func(t *testing.T) {
+		entries := []SubtitleEntry{
+			{Start: 0, End: 90000, Text: "single long descriptive cue spanning 90 seconds"},
+		}
+		chunks := chunkSubtitleEntries(entries)
+		if len(chunks) != 1 {
+			t.Fatalf("expected 1 chunk for single cue, got %d", len(chunks))
+		}
+		if chunks[0].Start != 0 || chunks[0].End != 90000 {
+			t.Fatalf("unexpected chunk boundaries: %+v", chunks[0])
+		}
+	})
+
+	t.Run("overlapping cues preserve maximum end timestamp", func(t *testing.T) {
+		entries := []SubtitleEntry{
+			{Start: 1000, End: 8000, Text: "primary line"},
+			{Start: 2000, End: 6000, Text: "overlapping shorter line"},
+		}
+		chunks := chunkSubtitleEntries(entries)
+		if len(chunks) != 1 {
+			t.Fatalf("expected 1 chunk, got %d: %+v", len(chunks), chunks)
+		}
+		if chunks[0].Start != 1000 || chunks[0].End != 8000 {
+			t.Fatalf("unexpected chunk boundaries for overlapping cues: %+v", chunks[0])
+		}
+	})
+}
+
+func TestResolveQueryInstruction(t *testing.T) {
+	custom := "Instruct: search\nQuery: "
+	empty := ""
+
+	tests := []struct {
+		name       string
+		cfg        SemanticSearchConfig
+		dimensions int
+		want       string
+	}{
+		{
+			name: "explicit custom instruction",
+			cfg: SemanticSearchConfig{
+				QueryInstruction: &custom,
+				EmbeddingsModel:  "BAAI/bge-base-en-v1.5",
+			},
+			dimensions: 768,
+			want:       custom,
+		},
+		{
+			name: "explicit empty instruction disables prefix even for bge",
+			cfg: SemanticSearchConfig{
+				QueryInstruction: &empty,
+				EmbeddingsModel:  "BAAI/bge-base-en-v1.5",
+			},
+			dimensions: 768,
+			want:       "",
+		},
+		{
+			name: "implicit bge model defaults to bge instruction",
+			cfg: SemanticSearchConfig{
+				EmbeddingsModel: "BAAI/bge-base-en-v1.5",
+			},
+			dimensions: 768,
+			want:       bgeQueryInstruction,
+		},
+		{
+			name: "implicit qwen model defaults to empty instruction",
+			cfg: SemanticSearchConfig{
+				EmbeddingsModel: "Qwen/Qwen3-Embedding-0.6B",
+			},
+			dimensions: 1024,
+			want:       "",
+		},
+		{
+			name: "implicit default tei with 768 dimensions defaults to bge instruction",
+			cfg: SemanticSearchConfig{
+				EmbeddingsProvider: "tei",
+			},
+			dimensions: 768,
+			want:       bgeQueryInstruction,
+		},
+		{
+			name: "implicit default tei with 1024 dimensions defaults to empty instruction",
+			cfg: SemanticSearchConfig{
+				EmbeddingsProvider: "tei",
+			},
+			dimensions: 1024,
+			want:       "",
+		},
+		{
+			name: "openai provider with non-bge model defaults to empty instruction",
+			cfg: SemanticSearchConfig{
+				EmbeddingsProvider: "openai",
+				EmbeddingsModel:    "text-embedding-3-small",
+			},
+			dimensions: 1536,
+			want:       "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveQueryInstruction(tt.cfg, tt.dimensions)
+			if got != tt.want {
+				t.Fatalf("resolveQueryInstruction() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeSubtitleEmbeddingBatchSizeAndConcurrency(t *testing.T) {
+	if got := normalizeSubtitleEmbeddingBatchSize(0); got != defaultSubtitleEmbeddingBatchSize {
+		t.Fatalf("expected default batch size %d, got %d", defaultSubtitleEmbeddingBatchSize, got)
+	}
+	if got := normalizeSubtitleEmbeddingBatchSize(-5); got != defaultSubtitleEmbeddingBatchSize {
+		t.Fatalf("expected default batch size %d, got %d", defaultSubtitleEmbeddingBatchSize, got)
+	}
+	if got := normalizeSubtitleEmbeddingBatchSize(64); got != 64 {
+		t.Fatalf("expected batch size 64, got %d", got)
+	}
+	if got := normalizeSubtitleEmbeddingBatchSize(1000); got != maxSubtitleEmbeddingBatchSize {
+		t.Fatalf("expected capped batch size %d, got %d", maxSubtitleEmbeddingBatchSize, got)
+	}
+
+	if got := normalizeSubtitleEmbeddingConcurrency(0); got != defaultSubtitleEmbeddingConcurrency {
+		t.Fatalf("expected default concurrency %d, got %d", defaultSubtitleEmbeddingConcurrency, got)
+	}
+	if got := normalizeSubtitleEmbeddingConcurrency(-2); got != defaultSubtitleEmbeddingConcurrency {
+		t.Fatalf("expected default concurrency %d, got %d", defaultSubtitleEmbeddingConcurrency, got)
+	}
+	if got := normalizeSubtitleEmbeddingConcurrency(4); got != 4 {
+		t.Fatalf("expected concurrency 4, got %d", got)
+	}
+	if got := normalizeSubtitleEmbeddingConcurrency(100); got != maxSubtitleEmbeddingConcurrency {
+		t.Fatalf("expected capped concurrency %d, got %d", maxSubtitleEmbeddingConcurrency, got)
+	}
+}
+
+func TestSubtitleSearchStoreQueryInput(t *testing.T) {
+	var nilStore *subtitleSearchStore
+	if got := nilStore.queryInput("test"); got != "test" {
+		t.Fatalf("expected %q, got %q", "test", got)
+	}
+
+	emptyStore := &subtitleSearchStore{queryInstruction: ""}
+	if got := emptyStore.queryInput("test"); got != "test" {
+		t.Fatalf("expected %q, got %q", "test", got)
+	}
+
+	bgeStore := &subtitleSearchStore{queryInstruction: bgeQueryInstruction}
+	want := bgeQueryInstruction + "test"
+	if got := bgeStore.queryInput("test"); got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+

--- a/subtitle_search_test.go
+++ b/subtitle_search_test.go
@@ -212,15 +212,24 @@ func TestHybridSubtitleTitleContextKeepsEpisodesSeparate(t *testing.T) {
 
 func TestValidateEmbeddings(t *testing.T) {
 	good := [][]float32{make([]float32, subtitleEmbeddingDimensions)}
-	if err := validateEmbeddings(good, 1); err != nil {
+	if err := validateEmbeddings(good, 1, subtitleEmbeddingDimensions); err != nil {
 		t.Fatalf("valid embedding rejected: %v", err)
 	}
-	if err := validateEmbeddings(good, 2); err == nil {
+	if err := validateEmbeddings(good, 2, subtitleEmbeddingDimensions); err == nil {
 		t.Fatal("mismatched count accepted")
 	}
 	bad := [][]float32{make([]float32, subtitleEmbeddingDimensions-1)}
-	if err := validateEmbeddings(bad, 1); err == nil {
+	if err := validateEmbeddings(bad, 1, subtitleEmbeddingDimensions); err == nil {
 		t.Fatal("wrong dimension accepted")
+	}
+
+	// Verify 1024 dimensions (e.g. Qwen/Qwen3-Embedding-0.6B)
+	good1024 := [][]float32{make([]float32, 1024)}
+	if err := validateEmbeddings(good1024, 1, 1024); err != nil {
+		t.Fatalf("valid 1024-dim embedding rejected: %v", err)
+	}
+	if err := validateEmbeddings(good1024, 1, 768); err == nil {
+		t.Fatal("1024-dim vector accepted when expecting 768")
 	}
 }
 
@@ -279,7 +288,7 @@ func TestOpenAIEmbeddingClientSendsVLLMRequestAndOrdersResults(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client, err := newEmbeddingClient(server.URL, embeddingsProviderOpenAI, "test-key")
+	client, err := newEmbeddingClient(server.URL, embeddingsProviderOpenAI, "test-key", "", subtitleEmbeddingDimensions)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -298,7 +307,7 @@ func TestOpenAIEmbeddingClientRejectsWrongDimension(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(openAIEmbeddingResponse{Data: []openAIEmbeddingItem{{Index: 0, Embedding: bad}}})
 	}))
 	defer server.Close()
-	client, err := newEmbeddingClient(server.URL, embeddingsProviderOpenAI, "")
+	client, err := newEmbeddingClient(server.URL, embeddingsProviderOpenAI, "", "", subtitleEmbeddingDimensions)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -711,3 +720,95 @@ func TestScanSharedSubtitleCandidateDoesNotDecodeSubtitleText(t *testing.T) {
 		t.Fatalf("candidate=%+v err=%v", candidate, err)
 	}
 }
+
+func TestTEIProbeDimensions1024(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/embed" {
+			t.Fatalf("unexpected path: %q", r.URL.Path)
+		}
+		// Return 1024-dim vector for Qwen3
+		vec := make([]string, 1024)
+		for i := range vec {
+			vec[i] = "0.0"
+		}
+		_, _ = w.Write([]byte("[[" + strings.Join(vec, ",") + "]]"))
+	}))
+	defer server.Close()
+
+	client, err := newEmbeddingClient(server.URL, embeddingsProviderTEI, "", "", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dim, err := client.probeDimensions(context.Background())
+	if err != nil {
+		t.Fatalf("probe failed: %v", err)
+	}
+	if dim != 1024 {
+		t.Fatalf("probed dimension = %d, want 1024", dim)
+	}
+}
+
+func TestOpenAIClientCustomModelAnd1024Dimensions(t *testing.T) {
+	const customModel = "Qwen/Qwen3-Embedding-0.6B"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Model string   `json:"model"`
+			Input []string `json:"input"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatal(err)
+		}
+		if req.Model != customModel {
+			t.Fatalf("model = %q, want %q", req.Model, customModel)
+		}
+		vec := make([]float32, 1024)
+		vec[0] = 0.42
+		_ = json.NewEncoder(w).Encode(openAIEmbeddingResponse{
+			Data: []openAIEmbeddingItem{{Index: 0, Embedding: vec}},
+		})
+	}))
+	defer server.Close()
+
+	client, err := newEmbeddingClient(server.URL, embeddingsProviderOpenAI, "nas-token", customModel, 1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := client.embed(context.Background(), []string{"test query"})
+	if err != nil {
+		t.Fatalf("embed failed: %v", err)
+	}
+	if len(res) != 1 || len(res[0]) != 1024 {
+		t.Fatalf("expected 1 vector of length 1024, got len=%d", len(res[0]))
+	}
+	if res[0][0] != 0.42 {
+		t.Fatalf("vector[0] = %f, want 0.42", res[0][0])
+	}
+}
+
+func TestSubtitleSearchSchemaGenerationWithDimensions(t *testing.T) {
+	schema768 := subtitleSearchSchema(768)
+	if !strings.Contains(schema768, "embedding vector(768) NOT NULL") {
+		t.Fatal("schema768 does not contain vector(768)")
+	}
+
+	schema1024 := subtitleSearchSchema(1024)
+	if !strings.Contains(schema1024, "embedding vector(1024) NOT NULL") {
+		t.Fatal("schema1024 does not contain vector(1024)")
+	}
+	// Verify both tables have 1024
+	count := strings.Count(schema1024, "embedding vector(1024) NOT NULL")
+	if count != 2 {
+		t.Fatalf("expected 2 vector(1024) columns (chunks + shared_chunks), got %d", count)
+	}
+}
+
+func TestSubtitleSourceFingerprintDimensionSensitivity(t *testing.T) {
+	stream := SubtitleStream{Index: 0, Codec: "srt", Language: "English", Type: "text"}
+	fp768 := subtitleSourceFingerprintWithDimensions("movie-1", 1, 2, stream, "context", 768, "rev-1")
+	fp1024 := subtitleSourceFingerprintWithDimensions("movie-1", 1, 2, stream, "context", 1024, "rev-1")
+
+	if fp768 == fp1024 {
+		t.Fatalf("expected fingerprints to differ for different dimensions, both got: %s", fp768)
+	}
+}
+

--- a/thumb_test.go
+++ b/thumb_test.go
@@ -1,0 +1,199 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/gofiber/fiber/v3"
+)
+
+func TestApplicationThumbPathValidation(t *testing.T) {
+	app := &Application{}
+	app.config.Plex.Host = "http://127.0.0.1:32400"
+	app.config.Plex.Token = "test-token"
+
+	invalidPaths := []struct {
+		name string
+		path string
+	}{
+		{"empty", ""},
+		{"whitespace", "   "},
+		{"scheme-relative", "//evil.com/thumb.jpg"},
+		{"userinfo", "http://user:pass@127.0.0.1:32400/thumb.jpg"},
+		{"external origin", "http://evil.com/thumb.jpg"},
+		{"relative without slash", "library/metadata/1/thumb"},
+		{"double slash relative", "//library/metadata/1/thumb"},
+	}
+
+	for _, tc := range invalidPaths {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := app.Thumb(context.Background(), tc.path)
+			if err == nil {
+				t.Fatalf("path %q was unexpectedly accepted", tc.path)
+			}
+			if !errors.Is(err, errThumbValidation) {
+				t.Fatalf("expected errThumbValidation, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestApplicationThumbPlexTranscode(t *testing.T) {
+	var capturedToken atomic.Pointer[string]
+	var capturedURL atomic.Pointer[string]
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tok := r.Header.Get("X-Plex-Token")
+		capturedToken.Store(&tok)
+		u := r.URL.String()
+		capturedURL.Store(&u)
+
+		if r.URL.Path != "/photo/:/transcode" {
+			http.NotFound(w, r)
+			return
+		}
+		if r.URL.Query().Get("url") == "/fail" {
+			http.Error(w, "transcode failed", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "image/jpeg")
+		_, _ = w.Write([]byte("mock-image-data"))
+	}))
+	defer server.Close()
+
+	app := &Application{}
+	app.config.Plex.Host = server.URL
+	app.config.Plex.Token = "server-admin-token"
+
+	t.Run("successful transcode with header token", func(t *testing.T) {
+		body, contentType, err := app.Thumb(context.Background(), "/library/metadata/100/thumb")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		defer body.Close()
+
+		data, _ := io.ReadAll(body)
+		if string(data) != "mock-image-data" {
+			t.Fatalf("body = %q, want 'mock-image-data'", string(data))
+		}
+		if contentType != "image/jpeg" {
+			t.Fatalf("contentType = %q, want 'image/jpeg'", contentType)
+		}
+
+		tok := capturedToken.Load()
+		if tok == nil || *tok != "server-admin-token" {
+			t.Fatalf("header token = %v, want 'server-admin-token'", tok)
+		}
+		rawURL := capturedURL.Load()
+		if rawURL != nil && strings.Contains(*rawURL, "X-Plex-Token") {
+			t.Fatalf("URL must not contain X-Plex-Token query param: %s", *rawURL)
+		}
+	})
+
+	t.Run("uses caller token if present", func(t *testing.T) {
+		ctx := ContextWithAuthToken(context.Background(), "caller-user-token")
+		body, _, err := app.Thumb(ctx, "/library/metadata/100/thumb")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		defer body.Close()
+
+		tok := capturedToken.Load()
+		if tok == nil || *tok != "caller-user-token" {
+			t.Fatalf("header token = %v, want 'caller-user-token'", tok)
+		}
+	})
+
+	t.Run("transcode failure returns error", func(t *testing.T) {
+		_, _, err := app.Thumb(context.Background(), "/fail")
+		if err == nil {
+			t.Fatal("expected error on 500 status")
+		}
+	})
+}
+
+func TestAPIThumbEndpoint(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("url") == "/fail" {
+			http.Error(w, "internal server error", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write([]byte("image-png-content"))
+	}))
+	defer server.Close()
+
+	app := &Application{}
+	app.config.Plex.Host = server.URL
+	app.config.Plex.Token = "token"
+
+	api := &API{
+		config: Config{},
+		app:    app,
+	}
+
+	httpApp := fiber.New()
+	httpApp.Use(func(ctx fiber.Ctx) error {
+		ctx.SetUserContext(ContextWithUser(ContextWithAuthToken(context.Background(), "token"), User{Uuid: "caller"}))
+		return ctx.Next()
+	})
+	httpApp.Get("/thumb", api.thumb, api.authMiddleware)
+
+	t.Run("missing path returns 400 validation error", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/thumb", nil)
+		resp, err := httpApp.Test(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400", resp.StatusCode)
+		}
+	})
+
+	t.Run("invalid path returns 400 validation error", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/thumb?path=//evil.com/bad", nil)
+		resp, err := httpApp.Test(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400", resp.StatusCode)
+		}
+	})
+
+	t.Run("successful thumb returns 200 with content", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/thumb?path=/library/metadata/10/thumb", nil)
+		resp, err := httpApp.Test(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d, want 200", resp.StatusCode)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		if string(body) != "image-png-content" {
+			t.Fatalf("body = %q, want image-png-content", string(body))
+		}
+	})
+
+	t.Run("upstream transcode failure returns 503", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/thumb?path=/fail", nil)
+		resp, err := httpApp.Test(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusServiceUnavailable {
+			t.Fatalf("status = %d, want 503", resp.StatusCode)
+		}
+	})
+}


### PR DESCRIPTION
## Summary of Changes

### 1. Codebase Audit Fixes & Hardening
- **Subtitle Fallbacks:** In render jobs and `Clip`, fall back to rendering without subtitles when embedded/external subtitles contain no usable cues (`ErrNoUsableSubtitleCues`) instead of failing the job.
- **Empty Subtitle Caching:** `GetSubtitleEntriesForSource` returns an empty array `[]` and caches the result for cue-less subtitles instead of returning a 503 error.
- **Batch Subtitle Extraction:** Permits 0-byte `.srt` outputs from silent/empty tracks without failing the batch extraction.
- **SSRF & Security:** Enforces path and origin validation on `/thumb`, `/sessions`, and subtitle download endpoints; transfers tokens strictly via `X-Plex-Token` headers rather than query parameters.
- **Bounded I/O & Timeouts:** Adds dedicated timeout HTTP clients and `io.LimitReader` bounds across PlexTV and Plex API calls.
- **Error Standards:** Standardizes structured JSON error responses (`sessions_unavailable` with 503, `validation_error` with 422).
- **Nil-Pointer Safety:** Safely formats file names in `Clip` without nil-pointer dereferences.

### 2. Subtitle Indexing Hardening & Infinite Streaming Prevention
- **`pgx.ErrNoRows` vs `sql.ErrNoRows`:** Replaces `sql.ErrNoRows` checks with `errors.Is(err, pgx.ErrNoRows) || errors.Is(err, sql.ErrNoRows)` in `loadOrCreatePersistedJob` and `current`.
- **Pipelined Inserts:** Replaces per-chunk `tx.Exec` loops in `persistSubtitleChunks` and `persistSharedSubtitleChunks` with `pgx.Batch`, drastically reducing database transaction hold times and network round-trips.
- **Early Resource Release:** Releases `bulkEmbeddings` semaphores immediately after embeddings calculation and releases media proxy capabilities immediately after FFmpeg extraction.
- **Worker Cancellation:** Introduces `sectionCtx` in `discoverAndIndexSources`; fatal worker errors trigger `cancelSection()` to halt doomed upstream requests.
- **Infinite Streaming Prevention:**
  - Adds `seenPages` tracking (`ratingKeyStart:ratingKeyEnd`) to detect and break pagination cycles.
  - Halts pagination immediately once `MediaContainer.TotalSize` is reached.
  - Adds `errStopPagination` sentinel to stop traversal cleanly when 3 consecutive duplicate pages are detected, allowing queued workers to finish without aborting.
  - Tightens `maxIndexLibraryPages` safety bound from 200,000 to 10,000.
- **Crash Recovery:** Resets orphaned `building` sections on server restart and prunes dangling unready chunks.

### 3. Configurable & Auto-Detected Embedding Dimensions
- **Multi-Dimension Model Support:** Supports arbitrary embedding dimensions (such as 1024 for `Qwen/Qwen3-Embedding-0.6B`, 768 for `bge-base-en-v1.5`, 1536 for OpenAI).
- **Auto-Probing:** When `semantic_search.dimensions` is omitted or `0`, probes the embedding server on startup and auto-detects dimensions.
- **Configurable Model:** Adds `embeddings_model` to `SemanticSearchConfig` for OpenAI-compatible providers.
- **Automatic Postgres Migration:** Detects when existing vector column dimension (`atttypmod`) differs from the active model; drops HNSW indexes, truncates obsolete chunks/sources, alters column type to `vector(N)`, and recreates the index.
- **Dimension-Aware Fingerprinting:** Incorporates dimension into subtitle source fingerprints so track caches are cleanly invalidated if model dimensions change.

### 4. Subtitle Chunk Timing Boundaries & GPU Batching / Concurrency
- **15s Gap & 60s Duration Limits:**
  - In `chunkSubtitleEntries`, splits chunks when the silence gap between cues exceeds 15 seconds (`subtitleChunkMaxGapMs = 15000`), preventing dialogues across long silences or scenes from being merged into a single chunk.
  - Splits chunks when the total span of merged cues exceeds 60 seconds (`subtitleChunkMaxDurationMs = 60000`).
  - Correctly preserves maximum timestamp for overlapping cues and flushes out-of-order cues.
  - Bumps index version to `subtitle-index-v5-chunk-400-gap-15s-cast-clean-text` so previously indexed tracks with multi-minute silence gaps are automatically re-indexed with new boundaries.
- **GPU Batching & Concurrency:**
  - Added `batch_size` (default 32) and `concurrency` (default 2) to `SemanticSearchConfig`.
  - Sets `bulkEmbeddings` semaphore capacity to `concurrency`, allowing parallel indexing workers to send concurrent embedding requests to TEI to exploit GPU continuous dynamic batching.
- **Model-Aware Query Instruction:**
  - Added optional `query_instruction` to `SemanticSearchConfig`.
  - Automatically defaults to BGE retrieval prefix (`Represent this sentence for searching relevant passages: `) for BGE models or default 768-dim TEI, but omits the prefix for Qwen or OpenAI models unless explicitly configured.

## Verification
- All tests pass with race detection enabled: `go test -count=1 -race ./...` (5.6s)
- Static analysis clean: `go vet ./...` (0 warnings/errors)
- Added comprehensive unit tests for chunk timing boundaries, query instruction resolution, batch size and concurrency normalization, and config loading.