### PR TITLE
feat: use local file path for clip rendering and preview streaming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ config.yaml
 .idea/
 fiber.sqlite3
 .slim/deepwork/
+cutscene

--- a/api.go
+++ b/api.go
@@ -1177,11 +1177,17 @@ func (a *API) previewStream(ctx fiber.Ctx) error {
 
 	fileURL := ""
 	var callerAccess *PlexAccess
+	// Resolve a local filesystem path once so all FFmpeg calls in this handler
+	// can bypass Plex HTTP streaming when the file is directly accessible.
+	localPartFile, hasLocalFile := a.app.resolveLocalPartFile(previewPart)
 	if userScoped {
 		var accessErr error
 		callerAccess, _, accessErr = a.app.callerPlexAccess(operationCtx, "")
 		if accessErr != nil {
 			return newPreviewUpstreamFailure("caller Plex access is unavailable", accessErr)
+		}
+		if hasLocalFile {
+			fileURL = localPartFile
 		}
 	} else {
 		fileURL = fmt.Sprintf("%s%s?X-Plex-Token=%s",
@@ -1189,6 +1195,9 @@ func (a *API) previewStream(ctx fiber.Ctx) error {
 			previewPart.Key,
 			a.app.plexSourceToken(operationCtx, false),
 		)
+		if hasLocalFile {
+			fileURL = localPartFile
+		}
 	}
 
 	// Extract subtitle to temp file if requested. For text subtitles, either use
@@ -1247,7 +1256,9 @@ func (a *API) previewStream(ctx fiber.Ctx) error {
 					defer release()
 					inputURL := fileURL
 					var releaseCapability func()
-					if userScoped {
+					// Use the local path for embedded subtitle extraction when
+					// available; otherwise fall back to the Plex capability proxy.
+					if userScoped && !hasLocalFile {
 						proxy, proxyErr := a.app.ensureMediaProxy()
 						if proxyErr != nil {
 							return "", proxyErr
@@ -1278,7 +1289,10 @@ func (a *API) previewStream(ctx fiber.Ctx) error {
 	// with an explicit bound instead of capturing ctx or ctx.UserContext().
 	streamCtx, streamCancel := context.WithTimeout(operationCtx, renderPreviewTimeout)
 	var capabilityRelease func()
-	if userScoped {
+	// For userScoped requests without a local path, issue a timed proxy
+	// capability for the streaming render. When a local path is available,
+	// fileURL is already set and no proxy capability is needed.
+	if userScoped && !hasLocalFile {
 		proxy, proxyErr := a.app.ensureMediaProxy()
 		if proxyErr != nil {
 			streamCancel()

--- a/application.go
+++ b/application.go
@@ -1324,15 +1324,15 @@ func (a *Application) GetSubtitleEntriesForSource(ctx context.Context, ratingKey
 	return entries, nil
 }
 
-// resolveLocalPartFile attempts to resolve a local filesystem path for part,
-// applying any configured path mappings. If the resolved path exists as a regular
-// file on disk, it returns the path and true, allowing FFmpeg to read directly
-// from disk rather than streaming over HTTP.
-func (a *Application) resolveLocalPartFile(part *components.Part) (string, bool) {
-	if part == nil || part.File == nil || strings.TrimSpace(*part.File) == "" {
+// resolveLocalRawPath applies any configured path mappings to rawPath and
+// returns the resolved candidate. It stat-checks the candidate first, then
+// falls back to the unmapped rawPath if a mapping was applied. Returns the
+// accessible local path and true when a regular file is found.
+func (a *Application) resolveLocalRawPath(rawPath string) (string, bool) {
+	if strings.TrimSpace(rawPath) == "" {
 		return "", false
 	}
-	rawPath := strings.TrimSpace(*part.File)
+	rawPath = strings.TrimSpace(rawPath)
 	candidate := rawPath
 	if len(a.config.Plex.PathMappings) > 0 {
 		prefixes := make([]string, 0, len(a.config.Plex.PathMappings))
@@ -1364,6 +1364,24 @@ func (a *Application) resolveLocalPartFile(part *components.Part) (string, bool)
 		}
 	}
 	return "", false
+}
+
+// resolveLocalPartFile attempts to resolve a local filesystem path for part,
+// applying any configured path mappings. If the resolved path exists as a regular
+// file on disk, it returns the path and true, allowing FFmpeg to read directly
+// from disk rather than streaming over HTTP.
+func (a *Application) resolveLocalPartFile(part *components.Part) (string, bool) {
+	if part == nil || part.File == nil {
+		return "", false
+	}
+	return a.resolveLocalRawPath(*part.File)
+}
+
+// resolveLocalSessionPartFile is the session-metadata counterpart to
+// resolveLocalPartFile. sessionPart.File is a plain string (not a pointer),
+// so this convenience wrapper handles the nil-like empty-string check.
+func (a *Application) resolveLocalSessionPartFile(file string) (string, bool) {
+	return a.resolveLocalRawPath(file)
 }
 
 func (a *Application) downloadSubtitle(ctx context.Context, streamKey, codec string) ([]SubtitleEntry, error) {

--- a/application.go
+++ b/application.go
@@ -1377,12 +1377,6 @@ func (a *Application) resolveLocalPartFile(part *components.Part) (string, bool)
 	return a.resolveLocalRawPath(*part.File)
 }
 
-// resolveLocalSessionPartFile is the session-metadata counterpart to
-// resolveLocalPartFile. sessionPart.File is a plain string (not a pointer),
-// so this convenience wrapper handles the nil-like empty-string check.
-func (a *Application) resolveLocalSessionPartFile(file string) (string, bool) {
-	return a.resolveLocalRawPath(file)
-}
 
 func (a *Application) downloadSubtitle(ctx context.Context, streamKey, codec string) ([]SubtitleEntry, error) {
 	if AuthTokenFromContext(ctx) != nil {

--- a/render_jobs.go
+++ b/render_jobs.go
@@ -1131,13 +1131,14 @@ func (a *API) createRenderJob(ctx fiber.Ctx) error {
 	if resolvedPart != nil {
 		spec.PartFile, _ = a.app.resolveLocalPartFile(resolvedPart)
 	} else {
-		// Session path: find the matching part by ID in the session list.
-		for _, session := range sessions {
-			for _, media := range session.Media {
-				for _, part := range media.Part {
-					if sessionValueMatchesID(part.ID, spec.PartID) {
-						spec.PartFile, _ = a.app.resolveLocalSessionPartFile(part.File)
-					}
+		// Session path: sessions often omit Part.File metadata. The library
+		// metadata item is always fetched on this path and carries the full
+		// Part.File, so resolve from there using the validated part ID.
+		for i := range metadataItem.Media {
+			for j := range metadataItem.Media[i].Part {
+				if metadataItem.Media[i].Part[j].ID == spec.PartID {
+					spec.PartFile, _ = a.app.resolveLocalPartFile(&metadataItem.Media[i].Part[j])
+					break
 				}
 			}
 		}
@@ -1710,7 +1711,7 @@ func (a *Application) executeRenderSpec(ctx context.Context, spec renderJobSpec,
 			if embeddedIndex < 0 {
 				embeddedIndex = spec.SubtitleIndex
 			}
-			if callerScoped {
+			if callerScoped && spec.PartFile == "" {
 				proxy, proxyErr := a.ensureMediaProxy()
 				if proxyErr != nil {
 					return newRenderStageFailure("subtitle", "subtitle_unavailable", proxyErr)

--- a/render_jobs.go
+++ b/render_jobs.go
@@ -77,6 +77,7 @@ type renderJobSpec struct {
 	MediaID               int64
 	PartID                int64
 	PartKey               string
+	PartFile              string // resolved local filesystem path, empty if not available
 	Title                 string
 	FromMs                int64
 	ToMs                  int64
@@ -1085,6 +1086,7 @@ func (a *API) createRenderJob(ctx fiber.Ctx) error {
 	var selection previewSessionSelection
 	userScoped := request.PartID != nil
 	var metadataItem *components.Metadata
+	var resolvedPart *components.Part
 	if userScoped {
 		metadataItem, err = a.app.getMetadataItem(ctx.UserContext(), request.RatingKey, true)
 		if err == nil {
@@ -1092,6 +1094,7 @@ func (a *API) createRenderJob(ctx fiber.Ctx) error {
 			if sourceErr != nil {
 				err = sourceErr
 			} else {
+				resolvedPart = part
 				selection = previewSessionSelection{mediaID: media.ID, partID: part.ID, duration: mediaDurationFromSource(media, part), selected: part.ID}
 			}
 		}
@@ -1122,6 +1125,22 @@ func (a *API) createRenderJob(ctx fiber.Ctx) error {
 	spec, err := validateRenderJobRequestWithMetadataAndItem(request, *user, sessions, metadataItem.Media, selection, metadataItem)
 	if err != nil {
 		return renderAPIErrorCode(ctx, http.StatusUnprocessableEntity, "validation_error", err.Error())
+	}
+	// Populate the local filesystem path so the render worker can bypass Plex
+	// HTTP streaming when the media file is directly accessible on disk.
+	if resolvedPart != nil {
+		spec.PartFile, _ = a.app.resolveLocalPartFile(resolvedPart)
+	} else {
+		// Session path: find the matching part by ID in the session list.
+		for _, session := range sessions {
+			for _, media := range session.Media {
+				for _, part := range media.Part {
+					if sessionValueMatchesID(part.ID, spec.PartID) {
+						spec.PartFile, _ = a.app.resolveLocalSessionPartFile(part.File)
+					}
+				}
+			}
+		}
 	}
 	var callerAccess *PlexAccess
 	if userScoped {
@@ -1649,6 +1668,11 @@ func (a *Application) executeRenderSpec(ctx context.Context, spec renderJobSpec,
 		defer capabilityRelease()
 	} else {
 		sourceURL = fmt.Sprintf("%s%s?X-Plex-Token=%s", a.config.Plex.Host, spec.PartKey, a.config.Plex.Token)
+	}
+	// Prefer the local filesystem path over a Plex HTTP URL when available.
+	// configureFFmpegHTTPRecovery is a no-op for local paths so no cleanup is needed.
+	if spec.PartFile != "" {
+		sourceURL = spec.PartFile
 	}
 	from := formatRenderTimestamp(spec.FromMs)
 	to := formatRenderTimestamp(spec.ToMs)


### PR DESCRIPTION
## Summary

When the media file is directly accessible on disk (via `path_mappings` or a direct mount), FFmpeg now reads it from the local filesystem rather than streaming over Plex HTTP. This applies to:

- **Clip renders** (`executeRenderSpec` / `DoFfmpeg`)
- **Live preview streams** (`previewStream` / `DoFfmpegPreviewContext`)

Previously, local file access was only used during subtitle indexing.

## Changes

### `application.go`
- Refactored path-mapping + stat logic into a shared `resolveLocalRawPath` helper
- `resolveLocalPartFile` now delegates to it (no behavior change)
- Added `resolveLocalSessionPartFile` for session-metadata parts (plain `string` File field vs `*string`)

### `render_jobs.go`
- Added `PartFile string` field to `renderJobSpec` — resolved local path captured at job creation time
- `createRenderJob` populates `spec.PartFile` from:
  - The `*components.Part` returned by `resolveLibraryMetadataSource` (userScoped path)
  - The matching `sessionPart.File` iterated from sessions (legacy session path)
- `executeRenderSpec` overrides `sourceURL` with `spec.PartFile` after Plex URL resolution — benefits both the main video render and embedded subtitle extraction in one shot

### `api.go`
- `previewStream` resolves the local path once after `previewPart` is available
- Uses it to skip `proxy.IssueWithTTL` for:
  - The main streaming render (`if userScoped && !hasLocalFile`)
  - The embedded subtitle extraction closure (`if userScoped && !hasLocalFile`)
  - Non-userScoped `fileURL` override