### PR TITLE
Build subtitle search indexes without startup timeout

### DIFF
--- a/application.go
+++ b/application.go
@@ -201,27 +201,29 @@ type sessionStream struct {
 }
 
 type Application struct {
-	config            Config
-	plexAdmin         *plexgo.PlexAPI
-	plexUser          *plexgo.PlexAPI
-	plexTv            *PlexTV
-	plexResources     *PlexResourceResolver
-	mediaProxy        *plexCapabilityProxy
-	sharedCorpus      bool
-	machineIdentifier string
-	ownerEmail        string
-	ownerUUID         string
-	subtitleCache     *subtitleCache
-	ffmpegLimiter     *ffmpegLimiter
-	subtitleBulkGate  chan struct{}
-	renderJobs        *renderJobManager
-	clipStore         *clipStore
-	lifetime          context.Context
-	cancelLifetime    context.CancelFunc
-	closeOnce         sync.Once
-	closeErr          error
-	subtitleSearch    *subtitleSearchStore
-	subtitleJobs      *subtitleIndexJobManager
+	config                             Config
+	plexAdmin                          *plexgo.PlexAPI
+	plexUser                           *plexgo.PlexAPI
+	plexTv                             *PlexTV
+	plexResources                      *PlexResourceResolver
+	mediaProxy                         *plexCapabilityProxy
+	sharedCorpus                       bool
+	machineIdentifier                  string
+	ownerEmail                         string
+	ownerUUID                          string
+	subtitleCache                      *subtitleCache
+	ffmpegLimiter                      *ffmpegLimiter
+	subtitleBulkGate                   chan struct{}
+	renderJobs                         *renderJobManager
+	clipStore                          *clipStore
+	lifetime                           context.Context
+	cancelLifetime                     context.CancelFunc
+	closeOnce                          sync.Once
+	closeErr                           error
+	subtitleSearch                     *subtitleSearchStore
+	subtitleJobs                       *subtitleIndexJobManager
+	subtitleSearchIndexMigrationCancel context.CancelFunc
+	subtitleSearchIndexMigrationWait   sync.WaitGroup
 }
 
 func NewApplication(config Config) (*Application, error) {
@@ -340,6 +342,9 @@ func NewApplication(config Config) (*Application, error) {
 		_ = app.clipStore.close()
 		return nil, fmt.Errorf("could not initialize render jobs: %w", err)
 	}
+	if app.subtitleSearch != nil {
+		app.startSubtitleSearchIndexMigration()
+	}
 
 	return app, nil
 }
@@ -352,6 +357,10 @@ func (a *Application) Close() error {
 	}
 	a.closeOnce.Do(func() {
 		a.stopWork()
+		if a.subtitleSearchIndexMigrationCancel != nil {
+			a.subtitleSearchIndexMigrationCancel()
+			a.subtitleSearchIndexMigrationWait.Wait()
+		}
 		if a.clipStore != nil {
 			if err := a.clipStore.close(); err != nil {
 				a.closeErr = err
@@ -371,6 +380,21 @@ func (a *Application) Close() error {
 		}
 	})
 	return a.closeErr
+}
+
+func (a *Application) startSubtitleSearchIndexMigration() {
+	if a == nil || a.subtitleSearch == nil || a.lifetime == nil {
+		return
+	}
+	migrationContext, cancel := context.WithCancel(a.lifetime)
+	a.subtitleSearchIndexMigrationCancel = cancel
+	a.subtitleSearchIndexMigrationWait.Add(1)
+	go func() {
+		defer a.subtitleSearchIndexMigrationWait.Done()
+		if err := migrateSubtitleSearchIndexes(migrationContext, a.subtitleSearch.pool); err != nil && migrationContext.Err() == nil {
+			log.Printf("subtitle search index migration unavailable: %s", redactedDiagnostic(err))
+		}
+	}()
 }
 
 const maxClipArtworkBytes int64 = 8 << 20
@@ -1376,7 +1400,6 @@ func (a *Application) resolveLocalPartFile(part *components.Part) (string, bool)
 	}
 	return a.resolveLocalRawPath(*part.File)
 }
-
 
 func (a *Application) downloadSubtitle(ctx context.Context, streamKey, codec string) ([]SubtitleEntry, error) {
 	if AuthTokenFromContext(ctx) != nil {

--- a/subtitle_search.go
+++ b/subtitle_search.go
@@ -158,13 +158,40 @@ const (
 	openAIEmbeddingModel     = "BAAI/bge-base-en-v1.5"
 )
 
+const subtitleSearchIndexMigrationLockKey int64 = 748238519
+
+type subtitleSearchIndexMigrationStatement struct {
+	name string
+	sql  string
+}
+
+var subtitleSearchIndexMigrationStatements = []subtitleSearchIndexMigrationStatement{
+	{sql: "CREATE EXTENSION IF NOT EXISTS pg_trgm"},
+	{name: "subtitle_chunks_owner_idx", sql: "CREATE INDEX CONCURRENTLY IF NOT EXISTS subtitle_chunks_owner_idx ON subtitle_chunks (owner_uuid)"},
+	{name: "subtitle_chunks_normalized_text_trgm_idx", sql: "CREATE INDEX CONCURRENTLY IF NOT EXISTS subtitle_chunks_normalized_text_trgm_idx ON subtitle_chunks USING GIN (btrim(regexp_replace(lower(text), '[^[:alnum:]]+', ' ', 'g')) gin_trgm_ops)"},
+	{name: "subtitle_shared_chunks_machine_section_scan_idx", sql: "CREATE INDEX CONCURRENTLY IF NOT EXISTS subtitle_shared_chunks_machine_section_scan_idx ON subtitle_shared_chunks (machine_identifier, section_uuid, scan_id)"},
+	{name: "subtitle_shared_chunks_normalized_text_trgm_idx", sql: "CREATE INDEX CONCURRENTLY IF NOT EXISTS subtitle_shared_chunks_normalized_text_trgm_idx ON subtitle_shared_chunks USING GIN (btrim(regexp_replace(lower(text), '[^[:alnum:]]+', ' ', 'g')) gin_trgm_ops)"},
+}
+
+const subtitleSearchInvalidIndexQuery = `
+SELECT EXISTS (
+    SELECT 1
+    FROM pg_index
+    WHERE indexrelid = to_regclass($1)
+      AND NOT indisvalid
+)
+`
+
+func subtitleSearchDropInvalidIndexSQL(name string) string {
+	return "DROP INDEX CONCURRENTLY IF EXISTS " + name
+}
+
 func subtitleSearchSchema(dimensions int) string {
 	if dimensions <= 0 {
 		dimensions = defaultSubtitleEmbeddingDimensions
 	}
 	return fmt.Sprintf(`
 CREATE EXTENSION IF NOT EXISTS vector;
-CREATE EXTENSION IF NOT EXISTS pg_trgm;
 CREATE TABLE IF NOT EXISTS subtitle_chunks (
     id BIGSERIAL PRIMARY KEY,
     owner_uuid TEXT NOT NULL,
@@ -186,8 +213,6 @@ CREATE TABLE IF NOT EXISTS subtitle_chunks (
     UNIQUE (owner_uuid, rating_key, media_id, part_id, subtitle_index, start_ms, end_ms, content_hash)
 );
 CREATE INDEX IF NOT EXISTS subtitle_chunks_text_search_idx ON subtitle_chunks USING GIN (text_search);
-CREATE INDEX IF NOT EXISTS subtitle_chunks_owner_idx ON subtitle_chunks (owner_uuid);
-CREATE INDEX IF NOT EXISTS subtitle_chunks_normalized_text_trgm_idx ON subtitle_chunks USING GIN (btrim(regexp_replace(lower(text), '[^[:alnum:]]+', ' ', 'g')) gin_trgm_ops);
 CREATE INDEX IF NOT EXISTS subtitle_chunks_embedding_hnsw_idx ON subtitle_chunks USING hnsw (embedding vector_cosine_ops);
 CREATE TABLE IF NOT EXISTS subtitle_index_jobs (
     id UUID PRIMARY KEY,
@@ -278,11 +303,44 @@ CREATE TABLE IF NOT EXISTS subtitle_shared_chunks (
     UNIQUE (machine_identifier, section_uuid, scan_id, rating_key, media_id, part_id, subtitle_index, start_ms, end_ms, content_hash)
 );
 CREATE INDEX IF NOT EXISTS subtitle_shared_chunks_text_idx ON subtitle_shared_chunks USING GIN (text_search);
-CREATE INDEX IF NOT EXISTS subtitle_shared_chunks_machine_section_scan_idx ON subtitle_shared_chunks (machine_identifier, section_uuid, scan_id);
-CREATE INDEX IF NOT EXISTS subtitle_shared_chunks_normalized_text_trgm_idx ON subtitle_shared_chunks USING GIN (btrim(regexp_replace(lower(text), '[^[:alnum:]]+', ' ', 'g')) gin_trgm_ops);
 CREATE INDEX IF NOT EXISTS subtitle_shared_chunks_embedding_idx ON subtitle_shared_chunks USING hnsw (embedding vector_cosine_ops);
 ALTER TABLE subtitle_shared_sections ADD COLUMN IF NOT EXISTS ready BOOLEAN NOT NULL DEFAULT FALSE;
 `, dimensions, dimensions)
+}
+
+func migrateSubtitleSearchIndexes(ctx context.Context, pool *pgxpool.Pool) error {
+	conn, err := pool.Acquire(ctx)
+	if err != nil {
+		return fmt.Errorf("could not acquire subtitle search index migration connection: %w", err)
+	}
+	defer conn.Release()
+
+	if _, err := conn.Exec(ctx, "SELECT pg_advisory_lock($1)", subtitleSearchIndexMigrationLockKey); err != nil {
+		return fmt.Errorf("could not acquire subtitle search index migration lock: %w", err)
+	}
+	defer func() {
+		if _, err := conn.Exec(context.Background(), "SELECT pg_advisory_unlock($1)", subtitleSearchIndexMigrationLockKey); err != nil {
+			log.Printf("subtitle search index migration lock release failed: %s", redactedDiagnostic(err))
+		}
+	}()
+
+	for _, statement := range subtitleSearchIndexMigrationStatements {
+		if statement.name != "" {
+			var invalid bool
+			if err := conn.QueryRow(ctx, subtitleSearchInvalidIndexQuery, statement.name).Scan(&invalid); err != nil {
+				return fmt.Errorf("could not inspect subtitle search index %s: %w", statement.name, err)
+			}
+			if invalid {
+				if _, err := conn.Exec(ctx, subtitleSearchDropInvalidIndexSQL(statement.name)); err != nil {
+					return fmt.Errorf("could not drop invalid subtitle search index %s: %w", statement.name, err)
+				}
+			}
+		}
+		if _, err := conn.Exec(ctx, statement.sql); err != nil {
+			return fmt.Errorf("could not create subtitle search index: %w", err)
+		}
+	}
+	return nil
 }
 
 func migrateSubtitleEmbeddingDimensions(ctx context.Context, pool *pgxpool.Pool, targetDimensions int) error {

--- a/subtitle_search_test.go
+++ b/subtitle_search_test.go
@@ -802,18 +802,57 @@ func TestSubtitleSearchSchemaGenerationWithDimensions(t *testing.T) {
 	}
 }
 
-func TestSubtitleSearchSchemaIncludesBoundedLiteralSearchIndexes(t *testing.T) {
+func TestSubtitleSearchSchemaOmitsBackgroundLiteralSearchIndexes(t *testing.T) {
 	schema := subtitleSearchSchema(768)
-	wants := []string{
-		"CREATE EXTENSION IF NOT EXISTS pg_trgm;",
-		"CREATE INDEX IF NOT EXISTS subtitle_chunks_owner_idx ON subtitle_chunks (owner_uuid);",
-		"CREATE INDEX IF NOT EXISTS subtitle_shared_chunks_machine_section_scan_idx ON subtitle_shared_chunks (machine_identifier, section_uuid, scan_id);",
-		"CREATE INDEX IF NOT EXISTS subtitle_chunks_normalized_text_trgm_idx ON subtitle_chunks USING GIN (btrim(regexp_replace(lower(text), '[^[:alnum:]]+', ' ', 'g')) gin_trgm_ops);",
-		"CREATE INDEX IF NOT EXISTS subtitle_shared_chunks_normalized_text_trgm_idx ON subtitle_shared_chunks USING GIN (btrim(regexp_replace(lower(text), '[^[:alnum:]]+', ' ', 'g')) gin_trgm_ops);",
+	for _, forbidden := range []string{
+		"pg_trgm",
+		"subtitle_chunks_owner_idx",
+		"subtitle_chunks_normalized_text_trgm_idx",
+		"subtitle_shared_chunks_machine_section_scan_idx",
+		"subtitle_shared_chunks_normalized_text_trgm_idx",
+	} {
+		if strings.Contains(schema, forbidden) {
+			t.Errorf("base schema unexpectedly contains background migration DDL %q", forbidden)
+		}
 	}
-	for _, want := range wants {
-		if !strings.Contains(schema, want) {
-			t.Errorf("schema does not contain %q", want)
+
+	wantStatements := []string{
+		"CREATE EXTENSION IF NOT EXISTS pg_trgm",
+		"CREATE INDEX CONCURRENTLY IF NOT EXISTS subtitle_chunks_owner_idx ON subtitle_chunks (owner_uuid)",
+		"CREATE INDEX CONCURRENTLY IF NOT EXISTS subtitle_chunks_normalized_text_trgm_idx ON subtitle_chunks USING GIN (btrim(regexp_replace(lower(text), '[^[:alnum:]]+', ' ', 'g')) gin_trgm_ops)",
+		"CREATE INDEX CONCURRENTLY IF NOT EXISTS subtitle_shared_chunks_machine_section_scan_idx ON subtitle_shared_chunks (machine_identifier, section_uuid, scan_id)",
+		"CREATE INDEX CONCURRENTLY IF NOT EXISTS subtitle_shared_chunks_normalized_text_trgm_idx ON subtitle_shared_chunks USING GIN (btrim(regexp_replace(lower(text), '[^[:alnum:]]+', ' ', 'g')) gin_trgm_ops)",
+	}
+	if len(subtitleSearchIndexMigrationStatements) != len(wantStatements) {
+		t.Fatalf("migration statement count = %d, want %d", len(subtitleSearchIndexMigrationStatements), len(wantStatements))
+	}
+	for index, statement := range subtitleSearchIndexMigrationStatements {
+		if statement.sql != wantStatements[index] {
+			t.Errorf("migration statement %d = %q, want %q", index, statement.sql, wantStatements[index])
+		}
+		if strings.HasPrefix(statement.sql, "CREATE INDEX") && !strings.Contains(statement.sql, "CREATE INDEX CONCURRENTLY IF NOT EXISTS") {
+			t.Errorf("index migration is not concurrent and idempotent: %q", statement.sql)
+		}
+		if strings.Contains(statement.sql, "BEGIN") || strings.Contains(statement.sql, "COMMIT") {
+			t.Errorf("index migration statement contains transaction control: %q", statement.sql)
+		}
+	}
+}
+
+func TestSubtitleSearchInvalidIndexRecoveryContract(t *testing.T) {
+	if !strings.Contains(subtitleSearchInvalidIndexQuery, "pg_index") ||
+		!strings.Contains(subtitleSearchInvalidIndexQuery, "to_regclass($1)") ||
+		!strings.Contains(subtitleSearchInvalidIndexQuery, "NOT indisvalid") {
+		t.Fatalf("invalid-index query does not inspect pg_index validity: %q", subtitleSearchInvalidIndexQuery)
+	}
+
+	for _, statement := range subtitleSearchIndexMigrationStatements {
+		if statement.name == "" {
+			continue
+		}
+		want := "DROP INDEX CONCURRENTLY IF EXISTS " + statement.name
+		if got := subtitleSearchDropInvalidIndexSQL(statement.name); got != want {
+			t.Errorf("drop SQL for %s = %q, want %q", statement.name, got, want)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- move trigram and scope index creation out of the startup schema
- build indexes concurrently in a background migration with advisory-lock serialization
- recover invalid indexes left by an interrupted concurrent build

## Testing
- go test ./...